### PR TITLE
Cache the keymap when changing layers

### DIFF
--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -64,7 +64,7 @@ Layer_::mergeLayers(void) {
         for (uint8_t c = 0; c < COLS; c++) {
             int8_t layer = highestLayer;
 
-            while (layer >= DefaultLayer) {
+            while (layer > DefaultLayer) {
                 if (Layer.isOn (layer)) {
                     Key mappedKey;
 

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -57,6 +57,9 @@ Layer_::mergeLayers(void) {
 
     memset (keyMap, DefaultLayer, ROWS * COLS);
 
+    if (LayerState == (uint32_t)(1 << DefaultLayer))
+        return;
+
     for (uint8_t r = 0; r < ROWS; r++) {
         for (uint8_t c = 0; c < COLS; c++) {
             int8_t layer = highestLayer;

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -5,6 +5,7 @@ static uint8_t DefaultLayer;
 static uint32_t LayerState;
 
 uint8_t Layer_::highestLayer;
+uint8_t Layer_::keyMap[ROWS][COLS];
 
 static void handle_keymap_key_event(Key keymapEntry, uint8_t keyState) {
     if (keymapEntry.keyCode >= MOMENTARY_OFFSET) {
@@ -51,18 +52,36 @@ Layer_::Layer_ (void) {
     defaultLayer (0);
 }
 
-Key Layer_::lookup(byte row, byte col) {
-    Key mappedKey;
-    int8_t layer = highestLayer;
+void
+Layer_::mergeLayers(void) {
 
-    mappedKey.raw = Key_Transparent.raw;
+    memset (keyMap, DefaultLayer, ROWS * COLS);
 
-    while (mappedKey.raw == Key_Transparent.raw &&
-            layer >= DefaultLayer) {
-        if (Layer.isOn (layer))
-            mappedKey.raw = pgm_read_word(&(keymaps[layer][row][col]));
-        layer--;
+    for (uint8_t r = 0; r < ROWS; r++) {
+        for (uint8_t c = 0; c < COLS; c++) {
+            int8_t layer = highestLayer;
+
+            while (layer >= DefaultLayer) {
+                if (Layer.isOn (layer)) {
+                    Key mappedKey;
+
+                    mappedKey.raw = pgm_read_word(&(keymaps[layer][r][c]));
+
+                    if (mappedKey != Key_Transparent) {
+                        keyMap[r][c] = layer;
+                        break;
+                    }
+                }
+                layer--;
+            }
+        }
     }
+}
+
+Key Layer_::lookup(byte row, byte col) {
+    uint8_t layer = keyMap[row][col];
+    Key mappedKey;
+    mappedKey.raw = pgm_read_word(&(keymaps[layer][row][col]));
 
     return mappedKey;
 }
@@ -84,12 +103,14 @@ void Layer_::on (uint8_t layer) {
     bitSet (LayerState, layer);
     if (layer > highestLayer)
         highestLayer = layer;
+    mergeLayers();
 }
 
 void Layer_::off (uint8_t layer) {
     bitClear (LayerState, layer);
     if (layer == highestLayer)
         highestLayer = top();
+    mergeLayers();
 }
 
 boolean Layer_::isOn (uint8_t layer) {

--- a/src/layers.h
+++ b/src/layers.h
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include "key_defs.h"
 #include "plugin.h"
+#include KALEIDOSCOPE_HARDWARE_H
 
 class Layer_ {
   public:
@@ -28,6 +29,9 @@ class Layer_ {
 
  private:
     static uint8_t highestLayer;
+    static uint8_t keyMap[ROWS][COLS];
+
+    static void mergeLayers(void);
 };
 
 extern Layer_ Layer;


### PR DESCRIPTION
Instead of going through all the active layers each time we are looking for a key, whenever we switch layers, compute the effective keymap, and store the indexes. This makes the lookup a considerably faster operation, and lookups happen far more often than layer switching.

This comes at a cost of `ROWS*COLS` amount of memory, and a bit of code, but on the flip side, the lookup operation is now `O(1)`, which is a very nice property to have, if you want responsiveness. Changing layers is marginally slower, however, but even with 32 active layers, doing the computation once, instead of potentially many dozens of time, is still worth it.

We could further reduce the memory requirements if we stored more columns per byte, but that's for a future optimization.

Fixes #106.