### PR TITLE
Minor cleanup in the Kaleidoscope example

### DIFF
--- a/examples/Kaleidoscope/Kaleidoscope.ino
+++ b/examples/Kaleidoscope/Kaleidoscope.ino
@@ -17,9 +17,6 @@
 #include "Kaleidoscope-LEDEffect-Rainbow.h"
 #include "Kaleidoscope-Model01-TestMode.h"
 
-uint8_t primary_keymap = 0;
-uint8_t temporary_keymap = 0;
-
 #define NUMPAD_KEYMAP 2
 
 #define COLEMAK KEYMAP ( \


### PR DESCRIPTION
Drop the `primary_keymap` and `temporary_keymap` variables, they've been long unused.