### PR TITLE
Don't try to load the saved layer on setup()

### DIFF
--- a/examples/Kaleidoscope/Kaleidoscope.ino
+++ b/examples/Kaleidoscope/Kaleidoscope.ino
@@ -125,7 +125,7 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
 }
 
 void setup() {
-    Kaleidoscope.setup(KEYMAP_SIZE);
+    Kaleidoscope.setup();
 
     Kaleidoscope.use(&TestMode,
                      &LEDControl, &LEDOff,

--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -8,7 +8,7 @@ Kaleidoscope_::Kaleidoscope_(void) {
 }
 
 void
-Kaleidoscope_::setup(const byte keymap_count) {
+Kaleidoscope_::setup(void) {
     wdt_disable();
     delay(100);
     Keyboard.begin();
@@ -16,8 +16,6 @@ Kaleidoscope_::setup(const byte keymap_count) {
 
     // A workaround, so that the compiler does not optimize this out...
     handle_key_event (Key_NoKey, 255, 255, 0);
-
-    Layer.defaultLayer (KeyboardHardware.load_primary_layer (keymap_count));
 }
 
 void

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -61,7 +61,8 @@ class Kaleidoscope_ {
   public:
     Kaleidoscope_(void);
 
-    void setup(const byte keymap_count);
+    void setup(const byte keymap_count) { setup(); };
+    void setup(void);
     void loop(void);
     void use(KaleidoscopePlugin *plugin, ...) __attribute__((sentinel));
 


### PR DESCRIPTION
If we want to allow plugins to implement EEPROM storage, it is best if we don't do anything with EEPROM in the core firmware. As such, remove the `Layer.defaultLayer` call from `Kaleidoscope.setup`.

With that gone, the `keymap_count` argument is obsolete, so drop it from `Kaleidoscope.setup()` - but we keep an temporary `setup()` with the old arity, so that plugins can be updated at a slower pace.

This goes hand in hand with keyboardio/Kaleidoscope-Hardware-Model01#2, and is a pre-requisite for having plugins that manage EEPROM on their own.