### PR TITLE
Make the lookup of a key pluggable

### DIFF
--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -5,6 +5,7 @@ static uint32_t LayerState;
 
 uint8_t Layer_::highestLayer;
 uint8_t Layer_::keyMap[ROWS][COLS];
+Key (*Layer_::getKey)(uint8_t layer, byte row, byte col) = Layer.getKeyFromPROGMEM;
 
 static void handle_keymap_key_event(Key keymapEntry, uint8_t keyState) {
     if (keymapEntry.keyCode >= MOMENTARY_OFFSET) {
@@ -51,6 +52,15 @@ Layer_::Layer_ (void) {
     defaultLayer (0);
 }
 
+Key
+Layer_::getKeyFromPROGMEM (uint8_t layer, byte row, byte col) {
+    Key key;
+
+    key.raw = pgm_read_word(&(keymaps[layer][row][col]));
+
+    return key;
+}
+
 void
 Layer_::mergeLayers(void) {
 
@@ -65,9 +75,7 @@ Layer_::mergeLayers(void) {
 
             while (layer > DefaultLayer) {
                 if (Layer.isOn (layer)) {
-                    Key mappedKey;
-
-                    mappedKey.raw = pgm_read_word(&(keymaps[layer][r][c]));
+                    Key mappedKey = (*getKey)(layer, r, c);
 
                     if (mappedKey != Key_Transparent) {
                         keyMap[r][c] = layer;
@@ -82,10 +90,8 @@ Layer_::mergeLayers(void) {
 
 Key Layer_::lookup(byte row, byte col) {
     uint8_t layer = keyMap[row][col];
-    Key mappedKey;
-    mappedKey.raw = pgm_read_word(&(keymaps[layer][row][col]));
 
-    return mappedKey;
+    return (*getKey)(layer, row, col);
 }
 
 uint8_t Layer_::top (void) {

--- a/src/layers.h
+++ b/src/layers.h
@@ -26,11 +26,17 @@ class Layer_ {
 
     static Key eventHandler(Key mappedKey, byte row, byte col, uint8_t keyState);
 
+    static Key (*getKey)(uint8_t layer, byte row, byte col);
+
+    static Key getKeyFromPROGMEM(uint8_t layer, byte row, byte col);
+
  private:
     static uint8_t highestLayer;
     static uint8_t keyMap[ROWS][COLS];
 
     static void mergeLayers(void);
 };
+
+Key layer_getKey (uint8_t layer, uint8_t r, uint8_t c);
 
 extern Layer_ Layer;


### PR DESCRIPTION
We want to allow plugins to change how keys are looked up - or where they are looked up from -, and for this, the way we do that final lookup from `keymaps` or elsewhere, must be overrideable.

We do this by having a `getKey` function pointer in the `Layer_` class, which defaults to `getKeyFromPROGMEM`. Any plugin, or sketch, can change where `getKey` points to, and thereby change the way keys are looked up.

This - or something similar - is required if we want to allow plugins to implement looking up a key from EEPROM, for example.