### PR TITLE
Convert hooks into linked lists

### DIFF
--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -1,8 +1,8 @@
 #include "Kaleidoscope.h"
 #include <stdarg.h>
 
-Kaleidoscope_::eventHandlerHook Kaleidoscope_::eventHandlers[HOOK_MAX];
-Kaleidoscope_::loopHook Kaleidoscope_::loopHooks[HOOK_MAX];
+Kaleidoscope_::listItem<Kaleidoscope_::eventHandlerHook> *Kaleidoscope_::eventHandlerRootNode;
+Kaleidoscope_::listItem<Kaleidoscope_::loopHook> *Kaleidoscope_::loopHookRootNode;
 
 Kaleidoscope_::Kaleidoscope_(void) {
 }
@@ -20,10 +20,12 @@ Kaleidoscope_::setup(void) {
 
 void
 Kaleidoscope_::runLoopHooks (bool postClear) {
-  for (byte i = 0; loopHooks[i] != NULL && i < HOOK_MAX; i++) {
-    loopHook hook = loopHooks[i];
-    (*hook)(postClear);
-  }
+    auto *node = loopHookRootNode;
+
+    while (node) {
+        (*(node->hook))(postClear);
+        node = node->next;
+    }
 }
 
 void
@@ -51,52 +53,57 @@ Kaleidoscope_::use(KaleidoscopePlugin *plugin, ...) {
     va_end(ap);
 }
 
-void
-Kaleidoscope_::replaceEventHandlerHook(eventHandlerHook oldHook, eventHandlerHook newHook) {
-  for (byte i = 0; i < HOOK_MAX; i++) {
-    if (eventHandlers[i] == oldHook) {
-      eventHandlers[i] = newHook;
-      return;
+template<typename T>
+void Kaleidoscope_::appendHook(T **rootNode, T *newNode) {
+    if (!*rootNode) {
+        *rootNode = newNode;
+        return;
     }
-  }
-}
 
-void
-Kaleidoscope_::appendEventHandlerHook (eventHandlerHook hook) {
-  replaceEventHandlerHook((eventHandlerHook)NULL, hook);
-}
+    T *node = *rootNode;
 
-void
-Kaleidoscope_::useEventHandlerHook (eventHandlerHook hook) {
-  for (byte i = 0; i < HOOK_MAX; i++) {
-    if (eventHandlers[i] == hook)
-      return;
-  }
-  appendEventHandlerHook(hook);
-}
-
-void
-Kaleidoscope_::replaceLoopHook(loopHook oldHook, loopHook newHook) {
-  for (byte i = 0; i < HOOK_MAX; i++) {
-    if (loopHooks[i] == oldHook) {
-      loopHooks[i] = newHook;
-      return;
+    while (node->next) {
+        node = node->next;
     }
-  }
+    node->next = newNode;
+}
+
+template<typename T>
+void
+Kaleidoscope_::useHook(T **rootNode, T *newNode) {
+    if (!*rootNode) {
+        *rootNode = newNode;
+        return;
+    }
+
+    T *node = *rootNode;
+
+    while (node->next) {
+        if (node->hook == newNode->hook)
+            return;
+        node = node->next;
+    }
+    node->next = newNode;
 }
 
 void
-Kaleidoscope_::appendLoopHook(loopHook hook) {
-  replaceLoopHook((loopHook)NULL, hook);
+Kaleidoscope_::useHook(listItem<eventHandlerHook> *newNode) {
+    useHook(&eventHandlerRootNode, newNode);
 }
 
 void
-Kaleidoscope_::useLoopHook(loopHook hook) {
-  for (byte i = 0; i < HOOK_MAX; i++) {
-    if (loopHooks[i] == hook)
-      return;
-  }
-  appendLoopHook (hook);
+Kaleidoscope_::useHook(listItem<loopHook> *newNode) {
+    useHook(&loopHookRootNode, newNode);
+}
+
+void
+Kaleidoscope_::appendHook(listItem<eventHandlerHook> *newNode) {
+    appendHook(&eventHandlerRootNode, newNode);
+}
+
+void
+Kaleidoscope_::appendHook(listItem<loopHook> *newNode) {
+    appendHook(&loopHookRootNode, newNode);
 }
 
 Kaleidoscope_ Kaleidoscope;

--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -106,4 +106,16 @@ Kaleidoscope_::appendHook(listItem<loopHook> *newNode) {
     appendHook(&loopHookRootNode, newNode);
 }
 
+void
+Kaleidoscope_::prependHook(listItem<eventHandlerHook> *newNode) {
+    newNode->next = eventHandlerRootNode;
+    eventHandlerRootNode = newNode;
+}
+
+void
+Kaleidoscope_::prependHook(listItem<loopHook> *newNode) {
+    newNode->next = loopHookRootNode;
+    loopHookRootNode = newNode;
+}
+
 Kaleidoscope_ Kaleidoscope;

--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -19,21 +19,23 @@ Kaleidoscope_::setup(void) {
 }
 
 void
+Kaleidoscope_::runLoopHooks (bool postClear) {
+  for (byte i = 0; loopHooks[i] != NULL && i < HOOK_MAX; i++) {
+    loopHook hook = loopHooks[i];
+    (*hook)(postClear);
+  }
+}
+
+void
 Kaleidoscope_::loop(void) {
     KeyboardHardware.scan_matrix();
 
-    for (byte i = 0; loopHooks[i] != NULL && i < HOOK_MAX; i++) {
-        loopHook hook = loopHooks[i];
-        (*hook)(false);
-    }
+    runLoopHooks(false);
 
     Keyboard.sendReport();
     Keyboard.releaseAll();
 
-    for (byte i = 0; loopHooks[i] != NULL && i < HOOK_MAX; i++) {
-        loopHook hook = loopHooks[i];
-        (*hook)(true);
-    }
+    runLoopHooks(true);
 }
 
 void

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -94,6 +94,9 @@ class Kaleidoscope_ {
     static void replaceLoopHook(loopHook oldHook, loopHook newHook);
     static void appendLoopHook(loopHook hook);
     static void useLoopHook(loopHook hook);
+
+ private:
+    static void runLoopHooks(bool postClear);
 };
 
 extern Kaleidoscope_ Kaleidoscope;

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -94,6 +94,8 @@ class Kaleidoscope_ {
     static void appendHook(listItem<loopHook> *newNode);
     static void useHook(listItem<eventHandlerHook> *newNode);
     static void useHook(listItem<loopHook> *newNode);
+    static void prependHook(listItem<eventHandlerHook> *newNode);
+    static void prependHook(listItem<loopHook> *newNode);
 
   private:
     template<typename T> static void appendHook(T **rootNode, T *newNode);
@@ -114,6 +116,11 @@ extern Kaleidoscope_ Kaleidoscope;
         eventHandlerHookNode = {&hook, NULL};                            \
       Kaleidoscope.appendHook(&eventHandlerHookNode);                 \
   }
+#define event_handler_hook_prepend(hook) {                            \
+      static Kaleidoscope_::listItem<Kaleidoscope_::eventHandlerHook> \
+        eventHandlerHookNode = {&hook, NULL};                            \
+      Kaleidoscope.prependHook(&eventHandlerHookNode);                \
+  }
 
 #define loop_hook_use(hook) {                                 \
       static Kaleidoscope_::listItem<Kaleidoscope_::loopHook> \
@@ -124,4 +131,9 @@ extern Kaleidoscope_ Kaleidoscope;
       static Kaleidoscope_::listItem<Kaleidoscope_::loopHook>  \
         loopHookNode = {&hook, NULL};                             \
       Kaleidoscope.appendHook(&loopHookNode);                  \
+  }
+#define loop_hook_prepend(hook) {                             \
+      static Kaleidoscope_::listItem<Kaleidoscope_::loopHook> \
+        loopHookNode = {&hook, NULL};                            \
+      Kaleidoscope.prependHook(&loopHookNode);                \
   }

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -80,12 +80,16 @@ void handle_key_event(Key mappedKey, byte row, byte col, uint8_t keyState) {
     if (!(keyState & INJECTED)) {
         mappedKey = Layer.lookup(row, col);
     }
-    for (byte i = 0; Kaleidoscope.eventHandlers[i] != NULL && i < HOOK_MAX; i++) {
-        Kaleidoscope_::eventHandlerHook handler = Kaleidoscope.eventHandlers[i];
-        mappedKey = (*handler)(mappedKey, row, col, keyState);
-        if (mappedKey.raw == Key_NoKey.raw)
+
+    auto *node = Kaleidoscope.eventHandlerRootNode;
+
+    while (node) {
+        mappedKey = (*(node->hook))(mappedKey, row, col, keyState);
+        if (mappedKey == Key_NoKey)
             return;
+        node = node->next;
     }
+
     mappedKey = Layer.eventHandler(mappedKey, row, col, keyState);
     if (mappedKey.raw == Key_NoKey.raw)
         return;


### PR DESCRIPTION
Pretty much what I proposed in #118: instead of two 64-item array (so 128 bytes / array), have a linked list of hooks.

With the default firmware, this means -28 bytes of code, and -228(!) bytes of data. With my own sketch, which uses a lot more plugins, this comes out as +34 code, and -172 bytes of data.

As a bonus, this PR adds `prependHook` (and the `event_handler_hook_prepend` and `loop_hook_prepend` helper macros), to add a hook at the top. This may be useful for test mode, and a few others. If left unused, it will be optimized out, just like the rest.

This is a bigger change, and I have not tested it on real hardware yet - only checked if it compiles. Don't merge it yet!