### PR TITLE
Support for holding Consumer/SystemControl keys

### DIFF
--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -7,15 +7,18 @@ static bool handle_synthetic_key_event(Key mappedKey, uint8_t keyState) {
     if (!(mappedKey.flags & SYNTHETIC))
         return false;
 
-    if (!key_toggled_on(keyState))
-        return true;
-
     if (mappedKey.flags & IS_INTERNAL) {
         return false;
     } else if (mappedKey.flags & IS_CONSUMER) {
-        ConsumerControl.write(mappedKey.keyCode);
+      if (key_is_pressed(keyState))
+        ConsumerControl.press(mappedKey.keyCode);
+      else if (key_was_pressed(keyState))
+        ConsumerControl.release(mappedKey.keyCode);
     } else if (mappedKey.flags & IS_SYSCTL) {
-        SystemControl.write(mappedKey.keyCode);
+      if (key_is_pressed(keyState))
+        SystemControl.press(mappedKey.keyCode);
+      else if (key_was_pressed(keyState))
+        SystemControl.release();
     } else if (mappedKey.flags & SWITCH_TO_KEYMAP) {
         // Should not happen, handled elsewhere.
     }


### PR DESCRIPTION
Instead of calling the `.write` method of `ConsumerControl`/`SystemControl`, which registers the key, sends a report, then unregisters, and reports again, just `.press` it when the key is pressed, as we did before.

However, since `.press` always sends a report, and so does `.releaseAll`, we can't have it the same way we do for `Keyboard`. We need to explicitly release the consumer/system key, when the triggering key is released too. Not doing so makes the key stuck, as we never release it, and that will upset the operating system very much.

With this patch, we do an explicit release when the key toggles off, and thus, we support both holding the key, and allowing the OS to trigger repeat, and, the key won't be stuck, either!

Fixes #120.