### PR TITLE
Add an optional Focus hook

### DIFF
--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -97,4 +97,47 @@ Kaleidoscope_::useLoopHook(loopHook hook) {
   appendLoopHook (hook);
 }
 
+bool
+Kaleidoscope_::focusHook(const char *command) {
+  enum {
+    ON,
+    OFF,
+    GETSTATE,
+  } subCommand;
+
+  if (strncmp_P(command, PSTR("layer."), 6) != 0)
+    return false;
+
+  if (strcmp_P (command + 6, PSTR("on")) == 0)
+    subCommand = ON;
+  else if (strcmp_P(command + 6, PSTR("off")) == 0)
+    subCommand = OFF;
+  else if (strcmp_P(command + 6, PSTR("getState")) == 0)
+    subCommand = GETSTATE;
+  else
+    return false;
+
+  switch (subCommand) {
+  case ON:
+    {
+      uint8_t layer = Serial.parseInt();
+      Layer.on(layer);
+      break;
+    }
+
+  case OFF:
+    {
+      uint8_t layer = Serial.parseInt();
+      Layer.off(layer);
+      break;
+    }
+
+  case GETSTATE:
+    Serial.println(Layer.getLayerState(), BIN);
+    break;
+  }
+
+  return true;
+}
+
 Kaleidoscope_ Kaleidoscope;

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -94,9 +94,16 @@ class Kaleidoscope_ {
     static void replaceLoopHook(loopHook oldHook, loopHook newHook);
     static void appendLoopHook(loopHook hook);
     static void useLoopHook(loopHook hook);
+
+    static bool focusHook(const char *command);
 };
 
 extern Kaleidoscope_ Kaleidoscope;
+
+#define FOCUS_HOOK_KALEIDOSCOPE FOCUS_HOOK(Kaleidoscope.focusHook,  \
+                                           "layer.on\n"             \
+                                           "layer.off\n"            \
+                                           "layer.getState")
 
 /* -- DEPRECATED aliases; remove them when there are no more users. -- */
 


### PR DESCRIPTION
Implements the `layer.on`, `layer.off`, and `layer.getState` commands, which can be used to control the active layers from the host.
