### PR TITLE
Add an UNKNOWN_KEYSWITCH_LOCATION helper

### DIFF
--- a/src/key_events.h
+++ b/src/key_events.h
@@ -8,6 +8,8 @@
 
 extern const Key keymaps[][ROWS][COLS];
 
+#define UNKNOWN_KEYSWITCH_LOCATION 255,255
+
 // sending events to the computer
 /* The event handling starts with the Scanner calling handle_key_event() for
  * every key in the matrix, and it is the task of this method to figure out what


### PR DESCRIPTION
To be used in places where we have absolutely, positively no clue where a key event came from, coordinate-wise.