### PR TITLE
basic support for non-avr, non-usb boards

### DIFF
--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -9,7 +9,9 @@ Kaleidoscope_::Kaleidoscope_(void) {
 
 void
 Kaleidoscope_::setup(void) {
+#ifdef __AVR__
     wdt_disable();
+#endif
     delay(100);
     Keyboard.begin();
     KeyboardHardware.setup();

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -18,7 +18,9 @@ void setup();
 
 #include <stdio.h>
 #include <math.h>
+#ifdef __AVR__
 #include <avr/wdt.h>
+#endif
 
 #include KALEIDOSCOPE_HARDWARE_H
 #include "key_events.h"

--- a/src/key_events.h
+++ b/src/key_events.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <Arduino.h>
+#ifdef USBCON
 #include "KeyboardioHID.h"
+#endif
 
 #include KALEIDOSCOPE_HARDWARE_H
 #include "key_defs.h"

--- a/src/key_events.h
+++ b/src/key_events.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <Arduino.h>
-#ifdef USBCON
+#if defined(USBCON) && !defined(CORE_TEENSY)
 #include "KeyboardioHID.h"
 #endif
 


### PR DESCRIPTION
This is the smallest change to make Kaleidoscope compile for
nRF52 BLE boards.

There are two blockers that it addresses:

* The WDT is AVR specific, so conditionally include and use it
* The HID keyboard stuff errors out is `USBCON` is not defined.  Avoid this by not including those headers when there is no USB device.  My downstream code (see below) has its own copies of the HID  tables and aliases as a stopgap.

https://github.com/wez/KaleidoscopeKeyboards
has more code and build machinery for my proof of concept for using
Kaleidoscope as the driver for a keyboard using the new nRF52 based
board from Adafruit.

I plan to factor the BLE portions of my other repo out as re-usable Kaleidoscope plugins and submit those back to the keyboario project once I gotten a bit further along; I want to have more than just a one-key prototype in the bag first!
