### PR TITLE
Move the WDT calls to the hardware plugins

### DIFF
--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -9,12 +9,8 @@ Kaleidoscope_::Kaleidoscope_(void) {
 
 void
 Kaleidoscope_::setup(void) {
-#ifdef __AVR__
-    wdt_disable();
-#endif
-    delay(100);
-    Keyboard.begin();
     KeyboardHardware.setup();
+    Keyboard.begin();
 
     // A workaround, so that the compiler does not optimize this out...
     handle_keyswitch_event (Key_NoKey, 255, 255, 0);

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -18,9 +18,6 @@ void setup();
 
 #include <stdio.h>
 #include <math.h>
-#ifdef __AVR__
-#include <avr/wdt.h>
-#endif
 
 #include KALEIDOSCOPE_HARDWARE_H
 #include "key_events.h"


### PR DESCRIPTION
WDT is AVR specific, so it has a much better place in the hardware plugins. Move it there, and call `KeyboardHardware.setup()` earlier, so it can call `wdt_disable()` before all the other things it needs.

The delay after WDT disabling moves to the hardware plugin too.

Thanks to @wez and @obra for figuring out what to move where (see keyboardio/Kaleidoscope#129).

Goes hand in hand with keyboardio/Kaleidoscope-Hardware-Model01#4.