### PR TITLE
Only calculate version and filenames as we're building.

### DIFF
--- a/tools/kaleidoscope-builder
+++ b/tools/kaleidoscope-builder
@@ -95,6 +95,8 @@ build () {
 }
 
 compile () {
+    build_version
+    build_filenames
     install -d "${OUTPUT_PATH}"
 
     echo "Building ${OUTPUT_DIR}/${SKETCH} (${LIB_VERSION}) ..."

--- a/tools/kaleidoscope-builder
+++ b/tools/kaleidoscope-builder
@@ -19,6 +19,10 @@ firmware_size () {
 find_sketch () {
     SKETCH="${SKETCH:-${DEFAULT_SKETCH}}"
     LIBRARY="${LIBRARY:-${SKETCH}}"
+    if [ -z "${SKETCH}" ] || [ -z "${LIBRARY}" ] || [ -z "${ROOT}" ] || [ -z "${SOURCEDIR}" ]; then
+        echo "SKETCH, LIBRARY, SOURCEDIR, and ROOT need to be set before including this file!" >&2
+        exit 1
+    fi
 
     for path in "hardware/keyboardio/avr/libraries/Kaleidoscope-${LIBRARY}/examples/${SKETCH}" \
                     "examples/${LIBRARY}" \

--- a/tools/kaleidoscope-builder.conf
+++ b/tools/kaleidoscope-builder.conf
@@ -11,10 +11,6 @@ esac
 SKETCH="${SKETCH:-${DEFAULT_SKETCH}}"
 LIBRARY="${LIBRARY:-${SKETCH}}"
 
-if [ -z "${SKETCH}" ] || [ -z "${LIBRARY}" ] || [ -z "${ROOT}" ] || [ -z "${SOURCEDIR}" ]; then
-    echo "SKETCH, LIBRARY, SOURCEDIR, and ROOT need to be set before including this file!" >&2
-    exit 1
-fi
 
 
 ########

--- a/tools/kaleidoscope-builder.conf
+++ b/tools/kaleidoscope-builder.conf
@@ -93,20 +93,21 @@ BOOTLOADER_PATH="${BOOTLOADER_PATH:-${BOARD_HARDWARE_PATH}/keyboardio/avr/bootlo
 ###### Build and output configuration
 ######
 
-GIT_VERSION="$(cd $(find_sketch); git describe --abbrev=4 --dirty --always)"
-LIB_VERSION="$(cd $(find_sketch); (grep version= ../../library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
+build_version () {
+	GIT_VERSION="$(cd $(find_sketch); git describe --abbrev=4 --dirty --always)"
+	LIB_VERSION="$(cd $(find_sketch); (grep version= ../../library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
+	
+	BUILD_PATH="${BUILD_PATH:-$(mktemp -d 2>/dev/null || mktemp -d -t 'build')}"
+	OUTPUT_DIR="${OUTPUT_DIR:-output/${LIBRARY}}"
+	OUTPUT_PATH="${OUTPUT_PATH:-${SOURCEDIR}/${OUTPUT_DIR}}"
+}
 
-BUILD_PATH="${BUILD_PATH:-$(mktemp -d 2>/dev/null || mktemp -d -t 'build')}"
-OUTPUT_DIR="${OUTPUT_DIR:-output/${LIBRARY}}"
-OUTPUT_PATH="${OUTPUT_PATH:-${SOURCEDIR}/${OUTPUT_DIR}}"
-
-
-OUTPUT_FILE_PREFIX="${SKETCH}-${LIB_VERSION}"
-
-HEX_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.hex"
-HEX_FILE_WITH_BOOTLOADER_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}-with-bootloader.hex"
-ELF_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.elf"
-
+build_filenames () {
+	OUTPUT_FILE_PREFIX="${SKETCH}-${LIB_VERSION}"
+	HEX_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.hex"
+	HEX_FILE_WITH_BOOTLOADER_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}-with-bootloader.hex"
+	ELF_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.elf"
+}
 
 
 


### PR DESCRIPTION
This helps unbreak build-all and out of tree builds

@algernon does this seem sensible to you? Otherwise, build-all out of tree craps out since there's no one sketch.
