### PR TITLE
Add an USE_PLUGIN() macro

### DIFF
--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -50,6 +50,7 @@ extern HARDWARE_IMPLEMENTATION KeyboardHardware;
           static KaleidoscopePlugin *__p[] = {plugins, NULL};   \
           Kaleidoscope.use(plugins, NULL);                      \
         })
+#define USE_PLUGIN(plugin) (plugin)->begin()
 
 class KaleidoscopePlugin {
  public:


### PR DESCRIPTION
Does the same thing as `Kaleidoscope.use` (and `USE_PLUGINS` as a consequence), but for only one plugin. While it is a bit more of a burden to call `USE_PLUGIN` for all plugins, than it is to list them in `USE_PLUGINS`.

The advantage is that the result is noticeably smaller code. Having both allows the end-user to choose convenience or small size, depending on their needs.