### PR TITLE
Rework Kaleidoscope.use to be a compile-time recursive function

### DIFF
--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -35,19 +35,6 @@ Kaleidoscope_::loop(void) {
 }
 
 void
-Kaleidoscope_::use(KaleidoscopePlugin *plugin, ...) {
-  va_list ap;
-  KaleidoscopePlugin *p;
-
-  plugin->begin();
-  va_start(ap, plugin);
-  while ((p = va_arg(ap, KaleidoscopePlugin*)) != NULL) {
-    p->begin();
-  }
-  va_end(ap);
-}
-
-void
 Kaleidoscope_::replaceEventHandlerHook(eventHandlerHook oldHook, eventHandlerHook newHook) {
   for (byte i = 0; i < HOOK_MAX; i++) {
     if (eventHandlers[i] == oldHook) {


### PR DESCRIPTION
Based on suggestions from Wez Furlong (@wez) in #135, this replaces the `Kaleidoscope.use` function with one that does its thing at compile time.

The net result is that we save a considerable amount of code, while still having all of the benefits, and being 100% backwards compatible, no code needs to change.

We may want to adjust existing code to use `Kaleidoscope.use` directly, and drop any trailing NULLs we may have had. But there is no rush to do so.
