### PR TITLE
Fix paths in README.md to match Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ cd $HOME/kaleidoscope
 # then clone the hardware definitions
 git clone --recursive https://github.com/keyboardio/Arduino-Boards.git
 # and make them available to the arduino environment
-mkdir -p $SKETCHBOOK_DIR/hardware/kaleidoscope
-ln -s $HOME/kaleidoscope/Arduino-Boards $SKETCHBOOK_DIR/hardware/kaleidoscope/avr
+mkdir -p $SKETCHBOOK_DIR/hardware/keyboardio
+ln -s $HOME/kaleidoscope/Arduino-Boards $SKETCHBOOK_DIR/hardware/keyboardio/avr
 ```
 
 ## Clone and Build the Kaleidoscope Firmware


### PR DESCRIPTION
Following the instructions in README.md resulted in build errors for me, due to a disagreement between file paths in README.md and the ones specified in the Makefile.  I assume that the Makefile is correct and not README.md, but I can make the other pull request (changing the Makefile to match README.md) if needed.

It's always possible I'm completely missing something, too.  Did I do something wrong?