### PR TITLE
masking: Let the release event of a masked key through

### DIFF
--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -58,8 +58,9 @@ void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
   if (KeyboardHardware.isKeyMasked(row, col)) {
     if (keyToggledOff(keyState)) {
       KeyboardHardware.unMaskKey(row, col);
+    } else {
+      return;
     }
-    return;
   }
 
   for (byte i = 0; Kaleidoscope.eventHandlers[i] != NULL && i < HOOK_MAX; i++) {


### PR DESCRIPTION
When a masked key is released, instead of unmasking it and returning, unmask it and let the event through. This fixes keyboardio/Kaleidoscope-OneShot#10.

Reported-by: Craig Disselkoen
Signed-off-by: Gergely Nagy <algernon@madhouse-project.org>