### PR TITLE
Make keys repeat the code they had on press

### DIFF
--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -44,9 +44,8 @@ static bool handleKeyswitchEventDefault(Key mappedKey, byte row, byte col, uint8
 }
 
 void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
-  if (!(keyState & INJECTED)) {
-    mappedKey = Layer.lookup(row, col);
-  }
+  if (keyToggledOn(keyState) || keyToggledOff(keyState))
+    Layer.updateKeyCache(row, col);
 
   /* If the key we are dealing with is masked, ignore it until it is released.
    * When releasing it, clear the mask, so future key events can be handled
@@ -61,6 +60,10 @@ void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
     } else {
       return;
     }
+  }
+
+  if (!(keyState & INJECTED)) {
+    mappedKey = Layer.lookup(row, col);
   }
 
   for (byte i = 0; Kaleidoscope.eventHandlers[i] != NULL && i < HOOK_MAX; i++) {

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -6,7 +6,7 @@ static uint32_t LayerState;
 uint8_t Layer_::highestLayer;
 Key Layer_::keyMap[ROWS][COLS];
 Key(*Layer_::getKey)(uint8_t layer, byte row, byte col) = Layer.getKeyFromPROGMEM;
-bool Layer_::repeat_first_press = false;
+bool Layer_::repeat_first_press = true;
 
 static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState) {
   if (keymapEntry.keyCode >= MOMENTARY_OFFSET) {

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -4,7 +4,7 @@ static uint8_t DefaultLayer;
 static uint32_t LayerState;
 
 uint8_t Layer_::highestLayer;
-uint8_t Layer_::keyMap[ROWS][COLS];
+Key Layer_::keyMap[ROWS][COLS];
 Key(*Layer_::getKey)(uint8_t layer, byte row, byte col) = Layer.getKeyFromPROGMEM;
 bool Layer_::repeat_first_press = false;
 
@@ -89,17 +89,11 @@ Layer_::updateKeyCache(byte row, byte col) {
       Key mappedKey = (*getKey)(layer, row, col);
 
       if (mappedKey != Key_Transparent) {
-        keyMap[row][col] = layer;
+        keyMap[row][col] = mappedKey;
         break;
       }
     }
   }
-}
-
-Key Layer_::lookup(byte row, byte col) {
-  uint8_t layer = keyMap[row][col];
-
-  return (*getKey)(layer, row, col);
 }
 
 uint8_t Layer_::top(void) {

--- a/src/layers.h
+++ b/src/layers.h
@@ -30,11 +30,13 @@ class Layer_ {
 
   static Key getKeyFromPROGMEM(uint8_t layer, byte row, byte col);
 
+  static void updateKeyCache(byte row, byte col);
+
+  static bool repeat_first_press;
+
  private:
   static uint8_t highestLayer;
   static uint8_t keyMap[ROWS][COLS];
-
-  static void mergeLayers(void);
 };
 
 Key layer_getKey(uint8_t layer, uint8_t r, uint8_t c);

--- a/src/layers.h
+++ b/src/layers.h
@@ -8,7 +8,9 @@ class Layer_ {
  public:
   Layer_(void);
 
-  static Key lookup(byte row, byte col);
+  static Key lookup(byte row, byte col) {
+    return keyMap[row][col];
+  };
   static void on(uint8_t layer);
   static void off(uint8_t layer);
   static void move(uint8_t layer);
@@ -36,7 +38,7 @@ class Layer_ {
 
  private:
   static uint8_t highestLayer;
-  static uint8_t keyMap[ROWS][COLS];
+  static Key keyMap[ROWS][COLS];
 };
 
 Key layer_getKey(uint8_t layer, uint8_t r, uint8_t c);


### PR DESCRIPTION
For the details, see the the commit messages.

The summary of these changes is that:
- We can toggle between the current behaviour, and keys repeating the code they had on press. (With the latter being made default in the third commit)
- We cache the keys at the time they are pressed or released, and we cache keys on-demand, one by one. This replaces the former implementation that updated the cache for the whole keyboard when the layer state changes.
- We cache not the layer a key is on, but the keycode, so when looking up, we look up once instead of twice.
- The `Layer.lookup` function is now inlined.

The result is that the user can choose which behaviour they want, and scan cycles went from ~5.3ms to ~2.6ms, at the cost of 65 bytes of RAM (one for the toggle bool, 64 because of the layer index => key cache change) and 14 bytes of code.