### PR TITLE
Layer: Make the repeating behaviour the default, and the only one

### DIFF
--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -84,6 +84,9 @@ void
 Layer_::updateKeyCache(byte row, byte col) {
   int8_t layer = highestLayer;
 
+  if (row >= ROWS || col >= COLS)
+    return;
+
   for (layer = highestLayer; layer >= DefaultLayer; layer--) {
     if (Layer.isOn(layer)) {
       Key mappedKey = (*getKey)(layer, row, col);

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -6,7 +6,6 @@ static uint32_t LayerState;
 uint8_t Layer_::highestLayer;
 Key Layer_::keyMap[ROWS][COLS];
 Key(*Layer_::getKey)(uint8_t layer, byte row, byte col) = Layer.getKeyFromPROGMEM;
-bool Layer_::repeat_first_press;
 
 static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState) {
   if (keymapEntry.keyCode >= MOMENTARY_OFFSET) {
@@ -29,24 +28,6 @@ static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState) {
       } else {
         Layer.off(target);
       }
-
-      /*
-       * When toggling a layer off, we mask all keys still held. Masked keys
-       * will be ignored until released and pressed again (see
-       * `handleKeyswitchEvent` in key_events.cpp).
-       *
-       * We do this because when holding a momentary layer switch key, then
-       * pressing and holding some others, they will fire as keys on the
-       * momentary layer. But if we release the momentary layer switch key
-       * before releasing the others, they will continue firing, but from
-       * another layer. When typing fast, it may easily happen that we end up in
-       * a situation where the layer key releases first (in the same scan cycle,
-       * but handled first), and it will emit a key from the wrong layer. So we
-       * ignore held keys after releasing a layer key, until they are pressed
-       * again, to avoid the aforementioned issue.
-       */
-      if (!Layer.repeat_first_press)
-        KeyboardHardware.maskHeldKeys();
     }
 
     // switch keymap and stay there

--- a/src/layers.h
+++ b/src/layers.h
@@ -34,8 +34,6 @@ class Layer_ {
 
   static void updateKeyCache(byte row, byte col);
 
-  static bool repeat_first_press;
-
  private:
   static uint8_t highestLayer;
   static Key keyMap[ROWS][COLS];


### PR DESCRIPTION
Also fixes a bug in `Layer_::updateKeyCache` which could result in out-of-bounds writes and crashing the firmware hard.

Other than that, this changes the default behaviour when momentary layers turn off while other keys are held to continue repeating the other keys. Also makes this the only behaviour, removing the old.

If someone wants the old behaviour back, we can always reintroduce it easily, but as most people seemed to want the new one, lets have that as the default for now.