### PR TITLE
Update the key cache on layer change and at keyboard setup

### DIFF
--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -14,6 +14,8 @@ Kaleidoscope_::setup(void) {
 
   // A workaround, so that the compiler does not optimize this out...
   handleKeyswitchEvent(Key_NoKey, 255, 255, 0);
+
+  // Update the key cache, so we start with a non-empty state.
   Layer.updateKeyCache();
 }
 

--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -14,6 +14,7 @@ Kaleidoscope_::setup(void) {
 
   // A workaround, so that the compiler does not optimize this out...
   handleKeyswitchEvent(Key_NoKey, 255, 255, 0);
+  Layer.updateKeyCache();
 }
 
 void

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -106,6 +106,9 @@ void Layer_::on(uint8_t layer) {
   bitSet(LayerState, layer);
   if (layer > highestLayer)
     highestLayer = layer;
+
+  // Update the key cache, so that if anything depends on knowing the active
+  // layout, the layout will be in sync.
   updateKeyCache();
 }
 
@@ -113,6 +116,9 @@ void Layer_::off(uint8_t layer) {
   bitClear(LayerState, layer);
   if (layer == highestLayer)
     highestLayer = top();
+
+  // Update the key cache, so that if anything depends on knowing the active
+  // layout, the layout will be in sync.
   updateKeyCache();
 }
 

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -80,6 +80,15 @@ Layer_::updateKeyCache(byte row, byte col) {
   }
 }
 
+void
+Layer_::updateKeyCache(void) {
+  for (byte row = 0; row < ROWS; row++) {
+    for (byte col = 0; col < COLS; col++) {
+      updateKeyCache(row, col);
+    }
+  }
+}
+
 uint8_t Layer_::top(void) {
   for (int8_t i = 31; i >= 0; i--) {
     if (bitRead(LayerState, i))
@@ -97,12 +106,14 @@ void Layer_::on(uint8_t layer) {
   bitSet(LayerState, layer);
   if (layer > highestLayer)
     highestLayer = layer;
+  updateKeyCache();
 }
 
 void Layer_::off(uint8_t layer) {
   bitClear(LayerState, layer);
   if (layer == highestLayer)
     highestLayer = top();
+  updateKeyCache();
 }
 
 boolean Layer_::isOn(uint8_t layer) {

--- a/src/layers.h
+++ b/src/layers.h
@@ -33,6 +33,7 @@ class Layer_ {
   static Key getKeyFromPROGMEM(uint8_t layer, byte row, byte col);
 
   static void updateKeyCache(byte row, byte col);
+  static void updateKeyCache(void);
 
  private:
   static uint8_t highestLayer;


### PR DESCRIPTION
When we change layers, we want to update the key cache for the whole keyboard, so that LED modes and other things that depend on all keys being up-to-date will work as expected.

Do the same at `Kaleidoscope.setup` time, so we start with a good state too.

This fixes keyboardio/Kaleidoscope-Numlock#7.
