### PR TITLE
When a momentary layer is held, reactivate the layer if it turns off

### DIFF
--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -20,6 +20,11 @@ static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState) {
       } else {
         Layer.on(target);
       }
+    } else if (keyIsPressed(keyState) &&
+               target != KEYMAP_NEXT &&
+               target != KEYMAP_PREVIOUS) {
+      if (!Layer.isOn(target))
+        Layer.on(target);
     }
     if (keyToggledOff(keyState)) {
       if (target == KEYMAP_NEXT) {

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -28,6 +28,20 @@ static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState) {
       break;
 
     default:
+      /* The default case is when we are switching to a layer by its number, and
+       * is a bit more complicated than switching there when the key toggles on,
+       * and away when it toggles off.
+       *
+       * We want to handle the case where we have more than one momentary layer
+       * key on our keymap that point to the same target layer, and we hold
+       * both, and release one. In this case, the layer should remain active,
+       * because the second momentary key is still held.
+       *
+       * To do this, we turn the layer back on if the switcher key is still
+       * held, not only when it toggles on. So when one of them is released,
+       * that does turn the layer off, but with the other still being held, the
+       * layer will toggle back on in the same cycle.
+       */
       if (keyIsPressed(keyState)) {
         if (!Layer.isOn(target))
           Layer.on(target);

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -12,32 +12,32 @@ static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState) {
   if (keymapEntry.keyCode >= MOMENTARY_OFFSET) {
     uint8_t target = keymapEntry.keyCode - MOMENTARY_OFFSET;
 
-    if (keyToggledOn(keyState)) {
-      if (target == KEYMAP_NEXT) {
+    switch (target) {
+    case KEYMAP_NEXT:
+      if (keyToggledOn(keyState))
         Layer.next();
-      } else if (target == KEYMAP_PREVIOUS) {
+      else if (keyToggledOff(keyState))
         Layer.previous();
-      } else {
-        Layer.on(target);
-      }
-    } else if (keyIsPressed(keyState) &&
-               target != KEYMAP_NEXT &&
-               target != KEYMAP_PREVIOUS) {
-      if (!Layer.isOn(target))
-        Layer.on(target);
-    }
-    if (keyToggledOff(keyState)) {
-      if (target == KEYMAP_NEXT) {
+      break;
+
+    case KEYMAP_PREVIOUS:
+      if (keyToggledOn(keyState))
         Layer.previous();
-      } else if (target == KEYMAP_PREVIOUS) {
+      else if (keyToggledOff(keyState))
         Layer.next();
-      } else {
+      break;
+
+    default:
+      if (keyIsPressed(keyState)) {
+        if (!Layer.isOn(target))
+          Layer.on(target);
+      } else if (keyToggledOff(keyState)) {
         Layer.off(target);
       }
+      break;
     }
-
-    // switch keymap and stay there
   } else if (keyToggledOn(keyState)) {
+    // switch keymap and stay there
     if (Layer.isOn(keymapEntry.keyCode) && keymapEntry.keyCode)
       Layer.off(keymapEntry.keyCode);
     else


### PR DESCRIPTION
If we have two keys on our keymap that momentarily go to the same layer (which is the case for the factory firmware), we hold both, and release one, we want the layer to remain active still.

To this effect, in `handleKeymapKeyswitchEvent` we will handle the case when a momentary layer key is pressed, but not toggled on (that is, it is held): if it is not a next/previous switch, we re-activate the layer if it wasn't on.

This fixes #154, thanks to @ToyKeeper for the report.

(The second commit in the series should have no functional changes, it just makes the code a bit more readable, in my opinion.)