### PR TITLE
Layer: Add Layer.highest() to access the cached highestLayer

### DIFF
--- a/src/layers.h
+++ b/src/layers.h
@@ -44,12 +44,14 @@ class Layer_ {
     uint8_t layer = activeLayers[row][col];
     return (*getKey)(layer, row, col);
   }
-
   static void on(uint8_t layer);
   static void off(uint8_t layer);
   static void move(uint8_t layer);
 
   static uint8_t top(void);
+  static uint8_t highest(void) {
+    return highestLayer;
+  }
   static void next(void);
   static void previous(void);
 


### PR DESCRIPTION
Sometimes we would like to know the highest active layer, which is available in the `highestLayer` private variable, and via `.top()` too. We do not want to make `highestLayer` public, because we want to be the only ones changing it. And while `top()` gets us roughly the same information, it does so at a cost. For a lot of purposes, the cached `highestLayer` would be perfectly adequate.

The new `Layer.highest()` accessor does just this.
