### PR TITLE
Rename Layer.highest() to Layer.top()

### DIFF
--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -109,12 +109,14 @@ Layer_::updateActiveLayers(void) {
   }
 }
 
-uint8_t Layer_::top(void) {
+void Layer_::updateHighestLayer(void) {
   for (int8_t i = 31; i >= 0; i--) {
-    if (bitRead(LayerState, i))
-      return i;
+    if (bitRead(LayerState, i)) {
+      highestLayer = i;
+      return;
+    }
   }
-  return 0;
+  highestLayer = 0;
 }
 
 void Layer_::move(uint8_t layer) {
@@ -127,7 +129,7 @@ void Layer_::on(uint8_t layer) {
 
   bitSet(LayerState, layer);
   if (layer > highestLayer)
-    highestLayer = layer;
+    updateHighestLayer();
 
   /* If the layer did turn on, update the keymap cache. See layers.h for an
    * explanation about the caches we have. */
@@ -140,7 +142,7 @@ void Layer_::off(uint8_t layer) {
 
   bitClear(LayerState, layer);
   if (layer == highestLayer)
-    highestLayer = top();
+    updateHighestLayer();
 
   /* If the layer did turn off, update the keymap cache. See layers.h for an
    * explanation about the caches we have. */
@@ -153,11 +155,11 @@ boolean Layer_::isOn(uint8_t layer) {
 }
 
 void Layer_::next(void) {
-  on(top() + 1);
+  on(highestLayer + 1);
 }
 
 void Layer_::previous(void) {
-  off(top());
+  off(highestLayer);
 }
 
 void Layer_::defaultLayer(uint8_t layer) {

--- a/src/layers.h
+++ b/src/layers.h
@@ -48,8 +48,7 @@ class Layer_ {
   static void off(uint8_t layer);
   static void move(uint8_t layer);
 
-  static uint8_t top(void);
-  static uint8_t highest(void) {
+  static uint8_t top(void) {
     return highestLayer;
   }
   static void next(void);
@@ -72,6 +71,8 @@ class Layer_ {
   static void updateActiveLayers(void);
 
  private:
+  static void updateHighestLayer(void);
+
   static uint8_t highestLayer;
   static Key liveCompositeKeymap[ROWS][COLS];
   static uint8_t activeLayers[ROWS][COLS];


### PR DESCRIPTION
For all cases outside of Kaleidoscope itself, we are good with the value of `highestLayer`, and do not need to re-scan the layer state. For this reason - upon @obra's suggestion - rename `Layer.highest()` to `Layer.top()`, and the old `Layer.top()` to `Layer.updateHighestLayer()`, and make the latter private, and update the `highestLayer` member variable instead of returning the number.
