### PR TITLE
Update the live composite keymap too at setup time

### DIFF
--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -19,6 +19,11 @@ Kaleidoscope_::setup(void) {
 
   // Update the keymap cache, so we start with a non-empty state.
   Layer.updateActiveLayers();
+  for (byte row = 0; row < ROWS; row++) {
+    for (byte col = 0; col < COLS; col++) {
+      Layer.updateLiveCompositeKeymap(row, col);
+    }
+  }
 }
 
 void


### PR DESCRIPTION
We want to start with a pre-cached state, so we have both less work to do when keys are first pressed, and so that plugins that rely on the live composite state will work reliably too.