### PR TITLE
Establish standardized format of cRGB for all hardwares

### DIFF
--- a/src/Kaleidoscope-Hardware.h
+++ b/src/Kaleidoscope-Hardware.h
@@ -1,0 +1,79 @@
+#pragma once
+
+typedef struct {
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+} cRGB;
+
+typedef struct {
+  uint8_t g;
+  uint8_t r;
+  uint8_t b;
+} cGRB;
+
+static inline cGRB asCGRB(const cRGB& crgb) {
+  return (cGRB){crgb.g, crgb.r, crgb.b};
+}
+
+static inline cRGB asCRGB(const cGRB& cgrb) {
+  return (cRGB){cgrb.r, cgrb.g, cgrb.b};
+}
+
+typedef struct {
+  uint8_t r;
+  uint8_t b;
+  uint8_t g;
+} cRBG;
+
+static inline cRBG asCRBG(const cRGB& crgb) {
+  return (cRBG){crgb.r, crgb.b, crgb.g};
+}
+
+static inline cRGB asCRGB(const cRBG& crbg) {
+  return (cRGB){crbg.r, crbg.g, crbg.b};
+}
+
+typedef struct {
+  uint8_t g;
+  uint8_t b;
+  uint8_t r;
+} cGBR;
+
+static inline cGBR asCGBR(const cRGB& crgb) {
+  return (cGBR){crgb.g, crgb.b, crgb.r};
+}
+
+static inline cRGB asCRGB(const cGBR& cgbr) {
+  return (cRGB){cgbr.r, cgbr.g, cgbr.b};
+}
+
+typedef struct {
+  uint8_t b;
+  uint8_t r;
+  uint8_t g;
+} cBRG;
+
+static inline cBRG asCBRG(const cRGB& crgb) {
+  return (cBRG){crgb.b, crgb.r, crgb.g};
+}
+
+static inline cRGB asCRGB(const cBRG& cbrg) {
+  return (cRGB){cbrg.r, cbrg.g, cbrg.b};
+}
+
+typedef struct {
+  uint8_t b;
+  uint8_t g;
+  uint8_t r;
+} cBGR;
+
+static inline cBGR asCBGR(const cRGB& crgb) {
+  return (cBGR){crgb.b, crgb.g, crgb.r};
+}
+
+static inline cRGB asCRGB(const cBGR& cbgr) {
+  return (cRGB){cbgr.r, cbgr.g, cbgr.b};
+}
+
+#define CRGB(r,g,b) (cRGB){r,g,b}

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -21,6 +21,7 @@ void setup();
 
 
 #include KALEIDOSCOPE_HARDWARE_H
+#include "Kaleidoscope-Hardware.h"
 #include "key_events.h"
 #include "kaleidoscope/hid.h"
 #include "layers.h"


### PR DESCRIPTION
This is pull request # 1/4 unifying the definition of `cRGB` across hardwares.  The other three pull requests are against `keyboardio/Kaleidoscope-Hardware-Model01`, `keyboardio/KeyboardioScanner`, and `shortcutgg/Kaleidoscope-Hardware-Shortcut`.  None of the four pull requests will build without the others, unfortunately.

The rationale for these pull requests is as follows.  First, a unified definition of `cRGB` is intuitive and elegant.  As part of the core hardware API, it also makes sense to define `cRGB` in the Kaleidoscope core.  

Second, this brings down a major barrier to implementing an actual abstract hardware base class (which is planned as a followup series of pull requests against these same repos; however, the issue of unifying `cRGB` seemed separate enough to warrant separate pull requests with their own discussion).  In fact, the unified definition of `cRGB` is declared by itself in a file called “Kaleidoscope-Hardware.h”, which is very forward-looking as eventually it will simply be declared as part of the abstract hardware base class.

Third, although it may seem at first glance that these pull requests may harm performance in terms of code size and/or execution time, this is actually not the case.  The additional function calls are inlined, and the resulting code generally just takes struct-copy operations that were already happening and changes them to copy struct members to different places.  The code is more verbose, but should compile down to the same number of operations to my knowledge.  To back up these assertions, we compare results of compiling a few sketches before and after these four pull requests are applied.  For the Model 01, we build the two sketches in `keyboardio/Kaleidoscope/examples`; the unified `cRGB` definition results in the exact same code size for `AppSwitcher`, and actually a 2-byte *improvement* for `Kaleidoscope`.  For the Shortcut, we build the sketch in `shortcutgg/Kaleidoscope-Hardware-Shortcut/examples`; again we end up with the exact same code size with or without these four pull requests.  I would imagine these results also indicate execution time hasn’t changed.