### PR TITLE
kaleidoscope-builder: Better error message for sketch-not-found

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -32,6 +32,7 @@ find_sketch () {
             return
         fi
     done
+        echo "Couldn't find sketch (.ino file)" >&2
     exit 1
 }
 


### PR DESCRIPTION
Currently, if kaleidoscope-builder fails to find a sketch file, the
resulting error message is very confusing and unhelpful.  This commit
makes it more straightforward and helpful.