### PR TITLE
Make the already deprecated hook registration functions emit a warning

### DIFF
--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -134,3 +134,13 @@ Kaleidoscope_::focusHook(const char *command) {
 }
 
 Kaleidoscope_ Kaleidoscope;
+
+/* Deprecated functions */
+
+void event_handler_hook_use(Kaleidoscope_::eventHandlerHook hook) {
+  Kaleidoscope.useEventHandlerHook(hook);
+}
+
+void loop_hook_use(Kaleidoscope_::loopHook hook) {
+  Kaleidoscope.useLoopHook(hook);
+}

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -122,9 +122,4 @@ extern Kaleidoscope_ Kaleidoscope;
 /* -- DEPRECATED aliases; remove them when there are no more users. -- */
 
 #define event_handler_hook_use(hook) Kaleidoscope.useEventHandlerHook(hook);
-#define event_handler_hook_append(hook) Kaleidoscope.appendEventHandlerHook(hook)
-#define event_handler_hook_replace(oldHook, newHook) Kaleidoscope.replaceEventHandlerHook(oldHook, newHook)
-
 #define loop_hook_use(hook) Kaleidoscope.useLoopHook(hook)
-#define loop_hook_append(hook) Kaleidoscope.appendLoopHook(hook)
-#define loop_hook_replace(oldHook, newHook) Kaleidoscope.replaceLoopHook(oldHook, newHook)

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -121,5 +121,5 @@ extern Kaleidoscope_ Kaleidoscope;
 
 /* -- DEPRECATED aliases; remove them when there are no more users. -- */
 
-#define event_handler_hook_use(hook) Kaleidoscope.useEventHandlerHook(hook);
-#define loop_hook_use(hook) Kaleidoscope.useLoopHook(hook)
+void event_handler_hook_use(Kaleidoscope_::eventHandlerHook hook) __attribute__((deprecated));
+void loop_hook_use(Kaleidoscope_::loopHook hook) __attribute__((deprecated));


### PR DESCRIPTION
The first half of this PR removes the `_hook_append` and `_hook_replace` aliases, which aren't used anywhere anymore, neither by plugins within Arduino-Boards, nor any plugins outside of it.

Then, the other half turns the `_hook_use` aliases into real functions, so we can attach a deprecated attribute, and emit a compile-time warning when they are used. There are currently two plugins outside of Arduino-Boards affected: [LangPack-Hungarian](https://github.com/algernon/Kaleidoscope-LangPack-Hungarian) and [LED-WavePool](https://github.com/ToyKeeper/Kaleidoscope-LED-Wavepool).

I'll fix the first one, and submit a PR for the second, but meanwhile, this PR can help move deprecation forward.