### PR TITLE
Deprecate a few more things

### DIFF
--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -144,3 +144,14 @@ void event_handler_hook_use(Kaleidoscope_::eventHandlerHook hook) {
 void loop_hook_use(Kaleidoscope_::loopHook hook) {
   Kaleidoscope.useLoopHook(hook);
 }
+
+void __USE_PLUGINS(KaleidoscopePlugin *plugin, ...) {
+  va_list ap;
+
+  Kaleidoscope.use(plugin);
+
+  va_start(ap, plugin);
+  while ((plugin = (KaleidoscopePlugin *)va_arg(ap, KaleidoscopePlugin *)) != NULL)
+    Kaleidoscope.use(plugin);
+  va_end(ap);
+}

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -46,7 +46,8 @@ class Kaleidoscope_ {
  public:
   Kaleidoscope_(void);
 
-  void setup(const byte keymap_count) {
+  void setup(const byte keymap_count)
+  __attribute__((deprecated("The keymap_count argument (and the KEYMAP_SIZE macro) are unused, and can be safely removed."))) {
     setup();
   }
   void setup(void);

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -36,8 +36,6 @@ extern HARDWARE_IMPLEMENTATION KeyboardHardware;
 const uint8_t KEYMAP_SIZE
 __attribute__((deprecated("Kaleidoscope.setup() does not require KEYMAP_SIZE anymore."))) = 0;
 
-#define USE_PLUGINS(plugins...) Kaleidoscope.use(plugins)
-
 class KaleidoscopePlugin {
  public:
   virtual void begin(void) = 0;
@@ -122,7 +120,13 @@ extern Kaleidoscope_ Kaleidoscope;
                                            "layer.getState")
 
 /* -- DEPRECATED aliases; remove them when there are no more users. -- */
+
 void event_handler_hook_use(Kaleidoscope_::eventHandlerHook hook)
 __attribute__((deprecated("Use Kaleidoscope.useEventHandlerHook instead")));
 void loop_hook_use(Kaleidoscope_::loopHook hook)
 __attribute__((deprecated("Use Kaleidoscope.useLoopHook instead")));
+
+void __USE_PLUGINS(KaleidoscopePlugin *plugin, ...)
+__attribute__((deprecated("Use Kaleidoscope.use(...) instead")));
+
+#define USE_PLUGINS(...) __USE_PLUGINS(__VA_ARGS__, NULL)

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -33,7 +33,8 @@ extern HARDWARE_IMPLEMENTATION KeyboardHardware;
 #define VERSION "locally-built"
 #endif
 
-#define KEYMAP_SIZE (sizeof(keymaps) / ROWS / COLS / sizeof(Key))
+const uint8_t KEYMAP_SIZE
+__attribute__((deprecated("Kaleidoscope.setup() does not require KEYMAP_SIZE anymore."))) = 0;
 
 #define USE_PLUGINS(plugins...) Kaleidoscope.use(plugins)
 

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -120,6 +120,7 @@ extern Kaleidoscope_ Kaleidoscope;
                                            "layer.getState")
 
 /* -- DEPRECATED aliases; remove them when there are no more users. -- */
-
-void event_handler_hook_use(Kaleidoscope_::eventHandlerHook hook) __attribute__((deprecated));
-void loop_hook_use(Kaleidoscope_::loopHook hook) __attribute__((deprecated));
+void event_handler_hook_use(Kaleidoscope_::eventHandlerHook hook)
+__attribute__((deprecated("Use Kaleidoscope.useEventHandlerHook instead")));
+void loop_hook_use(Kaleidoscope_::loopHook hook)
+__attribute__((deprecated("Use Kaleidoscope.useLoopHook instead")));


### PR DESCRIPTION
This does a few things:

- Adds deprecation messages to the `_hook_use` functions.
- Deprecates `Kaleidoscope.setup(key_count)` (but not the argument-less variant).
- Deprecates `KEYMAP_SIZE`, which was only used with the function above. As a side-effect, `KEYMAP_SIZE` will always be 0.
- Deprecates `USE_PLUGINS` in favour of `Kaleidoscope.use()`. This is done in a not-so neat way, but that's the best method I found to still have a deprecation notice.

Of these, I'm certain that the first two are useful and completely safe. The last two, I'm a bit unsure about, but should be safe nevertheless. I searched around on GitHub, and there are some users of both `KEYMAP_SIZE` and `USE_PLUGINS`. If I don't forget, I'll be submitting pull requests against those uses.