### PR TITLE
Fix URL to USD HID documentation

### DIFF
--- a/src/HIDTables.h
+++ b/src/HIDTables.h
@@ -2,7 +2,7 @@
 
 
 // These mappings were extracted and transcribed from
-// http://www.usb.org_SLASH_developers_SLASH_devclass_docs_SLASH_Hut1_12v2.pdf
+// http://www.usb.org/developers/hidpage/Hut1_12v2.pdf
 //
 // In most cases, I've preserved the "official" USB Implementers forum
 // "Usage Name", though I've standardized some abbreviations and spacing


### PR DESCRIPTION
This URL seems to have suffered overzealous replacement. It also appears to have changed on usb.org. I think this new URL is for the correct documentation (relevant table that starts on page 53).