### PR TITLE
Allow injected events tied to physical keyswitches

### DIFF
--- a/src/key_events.h
+++ b/src/key_events.h
@@ -11,6 +11,9 @@ extern const Key keymaps[][ROWS][COLS];
 // Code can use this macro on injected key events to signal that
 // the event isn't tied to a specific physical keyswitch
 #define UNKNOWN_KEYSWITCH_LOCATION 255,255
+// Conversely, if an injected event *is* tied to a physical keyswitch and should
+// be resolved by the current keymap, code can use Key_NoKey on the injected event
+// with a real (row, col) location
 
 // sending events to the computer
 /* The event handling starts with the Scanner calling handleKeyswitchEvent() for


### PR DESCRIPTION
Currently, injected events *must* use a valid `mappedKey` in their call to `handleKeyswitchEvent()`, and the `row` and `col` parameters are ignored (at least in core).  The theory, I believe, is that injected events are never tied to a physical keyswitch, always to a mapped key identity.

This pull request asks, why can't we allow code to instead (at its option) inject events onto a given physical keyswitch, and have them resolved normally based on whatever layer is active.  This is at least partly a genuine question - is there a reason I'm not aware of that says we can't allow this?  I haven't tested this pull request other than to say it passes CI; I wouldn't even know what test cases would be relevant, or if I've broken anything.  Review from @algernon / @obra is requested.  I'm wondering if the check for the INJECTED flag that I've removed was there simply to avoid out-of-bounds accesses, and therefore is no longer necessary (since we guard against out-of-bounds separately now).  On the other hand, if there was another reason for the check, then by removing it I may have broken something.

I've at least preserved back-compatibility by ensuring that if any existing code does inject keypresses with a valid `mappedKey` *and* a valid `row` and `col`, the `mappedKey` wins and the `row` and `col` are ignored, just as they were before this commit.