### PR TITLE
Revert "Make KaleidoscopePlugin.begin protected by default"

### DIFF
--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -36,37 +36,9 @@ extern HARDWARE_IMPLEMENTATION KeyboardHardware;
 const uint8_t KEYMAP_SIZE
 __attribute__((deprecated("Kaleidoscope.setup() does not require KEYMAP_SIZE anymore."))) = 0;
 
-class Kaleidoscope_;
-
 class KaleidoscopePlugin {
-  friend class Kaleidoscope_;
-
- protected:
-  /** @deprecated Initial setup function.
-   *  Use \ref initialSetup() instead, and see documentation there.
-   */
-  virtual void begin(void) __attribute__((deprecated("Use initialSetup() instead"))) { };
-
-  /** Initial plugin setup hook.
-   * All plugins are supposed to provide a singleton object, statically
-   * initialized at compile-time (with few exceptions). Because of this, the
-   * order in which they are instantiated is unspecified, and cannot be relied
-   * upon. For this reason, one's expected to explicitly initialize, "use" the
-   * plugins one wishes to, by calling `Kaleidoscope.use()` with a list of plugin
-   * object pointers.
-   *
-   * This function will in turn call the `initialSetup` function of each plugin,
-   * so that they can perform any initial setup they wish, such as registering
-   * event handler or loop hooks. This is the only time this function will be
-   * called. It is intentionally protected, and accessible by the `Kaleidoscope`
-   * class only.
-   *
-   * @TODO: Once the deprecated \ref begin() method is removed, turn this into an
-   * abstract function.
-   */
-  virtual void initialSetup(void) {
-    begin();
-  }
+ public:
+  virtual void begin(void) = 0;
 };
 
 class Kaleidoscope_ {
@@ -89,7 +61,7 @@ class Kaleidoscope_ {
   // Then, the one-argument version, that gives us type safety for a single
   // plugin.
   inline void use(KaleidoscopePlugin *p) {
-    p->initialSetup();
+    p->begin();
   }
 
   // We have a no-op with a int argument, as a temporary hack until we remove


### PR DESCRIPTION
Reverts keyboardio/Kaleidoscope#196

I think i was too hasty in merging the rename. I'd misunderstood the code as being a single function with a single caller, not something that was going to require this much churn. I'm backing it out for now, just to think a bit more. (I will pull in the docs now, though)