### PR TITLE
rename KaleidoscopePlugin.begin to KaleidosopePlugin.initialSetup

### DIFF
--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -42,9 +42,9 @@ class KaleidoscopePlugin {
   friend class Kaleidoscope_;
 
  protected:
- /** @deprecated Initial setup function.
-   *  Use \ref initialSetup() instead, and see documentation there.
-   */
+  /** @deprecated Initial setup function.
+    *  Use \ref initialSetup() instead, and see documentation there.
+    */
   virtual void begin(void) __attribute__((deprecated("Use initialSetup() instead"))) { };
 
 

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -42,6 +42,11 @@ class KaleidoscopePlugin {
   friend class Kaleidoscope_;
 
  protected:
+ /** @deprecated Initial setup function.
+   *  Use \ref initialSetup() instead, and see documentation there.
+   */
+  virtual void begin(void) __attribute__((deprecated("Use initialSetup() instead"))) { };
+
 
   /** Initial plugin setup hook.
    * All plugins are supposed to provide a singleton object, statically
@@ -56,8 +61,13 @@ class KaleidoscopePlugin {
    * event handler or loop hooks. This is the only time this function will be
    * called. It is intentionally protected, and accessible by the `Kaleidoscope`
    * class only.
+   *
+   * @TODO: Once the deprecated \ref begin() method is removed, turn this into an
+   * abstract function.
    */
-  virtual void begin(void) { };
+  virtual void initialSetup(void) {
+    begin();
+  }
 };
 
 class Kaleidoscope_ {
@@ -80,7 +90,7 @@ class Kaleidoscope_ {
   // Then, the one-argument version, that gives us type safety for a single
   // plugin.
   inline void use(KaleidoscopePlugin *p) {
-    p->begin();
+    p->initialSetup();
   }
 
   // We have a no-op with a int argument, as a temporary hack until we remove


### PR DESCRIPTION
to better explain what it does.

This is part 2 of #196. I (jesse) broke it out because it ends up being...very noisy.

I'm not sure we need to make this change and wanted to split it out from the docs and other code changes.