### PR TITLE
Specify full path to `stty`

### DIFF
--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -50,7 +50,7 @@ if [ "${uname_S}" = "Darwin" ]; then
     DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemHID* 2> /dev/null || echo '')}"
     DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCHID* 2> /dev/null || echo '')}"
     DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
-    RESET_DEVICE="stty -f ${DEVICE_PORT} 1200"
+    RESET_DEVICE="/bin/stty -f ${DEVICE_PORT} 1200"
 
 
     ARDUINO_PATH="${ARDUINO_PATH:-/Applications/Arduino.app/Contents/Java/}"


### PR DESCRIPTION
I install GNU coreutils on my Macs, to get GNU `ls`. It also installs a GNU-flavored `stty`, which wants `-F` instead of `-f`. Giving the full path to the OS `stty` avoids issues in this case, and should be consequence-free for folks that _don't_ have GNU coreutils installed.