### PR TITLE
Fixed a typo in key def aliases (s/Key_LGuy/Key_LGui/)

### DIFF
--- a/src/key_defs_aliases.h
+++ b/src/key_defs_aliases.h
@@ -15,7 +15,7 @@
 #define Key_LCtrl  Key_LeftControl
 #define Key_LShift Key_LeftShift
 #define Key_LAlt Key_LeftAlt
-#define Key_LGuy Key_LeftGui
+#define Key_LGui Key_LeftGui
 #define Key_RBracket  Key_RightBracket
 #define Key_RArrow  Key_RightArrow
 #define Key_RCtrl  Key_RightControl


### PR DESCRIPTION
I spotted an obvious typo in `key_defs_aliases.h`. I doubt anyone has tried to use that alias yet, but it might as well get fixed before that happens.