### PR TITLE
Rearranged and commented Layer.on() and Layer.off()

### DIFF
--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -125,29 +125,37 @@ void Layer_::move(uint8_t layer) {
 }
 
 void Layer_::on(uint8_t layer) {
-  bool wasOn = isOn(layer);
+  // If the target layer was off, turn it on:
+  if (!isOn(layer)) {
+    // Turn on its bit in LayerState
+    bitSet(LayerState, layer);
 
-  bitSet(LayerState, layer);
-  if (layer > highestLayer)
-    updateHighestLayer();
+    // If the target layer is above the previous highest active layer,
+    // update highestLayer
+    if (layer > highestLayer)
+      updateHighestLayer();
 
-  /* If the layer did turn on, update the keymap cache. See layers.h for an
-   * explanation about the caches we have. */
-  if (!wasOn)
+    // Update the keymap cache (but not liveCompositeKeymap; that gets
+    // updated separately, when keys toggle on or off. See layers.h
     updateActiveLayers();
+  }
 }
 
 void Layer_::off(uint8_t layer) {
-  bool wasOn = isOn(layer);
+  // If the target layer was on, turn it off:
+  if (isOn(layer)) {
+    // Turn off its bit in LayerState
+    bitClear(LayerState, layer);
 
-  bitClear(LayerState, layer);
-  if (layer == highestLayer)
-    updateHighestLayer();
+    // If the target layer was the previous highest active layer,
+    // update highestLayer
+    if (layer == highestLayer)
+      updateHighestLayer();
 
-  /* If the layer did turn off, update the keymap cache. See layers.h for an
-   * explanation about the caches we have. */
-  if (wasOn)
+    // Update the keymap cache (but not liveCompositeKeymap; that gets
+    // updated separately, when keys toggle on or off. See layers.h
     updateActiveLayers();
+  }
 }
 
 boolean Layer_::isOn(uint8_t layer) {

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -144,7 +144,7 @@ void Layer_::on(uint8_t layer) {
 
 void Layer_::off(uint8_t layer) {
   // If the target layer was already off, return
-  if (bitRead(LayerState, layer))
+  if (!bitRead(LayerState, layer))
     return;
 
   // Turn off its bit in LayerState

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -146,7 +146,7 @@ void Layer_::off(uint8_t layer) {
   // If the target layer was already off, return
   if (bitRead(LayerState, layer))
     return;
-  
+
   // Turn off its bit in LayerState
   bitClear(LayerState, layer);
 

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -126,7 +126,8 @@ void Layer_::move(uint8_t layer) {
 
 void Layer_::on(uint8_t layer) {
   // If the target layer was already on, return
-  if (bitRead(LayerState, layer)) return;
+  if (bitRead(LayerState, layer))
+    return;
 
   // Otherwise, turn on its bit in LayerState
   bitSet(LayerState, layer);
@@ -143,7 +144,8 @@ void Layer_::on(uint8_t layer) {
 
 void Layer_::off(uint8_t layer) {
   // If the target layer was already off, return
-  if (bitRead(LayerState, layer)) return;
+  if (bitRead(LayerState, layer))
+    return;
   
   // Turn off its bit in LayerState
   bitClear(LayerState, layer);

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -125,37 +125,37 @@ void Layer_::move(uint8_t layer) {
 }
 
 void Layer_::on(uint8_t layer) {
-  // If the target layer was off, turn it on:
-  if (!bitRead(LayerState, layer)) {
-    // Turn on its bit in LayerState
-    bitSet(LayerState, layer);
+  // If the target layer was already on, return
+  if (bitRead(LayerState, layer)) return;
 
-    // If the target layer is above the previous highest active layer,
-    // update highestLayer
-    if (layer > highestLayer)
-      updateHighestLayer();
+  // Otherwise, turn on its bit in LayerState
+  bitSet(LayerState, layer);
 
-    // Update the keymap cache (but not liveCompositeKeymap; that gets
-    // updated separately, when keys toggle on or off. See layers.h)
-    updateActiveLayers();
-  }
+  // If the target layer is above the previous highest active layer,
+  // update highestLayer
+  if (layer > highestLayer)
+    updateHighestLayer();
+
+  // Update the keymap cache (but not liveCompositeKeymap; that gets
+  // updated separately, when keys toggle on or off. See layers.h)
+  updateActiveLayers();
 }
 
 void Layer_::off(uint8_t layer) {
-  // If the target layer was on, turn it off:
-  if (bitRead(LayerState, layer)) {
-    // Turn off its bit in LayerState
-    bitClear(LayerState, layer);
+  // If the target layer was already off, return
+  if (bitRead(LayerState, layer)) return;
+  
+  // Turn off its bit in LayerState
+  bitClear(LayerState, layer);
 
-    // If the target layer was the previous highest active layer,
-    // update highestLayer
-    if (layer == highestLayer)
-      updateHighestLayer();
+  // If the target layer was the previous highest active layer,
+  // update highestLayer
+  if (layer == highestLayer)
+    updateHighestLayer();
 
-    // Update the keymap cache (but not liveCompositeKeymap; that gets
-    // updated separately, when keys toggle on or off. See layers.h)
-    updateActiveLayers();
-  }
+  // Update the keymap cache (but not liveCompositeKeymap; that gets
+  // updated separately, when keys toggle on or off. See layers.h)
+  updateActiveLayers();
 }
 
 boolean Layer_::isOn(uint8_t layer) {

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -126,7 +126,7 @@ void Layer_::move(uint8_t layer) {
 
 void Layer_::on(uint8_t layer) {
   // If the target layer was already on, return
-  if (bitRead(LayerState, layer))
+  if (isOn(layer))
     return;
 
   // Otherwise, turn on its bit in LayerState
@@ -144,7 +144,7 @@ void Layer_::on(uint8_t layer) {
 
 void Layer_::off(uint8_t layer) {
   // If the target layer was already off, return
-  if (!bitRead(LayerState, layer))
+  if (!isOn(layer))
     return;
 
   // Turn off its bit in LayerState

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -124,6 +124,7 @@ void Layer_::move(uint8_t layer) {
   on(layer);
 }
 
+// Activate a given layer
 void Layer_::on(uint8_t layer) {
   // If the target layer was already on, return
   if (isOn(layer))
@@ -142,6 +143,7 @@ void Layer_::on(uint8_t layer) {
   updateActiveLayers();
 }
 
+// Deactivate a given layer
 void Layer_::off(uint8_t layer) {
   // If the target layer was already off, return
   if (!isOn(layer))

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -136,7 +136,7 @@ void Layer_::on(uint8_t layer) {
       updateHighestLayer();
 
     // Update the keymap cache (but not liveCompositeKeymap; that gets
-    // updated separately, when keys toggle on or off. See layers.h
+    // updated separately, when keys toggle on or off. See layers.h)
     updateActiveLayers();
   }
 }
@@ -153,7 +153,7 @@ void Layer_::off(uint8_t layer) {
       updateHighestLayer();
 
     // Update the keymap cache (but not liveCompositeKeymap; that gets
-    // updated separately, when keys toggle on or off. See layers.h
+    // updated separately, when keys toggle on or off. See layers.h)
     updateActiveLayers();
   }
 }

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -126,7 +126,7 @@ void Layer_::move(uint8_t layer) {
 
 void Layer_::on(uint8_t layer) {
   // If the target layer was off, turn it on:
-  if (!isOn(layer)) {
+  if (!bitRead(LayerState, layer)) {
     // Turn on its bit in LayerState
     bitSet(LayerState, layer);
 
@@ -143,7 +143,7 @@ void Layer_::on(uint8_t layer) {
 
 void Layer_::off(uint8_t layer) {
   // If the target layer was on, turn it off:
-  if (isOn(layer)) {
+  if (bitRead(LayerState, layer)) {
     // Turn off its bit in LayerState
     bitClear(LayerState, layer);
 


### PR DESCRIPTION
The boolean wasOn was unnecessary, and there was no need to call
bitSet() (or bitClear(), in the case of Layer.off()) if the test
passed. Mostly, I just added a few explanatory comments.

**WARNING**: This change has not been tested on a keyboard yet.