### PR TITLE
Prevent reading past the end of the keymaps[] array

### DIFF
--- a/examples/AppSwitcher/AppSwitcher.ino
+++ b/examples/AppSwitcher/AppSwitcher.ino
@@ -24,7 +24,7 @@
 #include "Macros.h"
 
 /* *INDENT-OFF* */
-const Key keymaps[][ROWS][COLS] PROGMEM = {
+CREATE_KEYMAP(
   [0] = KEYMAP_STACKED
   (
    Key_NoKey,    Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
@@ -43,7 +43,7 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
    Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
    M(M_APPCANCEL)
    ),
-};
+	      )
 /* *INDENT-ON* */
 
 
@@ -66,6 +66,3 @@ void setup() {
 void loop() {
   Kaleidoscope.loop();
 }
-
-// This line should always be at the end of the sketch file
-#include <sketch-trailer.h>

--- a/examples/AppSwitcher/AppSwitcher.ino
+++ b/examples/AppSwitcher/AppSwitcher.ino
@@ -46,11 +46,6 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
 };
 /* *INDENT-ON* */
 
-// Calculate the number of layers defined in the "keymaps[]" array
-// above for use elsewhere in Kaleidoscope. Don't remove or modify
-// this line; it's used to prevent reading past the end of the array!
-const uint8_t LayerCount PROGMEM = sizeof(keymaps) / sizeof(*keymaps);
-
 
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
   switch (macroIndex) {
@@ -71,3 +66,6 @@ void setup() {
 void loop() {
   Kaleidoscope.loop();
 }
+
+// This line should always be at the end of the sketch file
+#include <sketch-trailer.h>

--- a/examples/AppSwitcher/AppSwitcher.ino
+++ b/examples/AppSwitcher/AppSwitcher.ino
@@ -46,6 +46,11 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
 };
 /* *INDENT-ON* */
 
+// Calculate the number of layers defined in the "keymaps[]" array
+// above for use elsewhere in Kaleidoscope. Don't remove or modify
+// this line; it's used to prevent reading past the end of the array!
+const uint8_t LayerCount PROGMEM = sizeof(keymaps) / sizeof(*keymaps);
+
 
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
   switch (macroIndex) {

--- a/examples/AppSwitcher/AppSwitcher.ino
+++ b/examples/AppSwitcher/AppSwitcher.ino
@@ -24,7 +24,7 @@
 #include "Macros.h"
 
 /* *INDENT-OFF* */
-CREATE_KEYMAP(
+KEYMAPS(
   [0] = KEYMAP_STACKED
   (
    Key_NoKey,    Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
@@ -43,7 +43,7 @@ CREATE_KEYMAP(
    Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
    M(M_APPCANCEL)
    ),
-	      )
+)
 /* *INDENT-ON* */
 
 

--- a/examples/Kaleidoscope/Kaleidoscope.ino
+++ b/examples/Kaleidoscope/Kaleidoscope.ino
@@ -57,7 +57,7 @@
                                               Key_KeymapNext_Momentary,         Key_KeymapNext_Momentary \
 )
 
-CREATE_KEYMAP(
+KEYMAPS(
   QWERTY,
   GENERIC_FN2,
   NUMPAD

--- a/examples/Kaleidoscope/Kaleidoscope.ino
+++ b/examples/Kaleidoscope/Kaleidoscope.ino
@@ -65,11 +65,6 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
 
 };
 
-// Calculate the number of layers defined in the "keymaps[]" array
-// above for use elsewhere in Kaleidoscope. Don't remove or modify
-// this line; it's used to prevent reading past the end of the array!
-const uint8_t LayerCount PROGMEM = sizeof(keymaps) / sizeof(*keymaps);
-
 static kaleidoscope::LEDSolidColor solidRed(60, 0, 0);
 static kaleidoscope::LEDSolidColor solidOrange(60, 20, 0);
 static kaleidoscope::LEDSolidColor solidYellow(40, 35, 0);
@@ -109,3 +104,6 @@ void setup() {
 void loop() {
   Kaleidoscope.loop();
 }
+
+// This line should always be at the end of the sketch file
+#include <sketch-trailer.h>

--- a/examples/Kaleidoscope/Kaleidoscope.ino
+++ b/examples/Kaleidoscope/Kaleidoscope.ino
@@ -57,13 +57,12 @@
                                               Key_KeymapNext_Momentary,         Key_KeymapNext_Momentary \
 )
 
-const Key keymaps[][ROWS][COLS] PROGMEM = {
+CREATE_KEYMAP(
   QWERTY,
   GENERIC_FN2,
   NUMPAD
+)
 
-
-};
 
 static kaleidoscope::LEDSolidColor solidRed(60, 0, 0);
 static kaleidoscope::LEDSolidColor solidOrange(60, 20, 0);
@@ -104,6 +103,3 @@ void setup() {
 void loop() {
   Kaleidoscope.loop();
 }
-
-// This line should always be at the end of the sketch file
-#include <sketch-trailer.h>

--- a/examples/Kaleidoscope/Kaleidoscope.ino
+++ b/examples/Kaleidoscope/Kaleidoscope.ino
@@ -65,6 +65,11 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
 
 };
 
+// Calculate the number of layers defined in the "keymaps[]" array
+// above for use elsewhere in Kaleidoscope. Don't remove or modify
+// this line; it's used to prevent reading past the end of the array!
+const uint8_t LayerCount PROGMEM = sizeof(keymaps) / sizeof(*keymaps);
+
 static kaleidoscope::LEDSolidColor solidRed(60, 0, 0);
 static kaleidoscope::LEDSolidColor solidOrange(60, 20, 0);
 static kaleidoscope::LEDSolidColor solidYellow(40, 35, 0);

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -129,9 +129,8 @@ void Layer_::move(uint8_t layer) {
 
 void Layer_::on(uint8_t layer) {
   // If we're trying to turn on a layer that doesn't exist; abort
-  if (layer >= LayerCount) {
+  if (LayerCount != 0 && layer >= LayerCount)
     return;
-  }
 
   bool wasOn = isOn(layer);
 

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -125,6 +125,11 @@ void Layer_::move(uint8_t layer) {
 }
 
 void Layer_::on(uint8_t layer) {
+  if (layer >= LayerCount) {
+    // Trying to turn on a layer that doesn't exist; abort
+    return;
+  }
+
   bool wasOn = isOn(layer);
 
   bitSet(LayerState, layer);

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -10,8 +10,8 @@ Key(*Layer_::getKey)(uint8_t layer, byte row, byte col) = Layer.getKeyFromPROGME
 
 // The total number of defined layers in the firmware sketch keymaps[]
 // array. If the keymap wasn't defined using CREATE_KEYMAP() in the
-// sketch file, LayerCount gets the default value of zero.
-uint8_t LayerCount __attribute__((weak)) = 0;
+// sketch file, layer_count gets the default value of zero.
+uint8_t layer_count __attribute__((weak)) = 0;
 
 static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState) {
   if (keymapEntry.keyCode >= LAYER_SHIFT_OFFSET) {
@@ -132,7 +132,7 @@ void Layer_::move(uint8_t layer) {
 void Layer_::on(uint8_t layer) {
   // If we're trying to turn on a layer that doesn't exist, abort (but
   // if the keymap wasn't defined using CREATE_KEYMAP(), proceed anyway
-  if (LayerCount != 0 && layer >= LayerCount)
+  if (layer_count != 0 && layer >= layer_count)
     return;
 
   bool wasOn = isOn(layer);

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -8,7 +8,9 @@ Key Layer_::liveCompositeKeymap[ROWS][COLS];
 uint8_t Layer_::activeLayers[ROWS][COLS];
 Key(*Layer_::getKey)(uint8_t layer, byte row, byte col) = Layer.getKeyFromPROGMEM;
 
-// The total number of defined layers in the firmware sketch keymaps[] array
+// The total number of defined layers in the firmware sketch keymaps[]
+// array. If the keymap wasn't defined using CREATE_KEYMAP() in the
+// sketch file, LayerCount gets the default value of zero.
 uint8_t LayerCount __attribute__((weak)) = 0;
 
 static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState) {
@@ -128,7 +130,8 @@ void Layer_::move(uint8_t layer) {
 }
 
 void Layer_::on(uint8_t layer) {
-  // If we're trying to turn on a layer that doesn't exist; abort
+  // If we're trying to turn on a layer that doesn't exist, abort (but
+  // if the keymap wasn't defined using CREATE_KEYMAP(), proceed anyway
   if (LayerCount != 0 && layer >= LayerCount)
     return;
 

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -8,6 +8,9 @@ Key Layer_::liveCompositeKeymap[ROWS][COLS];
 uint8_t Layer_::activeLayers[ROWS][COLS];
 Key(*Layer_::getKey)(uint8_t layer, byte row, byte col) = Layer.getKeyFromPROGMEM;
 
+// The total number of defined layers in the firmware sketch keymaps[] array
+uint8_t LayerCount __attribute__((weak)) = 0;
+
 static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState) {
   if (keymapEntry.keyCode >= LAYER_SHIFT_OFFSET) {
     uint8_t target = keymapEntry.keyCode - LAYER_SHIFT_OFFSET;

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -125,8 +125,8 @@ void Layer_::move(uint8_t layer) {
 }
 
 void Layer_::on(uint8_t layer) {
+  // If we're trying to turn on a layer that doesn't exist; abort
   if (layer >= LayerCount) {
-    // Trying to turn on a layer that doesn't exist; abort
     return;
   }
 

--- a/src/layers.h
+++ b/src/layers.h
@@ -4,6 +4,9 @@
 #include "key_defs.h"
 #include KALEIDOSCOPE_HARDWARE_H
 
+// The total number of defined layers in the firmware sketch keymaps[] array
+extern const uint8_t LayerCount;
+
 class Layer_ {
  public:
   Layer_(void);

--- a/src/layers.h
+++ b/src/layers.h
@@ -4,8 +4,13 @@
 #include "key_defs.h"
 #include KALEIDOSCOPE_HARDWARE_H
 
+#define CREATE_KEYMAP(layers...)				\
+  const Key keymaps[][ROWS][COLS] PROGMEM = { layers };		\
+  const uint8_t LayerCount = sizeof(keymaps) / sizeof(*keymaps);
+
 // The total number of defined layers in the firmware sketch keymaps[] array
 extern const uint8_t LayerCount;
+
 
 class Layer_ {
  public:

--- a/src/layers.h
+++ b/src/layers.h
@@ -4,6 +4,9 @@
 #include "key_defs.h"
 #include KALEIDOSCOPE_HARDWARE_H
 
+// Macro for defining the keymap. This should be used in the sketch
+// file (*.ino) to define the keymap[] array that holds the user's
+// layers. It also computes the number of layers in that keymap.
 #define CREATE_KEYMAP(layers...)				\
   const Key keymaps[][ROWS][COLS] PROGMEM = { layers };		\
   uint8_t LayerCount = sizeof(keymaps) / sizeof(*keymaps);

--- a/src/layers.h
+++ b/src/layers.h
@@ -7,9 +7,9 @@
 // Macro for defining the keymap. This should be used in the sketch
 // file (*.ino) to define the keymap[] array that holds the user's
 // layers. It also computes the number of layers in that keymap.
-#define CREATE_KEYMAP(layers...)				\
+#define KEYMAPS(layers...)				\
   const Key keymaps[][ROWS][COLS] PROGMEM = { layers };		\
-  uint8_t LayerCount = sizeof(keymaps) / sizeof(*keymaps);
+  uint8_t layer_count = sizeof(keymaps) / sizeof(*keymaps);
 
 
 class Layer_ {

--- a/src/layers.h
+++ b/src/layers.h
@@ -6,10 +6,7 @@
 
 #define CREATE_KEYMAP(layers...)				\
   const Key keymaps[][ROWS][COLS] PROGMEM = { layers };		\
-  const uint8_t LayerCount = sizeof(keymaps) / sizeof(*keymaps);
-
-// The total number of defined layers in the firmware sketch keymaps[] array
-extern const uint8_t LayerCount;
+  uint8_t LayerCount = sizeof(keymaps) / sizeof(*keymaps);
 
 
 class Layer_ {

--- a/src/sketch-trailer.h
+++ b/src/sketch-trailer.h
@@ -1,6 +1,0 @@
-#pragma once
-
-// Calculate the number of layers defined in the "keymaps[]"
-// array. This needs to be included in the sketch after "keymaps" is
-// defined
-const uint8_t LayerCount PROGMEM = sizeof(keymaps) / sizeof(*keymaps);

--- a/src/sketch-trailer.h
+++ b/src/sketch-trailer.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// Calculate the number of layers defined in the "keymaps[]"
+// array. This needs to be included in the sketch after "keymaps" is
+// defined
+const uint8_t LayerCount PROGMEM = sizeof(keymaps) / sizeof(*keymaps);


### PR DESCRIPTION
If [pull request #35 for Model01-Firmware](https://github.com/keyboardio/Model01-Firmware/pull/35) is adopted, this change can prevent turning on a layer higher than the top layer defined in `keymaps[]`, thus preventing reading past the end of that array when a key is defined with `Key_KeymapNext_Momentary` on the top layer (or is visible through transparent keys from the top layer). This would address #243, I believe.

If this technique is used to fix that problem, the variable name in Model01-Firmware must match what's used here. See also [this discussion from the forum](https://community.keyboard.io/t/how-to-get-the-number-of-defined-layers/647).