### PR TITLE
Only call updateLiveCompositeKeymap() on key press; not release

### DIFF
--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -60,7 +60,7 @@ void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
 
     /* If a key had an on or off event, we update the live composite keymap. See
      * layers.h for an explanation about the different caches we have. */
-    if (keyToggledOn(keyState) || keyToggledOff(keyState))
+    if (keyToggledOn(keyState))
       Layer.updateLiveCompositeKeymap(row, col);
 
     /* If the key we are dealing with is masked, ignore it until it is released.

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -58,7 +58,7 @@ void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
    */
   if (row < ROWS && col < COLS) {
 
-    /* If a key had an on or off event, we update the live composite keymap. See
+    /* If a key had an on event, we update the live composite keymap. See
      * layers.h for an explanation about the different caches we have. */
     if (keyToggledOn(keyState))
       Layer.updateLiveCompositeKeymap(row, col);

--- a/src/layers.h
+++ b/src/layers.h
@@ -22,7 +22,7 @@ class Layer_ {
    *
    * At the same time, we want other keys to not be affected by the
    * now-turned-off layer. So we update the keycode in the cache on-demand, when
-   * the key is pressed or released. (see the top of `handleKeyswitchEvent`).
+   * the key is pressed. (see the top of `handleKeyswitchEvent`).
    *
    * On the other hand, we also have plugins that scan the whole keymap, and do
    * things based on that information, such as highlighting keys that changed


### PR DESCRIPTION
If we call updateLiveCompositeKeymap() on key release the keymap gets
updated before the release event occurs, and any ShiftToLayer(N) key
with a different definition on layer N won't work properly. Before its
release event is processed, it gets updated to the new value, and
layer N doesn't get turned off. If we only update the live keymap on
key press events, we don't have this problem.

Fixes #246 