### PR TITLE
Fix ConsumerControl repeating

### DIFF
--- a/src/kaleidoscope/hid.cpp
+++ b/src/kaleidoscope/hid.cpp
@@ -63,6 +63,7 @@ void releaseRawKey(Key mappedKey) {
 
 void releaseAllKeys() {
   Keyboard.releaseAll();
+  ConsumerControl.releaseAll();
 }
 
 void releaseKey(Key mappedKey) {
@@ -99,6 +100,7 @@ uint8_t getKeyboardLEDs() {
 
 void sendKeyboardReport() {
   Keyboard.sendReport();
+  ConsumerControl.sendReport();
 }
 
 void initializeConsumerControl() {

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -9,11 +9,8 @@ static bool handleSyntheticKeyswitchEvent(Key mappedKey, uint8_t keyState) {
     return false;
 
   if (mappedKey.flags & IS_CONSUMER) {
-    if (keyIsPressed(keyState)) {
-    } else if (keyWasPressed(keyState)) {
+    if (keyIsPressed(keyState))
       kaleidoscope::hid::pressConsumerControl(mappedKey);
-      kaleidoscope::hid::releaseConsumerControl(mappedKey);
-    }
   } else if (mappedKey.flags & IS_SYSCTL) {
     if (keyIsPressed(keyState)) {
     } else if (keyWasPressed(keyState)) {


### PR DESCRIPTION
Instead of sending a press & release for the consumer key when the physical key is released, send a press each cycle it is held, a report along with the keyboard report, and clear the consumer report each cycle too.

This will prevent these keys getting stuck, or sending multiple presses in the same report.

Fixes #176.

Depends on keyboardio/KeyboardioHID#13.