### PR TITLE
hid: Wrap Mouse.releaseAll() and Mouse.sendReport()

### DIFF
--- a/src/kaleidoscope/hid.cpp
+++ b/src/kaleidoscope/hid.cpp
@@ -151,6 +151,14 @@ void releaseMouseButtons(uint8_t buttons) {
   Mouse.release(buttons);
 }
 
+void releaseAllMouseButtons(void) {
+  Mouse.releaseAll();
+}
+
+void sendMouseReport(void) {
+  Mouse.sendReport();
+}
+
 /** SingleAbsolute mouse (grapahics tablet) events */
 
 void initializeAbsoluteMouse() {

--- a/src/kaleidoscope/hid.h
+++ b/src/kaleidoscope/hid.h
@@ -38,6 +38,8 @@ void moveMouse(signed char x, signed char y, signed char wheel);
 void clickMouseButtons(uint8_t buttons);
 void pressMouseButtons(uint8_t buttons);
 void releaseMouseButtons(uint8_t buttons);
+void releaseAllMouseButtons(void);
+void sendMouseReport(void);
 
 void initializeAbsoluteMouse();
 


### PR DESCRIPTION
Built on top of keyboardio/KeyboardioHID#14, required for keyboardio/Kaleidoscope-MouseKeys#10.
