### PR TITLE
Fixed reference to "CREATE_KEYMAP" (should have been "KEYMAPS")

### DIFF
--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -132,7 +132,7 @@ void Layer_::move(uint8_t layer) {
 // Activate a given layer
 void Layer_::on(uint8_t layer) {
   // If we're trying to turn on a layer that doesn't exist, abort (but
-  // if the keymap wasn't defined using CREATE_KEYMAP(), proceed anyway
+  // if the keymap wasn't defined using the KEYMAPS() macro, proceed anyway
   if (layer_count != 0 && layer >= layer_count)
     return;
 


### PR DESCRIPTION
The macro for defining the keymap (and also storing its size (in layers)) isn't named `CREATE_KEYMAP()`; it's `KEYMAPS()`.