### PR TITLE
Make updateHighestLayer() use layer_count if it's set

### DIFF
--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -9,9 +9,9 @@ uint8_t Layer_::activeLayers[ROWS][COLS];
 Key(*Layer_::getKey)(uint8_t layer, byte row, byte col) = Layer.getKeyFromPROGMEM;
 
 // The total number of defined layers in the firmware sketch keymaps[]
-// array. If the keymap wasn't defined using CREATE_KEYMAP() in the
-// sketch file, layer_count gets the default value of zero.
-uint8_t layer_count __attribute__((weak)) = 0;
+// array. If the keymap wasn't defined using KEYMAPS(), set it to the
+// highest possible number of layers.
+uint8_t layer_count __attribute__((weak)) = MAX_LAYERS;
 
 static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState) {
   if (keymapEntry.keyCode >= LAYER_SHIFT_OFFSET) {
@@ -115,12 +115,15 @@ Layer_::updateActiveLayers(void) {
 }
 
 void Layer_::updateHighestLayer(void) {
-  for (int8_t i = 31; i >= 0; i--) {
+  // If layer_count is set, start there, otherwise search from the
+  // highest possible layer for the top active layer
+  for (int8_t i = (layer_count - 1); i > 0; i++) {
     if (bitRead(LayerState, i)) {
       highestLayer = i;
       return;
     }
   }
+  // return 0 if no higher active layers were found
   highestLayer = 0;
 }
 
@@ -133,7 +136,7 @@ void Layer_::move(uint8_t layer) {
 void Layer_::on(uint8_t layer) {
   // If we're trying to turn on a layer that doesn't exist, abort (but
   // if the keymap wasn't defined using the KEYMAPS() macro, proceed anyway
-  if (layer_count != 0 && layer >= layer_count)
+  if (layer >= layer_count)
     return;
 
   bool wasOn = isOn(layer);

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -117,14 +117,15 @@ Layer_::updateActiveLayers(void) {
 void Layer_::updateHighestLayer(void) {
   // If layer_count is set, start there, otherwise search from the
   // highest possible layer for the top active layer
-  for (int8_t i = (layer_count - 1); i > 0; i++) {
+  for (int8_t i = (layer_count - 1); i > defaultLayer; i++) {
     if (bitRead(LayerState, i)) {
       highestLayer = i;
       return;
     }
   }
-  // return 0 if no higher active layers were found
-  highestLayer = 0;
+  // It's not possible to turn off the default layer (see
+  // updateActiveLayers()), so if no other layers are active:
+  highestLayer = defaultLayer;
 }
 
 void Layer_::move(uint8_t layer) {

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -122,7 +122,7 @@ Layer_::updateActiveLayers(void) {
 void Layer_::updateHighestLayer(void) {
   // If layer_count is set, start there, otherwise search from the
   // highest possible layer for the top active layer
-  for (int8_t i = (layer_count - 1); i > defaultLayer; i++) {
+  for (int8_t i = (layer_count - 1); i > defaultLayer; i--) {
     if (bitRead(LayerState, i)) {
       highestLayer = i;
       return;

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -3,6 +3,11 @@
 static uint8_t DefaultLayer;
 static uint32_t LayerState;
 
+// The maximum number of layers allowed. `LayerState`, which stores
+// the on/off status of the layers in a bitfield has only 32 bits, and
+// that should be enough for almost any layout.
+#define MAX_LAYERS sizeof(LayerState) * 8;
+
 uint8_t Layer_::highestLayer;
 Key Layer_::liveCompositeKeymap[ROWS][COLS];
 uint8_t Layer_::activeLayers[ROWS][COLS];

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -122,7 +122,7 @@ Layer_::updateActiveLayers(void) {
 void Layer_::updateHighestLayer(void) {
   // If layer_count is set, start there, otherwise search from the
   // highest possible layer for the top active layer
-  for (int8_t i = (layer_count - 1); i > defaultLayer; i--) {
+  for (int8_t i = (layer_count - 1); i > DefaultLayer; i--) {
     if (bitRead(LayerState, i)) {
       highestLayer = i;
       return;
@@ -130,7 +130,7 @@ void Layer_::updateHighestLayer(void) {
   }
   // It's not possible to turn off the default layer (see
   // updateActiveLayers()), so if no other layers are active:
-  highestLayer = defaultLayer;
+  highestLayer = DefaultLayer;
 }
 
 void Layer_::move(uint8_t layer) {

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -121,8 +121,8 @@ Layer_::updateActiveLayers(void) {
 
 void Layer_::updateHighestLayer(void) {
   // If layer_count is set, start there, otherwise search from the
-  // highest possible layer for the top active layer
-  for (int8_t i = (layer_count - 1); i > DefaultLayer; i--) {
+  // highest possible layer (MAX_LAYERS) for the top active layer
+  for (byte i = (layer_count - 1); i > DefaultLayer; i--) {
     if (bitRead(LayerState, i)) {
       highestLayer = i;
       return;

--- a/src/layers.h
+++ b/src/layers.h
@@ -11,11 +11,6 @@
   const Key keymaps[][ROWS][COLS] PROGMEM = { layers };		\
   uint8_t layer_count = sizeof(keymaps) / sizeof(*keymaps);
 
-// The maximum number of layers allowed. `LayerState`, which stores
-// the on/off status of the layers in a bitfield has only 32 bits, and
-// that should be enough for almost any layout.
-#define MAX_LAYERS 32
-
 class Layer_ {
  public:
   Layer_(void);

--- a/src/layers.h
+++ b/src/layers.h
@@ -11,6 +11,10 @@
   const Key keymaps[][ROWS][COLS] PROGMEM = { layers };		\
   uint8_t layer_count = sizeof(keymaps) / sizeof(*keymaps);
 
+// The maximum number of layers allowed. `LayerState`, which stores
+// the on/off status of the layers in a bitfield has only 32 bits, and
+// that should be enough for almost any layout.
+#define MAX_LAYERS 32
 
 class Layer_ {
  public:

--- a/src/layers.h
+++ b/src/layers.h
@@ -11,6 +11,7 @@
   const Key keymaps[][ROWS][COLS] PROGMEM = { layers };		\
   uint8_t layer_count = sizeof(keymaps) / sizeof(*keymaps);
 
+
 class Layer_ {
  public:
   Layer_(void);


### PR DESCRIPTION
Now that `layer_count` is (potentially) available, we can start looking for active layers at the top _defined_ layer instead of the top _possible_ layer. This ought to be more efficient, especially for sketches that don't have lots of layers defined.