### PR TITLE
A method for finding the active layer for a given key(switch)

### DIFF
--- a/src/layers.h
+++ b/src/layers.h
@@ -52,6 +52,9 @@ class Layer_ {
     uint8_t layer = activeLayers[row][col];
     return (*getKey)(layer, row, col);
   }
+  static uint8_t lookupActiveLayer(byte row, byte col) {
+    return activeLayers[row][col];
+  }
   static void on(uint8_t layer);
   static void off(uint8_t layer);
   static void move(uint8_t layer);


### PR DESCRIPTION
I'm working on a plugin that stores an array of objects associated with coordinates in the keymap: row, column, and layer. In order for it to look up a key, it needs to search this table for a match on all three coordinates. Row & column are easily available in the event handler hook function, but layer is not. I can get the `Key` object that the key is mapped to on the active layer, but not the layer index itself, unless I add another function, which I called `lookupActiveLayer()`, similar to `lookupOnActiveLayer()`.

I don't think it makes sense to make this information available by making the `activeLayers[]` array itself accessible – that seems like opening a whole can of worms that there's no call for, but similar [row, col, layer] indexing could be useful to other plugin authors.
