### PR TITLE
Add `ENABLE_BOOT_KEYBOARD()`

### DIFF
--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -138,6 +138,11 @@ extern Kaleidoscope_ Kaleidoscope;
                                            "layer.off\n"            \
                                            "layer.getState")
 
+#define ENABLE_BOOT_KEYBOARD() {                      \
+  Keyboard.bootKeyboard = &BootKeyboard;              \
+  BootKeyboard.default_protocol = HID_BOOT_PROTOCOL;  \
+}
+
 /* -- DEPRECATED aliases; remove them when there are no more users. -- */
 
 void event_handler_hook_use(Kaleidoscope_::eventHandlerHook hook)


### PR DESCRIPTION
To support the boot report protocol, we need to enable the boot keyboard. We don't want to do this by default, because it's significant amount of code, so it ships disabled. To enable it, we need to do a small dance, and the newly introduced `ENABLE_BOOT_KEYBOARD` macro does just that. It also sets the default protocol to boot.

Depends on keyboardio/KeyboardioHID#20.