### PR TITLE
Layer: Rename a few functions, to use more understandable names

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,6 +17,7 @@ If any of this does not make sense to you, or you have trouble updating your .in
     - [TypingBreaks](#typingbreaks)
   + [Deprecated APIs and their replacements](#deprecated-apis-and-their-replacements)
     - [Removal of Layer.defaultLayer](#removal-of-layerdefaultlayer)
+    - [More clarity in Layer method names](#more-clarity-in-layer-method-names)
     - [Finer OneShot stickability control](#finer-oneshot-stickability-control)
     - [Source code and namespace rearrangement](#source-code-and-namespace-rearrangement)
 * [Removed APIs](#removed-apis)
@@ -440,6 +441,16 @@ Storing the settable settings in EEPROM makes it depend on `Kaleidoscope-EEPROM-
 The `Layer.defaultLayer()` method has been deprecated, because it wasn't widely used, nor tested well, and needlessly complicated the layering logic. If one wants to set a default layer, which the keyboard switches to when booting up, `EEPROMSettings.default_layer()` may be of use.
 
 `Layer.defaultLayer` is slated for removal by **2019-02-14**.
+
+### More clarity in Layer method names
+
+A number of methods on the `Layer` object have been renamed, to make their intent clearer:
+
+- `Layer.on()` and `Layer.off()` became `Layer.activate()` and `Layer.decativate()`, repsectively.
+- `Layer.next()` and `Layer.previous()` became `Layer.activateNext()` and `Layer.deactivateTop()`.
+- `Layer.isOn` became `Layer.isActive()`.
+
+The goal was to have a method name that is a verb, because these are actions we do. The old names are still present, but emit a deprecation warning, and will be removed by **2019-02-14**.
 
 ### Finer OneShot stickability control
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -16,6 +16,7 @@ If any of this does not make sense to you, or you have trouble updating your .in
     - [MagicCombo](#magiccombo)
     - [TypingBreaks](#typingbreaks)
   + [Deprecated APIs and their replacements](#deprecated-apis-and-their-replacements)
+    - [Removal of Layer.defaultLayer](#removal-of-layerdefaultlayer)
     - [Finer OneShot stickability control](#finer-oneshot-stickability-control)
     - [Source code and namespace rearrangement](#source-code-and-namespace-rearrangement)
 * [Removed APIs](#removed-apis)
@@ -433,6 +434,12 @@ Both of them are unconditionally enabled now, because they add so much to the pl
 Storing the settable settings in EEPROM makes it depend on `Kaleidoscope-EEPROM-Settings`, which should be initialized before this plugin is.
 
 ## Deprecated APIs and their replacements
+
+### Removal of Layer.defaultLayer
+
+The `Layer.defaultLayer()` method has been deprecated, because it wasn't widely used, nor tested well, and needlessly complicated the layering logic. If one wants to set a default layer, which the keyboard switches to when booting up, `EEPROMSettings.default_layer()` may be of use.
+
+`Layer.defaultLayer` is slated for removal by **2019-02-14**.
 
 ### Finer OneShot stickability control
 

--- a/src/kaleidoscope/layers.cpp
+++ b/src/kaleidoscope/layers.cpp
@@ -27,7 +27,6 @@
 uint8_t layer_count __attribute__((weak)) = MAX_LAYERS;
 
 namespace kaleidoscope {
-uint8_t Layer_::DefaultLayer;
 uint32_t Layer_::LayerState;
 uint8_t Layer_::highestLayer;
 Key Layer_::liveCompositeKeymap[ROWS][COLS];
@@ -107,12 +106,12 @@ void Layer_::updateLiveCompositeKeymap(byte row, byte col) {
 }
 
 void Layer_::updateActiveLayers(void) {
-  memset(activeLayers, DefaultLayer, ROWS * COLS);
+  memset(activeLayers, 0, ROWS * COLS);
   for (byte row = 0; row < ROWS; row++) {
     for (byte col = 0; col < COLS; col++) {
       int8_t layer = highestLayer;
 
-      while (layer > DefaultLayer) {
+      while (layer > 0) {
         if (Layer.isOn(layer)) {
           Key mappedKey = (*getKey)(layer, row, col);
 
@@ -130,7 +129,7 @@ void Layer_::updateActiveLayers(void) {
 void Layer_::updateHighestLayer(void) {
   // If layer_count is set, start there, otherwise search from the
   // highest possible layer (MAX_LAYERS) for the top active layer
-  for (byte i = (layer_count - 1); i > DefaultLayer; i--) {
+  for (byte i = (layer_count - 1); i > 0; i--) {
     if (bitRead(LayerState, i)) {
       highestLayer = i;
       return;
@@ -138,7 +137,7 @@ void Layer_::updateHighestLayer(void) {
   }
   // It's not possible to turn off the default layer (see
   // updateActiveLayers()), so if no other layers are active:
-  highestLayer = DefaultLayer;
+  highestLayer = 0;
 }
 
 void Layer_::move(uint8_t layer) {
@@ -203,15 +202,6 @@ void Layer_::next(void) {
 
 void Layer_::previous(void) {
   off(highestLayer);
-}
-
-void Layer_::defaultLayer(uint8_t layer) {
-  move(layer);
-  DefaultLayer = layer;
-}
-
-uint8_t Layer_::defaultLayer(void) {
-  return DefaultLayer;
 }
 
 uint32_t Layer_::getLayerState(void) {

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -83,13 +83,15 @@ class Layer_ {
   static uint8_t top(void) {
     return highestLayer;
   }
+
+  static void defaultLayer(uint8_t layer) DEPRECATED(LAYER_DEFAULT) {}
+  static uint8_t defaultLayer(void) DEPRECATED(LAYER_DEFAULT) {
+    return 0;
+  }
   static void next(void);
   static void previous(void);
 
   static boolean isOn(uint8_t layer);
-
-  static void defaultLayer(uint8_t layer);
-  static uint8_t defaultLayer(void);
 
   static uint32_t getLayerState(void);
 

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -67,33 +67,50 @@ class Layer_ {
    * `lookupOnActiveLayer`.
    */
   static Key lookup(byte row, byte col) {
-    return liveCompositeKeymap[row][col];
+    return live_composite_keymap_[row][col];
   }
   static Key lookupOnActiveLayer(byte row, byte col) {
-    uint8_t layer = activeLayers[row][col];
+    uint8_t layer = active_layers_[row][col];
     return (*getKey)(layer, row, col);
   }
   static uint8_t lookupActiveLayer(byte row, byte col) {
-    return activeLayers[row][col];
+    return active_layers_[row][col];
   }
-  static void on(uint8_t layer);
-  static void off(uint8_t layer);
+
+  static void activate(uint8_t layer);
+  static void deactivate(uint8_t layer);
+  static void on(uint8_t layer) DEPRECATED(LAYER_ON) {
+    activate(layer);
+  }
+  static void off(uint8_t layer) DEPRECATED(LAYER_OFF) {
+    deactivate(layer);
+  }
+  static void activateNext();
+  static void deactivateTop();
+  static void next(void) DEPRECATED(LAYER_NEXT) {
+    activateNext();
+  }
+  static void previous(void) DEPRECATED(LAYER_PREVIOUS) {
+    deactivateTop();
+  }
   static void move(uint8_t layer);
 
   static uint8_t top(void) {
-    return highestLayer;
+    return top_active_layer_;
   }
+  static boolean isActive(uint8_t layer);
+  static boolean isOn(uint8_t layer) DEPRECATED(LAYER_ISON) {
+    return isActive(layer);
+  };
 
   static void defaultLayer(uint8_t layer) DEPRECATED(LAYER_DEFAULT) {}
   static uint8_t defaultLayer(void) DEPRECATED(LAYER_DEFAULT) {
     return 0;
   }
-  static void next(void);
-  static void previous(void);
 
-  static boolean isOn(uint8_t layer);
-
-  static uint32_t getLayerState(void);
+  static uint32_t getLayerState(void) {
+    return layer_state_;
+  }
 
   static Key eventHandler(Key mappedKey, byte row, byte col, uint8_t keyState);
 
@@ -105,15 +122,13 @@ class Layer_ {
   static void updateActiveLayers(void);
 
  private:
-  static void updateHighestLayer(void);
-
-  static uint8_t DefaultLayer;
-  static uint32_t LayerState;
-  static uint8_t highestLayer;
-  static Key liveCompositeKeymap[ROWS][COLS];
-  static uint8_t activeLayers[ROWS][COLS];
+  static uint32_t layer_state_;
+  static uint8_t top_active_layer_;
+  static Key live_composite_keymap_[ROWS][COLS];
+  static uint8_t active_layers_[ROWS][COLS];
 
   static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState);
+  static void updateTopActiveLayer(void);
 };
 }
 

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -78,7 +78,7 @@ EventHandlerResult ActiveModColorEffect::beforeReportingState() {
       if (layer >= LAYER_SHIFT_OFFSET)
         layer -= LAYER_SHIFT_OFFSET;
 
-      if (Layer.isOn(layer))
+      if (Layer.isActive(layer))
         ::LEDControl.setCrgbAt(r, c, highlight_color);
       else
         ::LEDControl.refreshAt(r, c);

--- a/src/kaleidoscope/plugin/NumPad.cpp
+++ b/src/kaleidoscope/plugin/NumPad.cpp
@@ -86,7 +86,7 @@ void NumPad::setKeyboardLEDColors(void) {
 }
 
 EventHandlerResult NumPad::afterEachCycle() {
-  if (!Layer.isOn(numPadLayer)) {
+  if (!Layer.isActive(numPadLayer)) {
     cleanupNumlockState();
   } else {
     if (numlockUnsynced)  {

--- a/src/kaleidoscope_internal/deprecations.h
+++ b/src/kaleidoscope_internal/deprecations.h
@@ -31,3 +31,18 @@
   "\n"                                                                      \
   "If you want to set the default layer for the keyboard, consider using\n" \
   "EEPROMSettings.default_layer() instead."
+
+#define _DEPRECATED_MESSAGE_LAYER_ON                                        \
+  "Please use `Layer.activate()` instead of `Layer.on()`."
+
+#define _DEPRECATED_MESSAGE_LAYER_OFF                                       \
+  "Please use `Layer.deactivate()` instead of `Layer.off()`."
+
+#define _DEPRECATED_MESSAGE_LAYER_NEXT                                      \
+  "Please use `Layer.activateNext()` instead of `Layer.next()`."
+
+#define _DEPRECATED_MESSAGE_LAYER_PREVIOUS                                  \
+  "Please use `Layer.deactivateTop()` instead of `Layer.previous()`."
+
+#define _DEPRECATED_MESSAGE_LAYER_ISON                                      \
+  "Please use `Layer.isActive()` instead of `Layer.isOn().`"

--- a/src/kaleidoscope_internal/deprecations.h
+++ b/src/kaleidoscope_internal/deprecations.h
@@ -26,3 +26,8 @@
   "------------------------------------------------------------------------\n" \
 
 /* Messages */
+#define _DEPRECATED_MESSAGE_LAYER_DEFAULT                                   \
+  "Layer.defaultLayer() is deprecated, and a no-op.\n"                      \
+  "\n"                                                                      \
+  "If you want to set the default layer for the keyboard, consider using\n" \
+  "EEPROMSettings.default_layer() instead."


### PR DESCRIPTION
Migrate layers to a naming convention based on `activate`/`deactivate`, while keeping the old methods around, as deprecated aliases.

Fixes #249.
