### PR TITLE
Change the INJECTED test to a mappedKey test

### DIFF
--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -75,7 +75,7 @@ void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
       }
     }
 
-    if (mappedKey == Key_NoKey) {
+    if (mappedKey.raw == Key_NoKey.raw) {
       mappedKey = Layer.lookup(row, col);
     }
 

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -75,7 +75,7 @@ void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
       }
     }
 
-    if (!(keyState & INJECTED)) {
+    if (mappedKey == Key_NoKey) {
       mappedKey = Layer.lookup(row, col);
     }
 


### PR DESCRIPTION
I'm finding that there's a problem with the `INJECTED` key state test in `handleKeyswitchEvent()`. In [Kaleidoscope-Qukeys](https://github.com/gedankenlab/Kaleidoscope-Qukeys), I need to be able to inject events and have other plugins handle them — even plugins that ignore their own injected events in order to prevent infinite loops. To do this, I want to use a static variable to decide which events my plugin will ignore, and call `handleKeyswitchEvent()` with a `mappedKey`, but without the `INJECTED` flag. The trouble is that the `mappedKey` parameter gets clobbered by a lookup unless `INJECTED` is set, but I think the same thing could be accomplished by simply checking to see if it's not the default `Key_NoKey` instead.

This system (plugins using their own state variables to prevent infinite loops, and skip handling events they inject themselves) has other advantages, as well, allowing plugins to work together better in general. However, I don't know all the plugins well enough to be sure that this change won't break other plugins right now. I suspect not, because if an event handler returns `Key_NoKey`, the next one won't be called, and plugins usually just return `mappedKey` to continue.

@algernon: can you think of anything this will break?

The previous test would clobber any `mappedKey` parameter that the caller supplied unless the `keyState` had the `INJECTED` flag. This change uses a different test, and only does the lookup if the `mappedKey` parameter was unset (i.e. `Key_NoKey`).
