### PR TITLE
kaleidoscope-builder cleanup

### DIFF
--- a/bin/find-device-port-linux-udev
+++ b/bin/find-device-port-linux-udev
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl 
+
+use warnings;
+use strict;
+my $vid = shift;
+my $pid = shift;
+my $prefix = '/dev/serial/by-id/';
+my @paths= `ls $prefix`;
+my %devices;
+
+for my $path (@paths) {
+	chomp($path);
+	next unless -l $prefix. $path;
+	my @data = `udevadm info -q property --name=${prefix}${path}`;
+	for my $line (@data) {
+	chomp ($line);
+	my ($key,$val) = split(/=/,$line,2);
+		$devices{$path}{$key} = $val;
+	}
+	if (($devices{$path}{'ID_VENDOR_ID'} == $vid) && 
+	   ($devices{$path}{'ID_MODEL_ID'} == $pid) ) {
+
+	   if ($devices{$path}{'ID_MM_CANDIDATE'}) {
+		warn "Yikes. ModemManager wants to pwn your keyboard";
+ 		}		   
+
+	print $devices{$path}{DEVNAME};
+	exit(0);
+   }
+
+
+}
+

--- a/bin/find-device-port-linux-udev
+++ b/bin/find-device-port-linux-udev
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl 
+#!/usr/bin/env perl
 
 use warnings;
 use strict;
@@ -17,17 +17,14 @@ for my $path (@paths) {
 	my ($key,$val) = split(/=/,$line,2);
 		$devices{$path}{$key} = $val;
 	}
-	if (($devices{$path}{'ID_VENDOR_ID'} == $vid) && 
+	if (($devices{$path}{'ID_VENDOR_ID'} == $vid) &&
 	   ($devices{$path}{'ID_MODEL_ID'} == $pid) ) {
 
 	   if ($devices{$path}{'ID_MM_CANDIDATE'}) {
-		warn "Yikes. ModemManager wants to pwn your keyboard";
- 		}		   
+         warn "Yikes. ModemManager wants to pwn your keyboard";
+     }
 
-	print $devices{$path}{DEVNAME};
-	exit(0);
+     print $devices{$path}{DEVNAME};
+     exit(0);
    }
-
-
 }
-

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -2,6 +2,31 @@
 
 set -e
 
+
+######
+###### Build and output configuration
+######
+
+build_version () {
+	GIT_VERSION="$(cd $(find_sketch); git describe --abbrev=4 --dirty --always)"
+	LIB_VERSION="$(cd $(find_sketch); (grep version= ../../library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
+	
+	BUILD_PATH="${BUILD_PATH:-$(mktemp -d 2>/dev/null || mktemp -d -t 'build')}"
+	OUTPUT_DIR="${OUTPUT_DIR:-output/${LIBRARY}}"
+	OUTPUT_PATH="${OUTPUT_PATH:-${SOURCEDIR}/${OUTPUT_DIR}}"
+}
+
+build_filenames () {
+	OUTPUT_FILE_PREFIX="${SKETCH}-${LIB_VERSION}"
+	HEX_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.hex"
+	HEX_FILE_WITH_BOOTLOADER_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}-with-bootloader.hex"
+	ELF_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.elf"
+}
+
+
+
+
+
 firmware_size () {
     if [ "${BOARD}" = "virtual" ]; then
       echo "[Size not computed for virtual build]"

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -237,7 +237,13 @@ clean () {
     rm -rf "${OUTPUT_PATH}"
 }
 
-reset_device () {
+reset_device() {
+	find_device_port
+    	check_device_port
+	reset_device_cmd
+}
+
+check_device_port () {
     if [ -z $DEVICE_PORT ]; then
         echo "Couldn't autodetect the keyboard's serial port."
         echo "If you see this message and your keyboard is connected to your computer,"
@@ -246,9 +252,8 @@ reset_device () {
         echo "Please report this issue at https://github.com/keyboardio/Kaleidoscope";
         exit 0;
     fi
-
-    ${RESET_DEVICE}
 }
+
 
 usage () {
     cat <<EOF

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -2,7 +2,6 @@
 
 set -e
 
-
 ######
 ###### Build and output configuration
 ######
@@ -10,7 +9,7 @@ set -e
 build_version () {
 	GIT_VERSION="$(cd $(find_sketch); git describe --abbrev=4 --dirty --always)"
 	LIB_VERSION="$(cd $(find_sketch); (grep version= ../../library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
-	
+
 	BUILD_PATH="${BUILD_PATH:-$(mktemp -d 2>/dev/null || mktemp -d -t 'build')}"
 	OUTPUT_DIR="${OUTPUT_DIR:-output/${LIBRARY}}"
 	OUTPUT_PATH="${OUTPUT_PATH:-${SOURCEDIR}/${OUTPUT_DIR}}"
@@ -23,17 +22,13 @@ build_filenames () {
 	ELF_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.elf"
 }
 
-
-
-
-
 firmware_size () {
     if [ "${BOARD}" = "virtual" ]; then
       echo "[Size not computed for virtual build]"
       return
     fi
 
-	## This is a terrible hack, please don't hurt me. - algernon
+	  ## This is a terrible hack, please don't hurt me. - algernon
 
     MAX_PROG_SIZE=28672
 
@@ -81,13 +76,11 @@ flash () {
     sleep 3s
     find_bootloader_ports
     flash_over_usb || flash_over_usb
-
 }
 
 flash_over_usb () {
     sleep 1s
     ${AVRDUDE} -q -q -C ${AVRDUDE_CONF} -p${MCU} -cavr109 -D -P ${DEVICE_PORT_BOOTLOADER} -b57600 "-Uflash:w:${HEX_FILE_PATH}:i"
-
 }
 
 flash_from_bootloader() {
@@ -96,14 +89,12 @@ flash_from_bootloader() {
 	flash_over_usb || flash_over_usb
 }
 
-
 program() {
     prepare_to_flash
     flash_with_programmer
 }
 
 flash_with_programmer() {
-
     ${AVRDUDE} -v \
 			-C ${AVRDUDE_CONF} \
 		        -p${MCU} \
@@ -152,7 +143,7 @@ compile () {
 
     ARDUINO_PACKAGES=""
     if [ -d ${ARDUINO_PACKAGE_PATH} ]; then
-	 ARDUINO_PACKAGES="-hardware \"${ARDUINO_PACKAGE_PATH}\""
+	      ARDUINO_PACKAGES="-hardware \"${ARDUINO_PACKAGE_PATH}\""
     fi
 
     ${ARDUINO_BUILDER} \
@@ -238,9 +229,9 @@ clean () {
 }
 
 reset_device() {
-	find_device_port
-    	check_device_port
-	reset_device_cmd
+    find_device_port
+    check_device_port
+    reset_device_cmd
 }
 
 check_device_port () {
@@ -253,7 +244,6 @@ check_device_port () {
         exit 0;
     fi
 }
-
 
 usage () {
     cat <<EOF
@@ -327,7 +317,6 @@ if [ -e "${SOURCEDIR}/kaleidoscope-builder.conf" ]; then
     . "${SOURCEDIR}/kaleidoscope-builder.conf"
 fi
 
-
 . ${ROOT}/etc/kaleidoscope-builder.conf
 
 if [ ! -z "${VERBOSE}" ] && [ "${VERBOSE}" -gt 0 ]; then
@@ -335,7 +324,6 @@ if [ ! -z "${VERBOSE}" ] && [ "${VERBOSE}" -gt 0 ]; then
 else
     ARDUINO_VERBOSE="-quiet"
 fi
-
 
 cmds=""
 

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -325,6 +325,12 @@ fi
 
 . ${ROOT}/etc/kaleidoscope-builder.conf
 
+if [ ! -z "${VERBOSE}" ] && [ "${VERBOSE}" -gt 0 ]; then
+    ARDUINO_VERBOSE="-verbose"
+else
+    ARDUINO_VERBOSE="-quiet"
+fi
+
 
 cmds=""
 

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -36,6 +36,11 @@ DEVICE_PORT="$(ls /dev/ttyACM* 2>/dev/null || echo '')"
 RESET_DEVICE="stty -F ${DEVICE_PORT} 1200 hupcl"
 MD5="md5sum"
 
+find_bootloader_ports() {
+	DEVICE_PORT_BOOTLOADER="$(ls /dev/ttyACM* 2>/dev/null || echo '')"
+}
+
+
 
 if [ "${uname_S}" = "Darwin" ]; then
     DEVICE_PORT="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
@@ -52,18 +57,13 @@ if [ "${uname_S}" = "Darwin" ]; then
 
     MD5="md5"
 
+    find_bootloader_ports() {
+        DEVICE_PORT_BOOTLOADER="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
+        DEVICE_PORT_BOOTLOADER="${DEVICE_PORT_BOOTLOADER:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
+    }
+    
 fi
 
-find_bootloader_ports() {
-
-DEVICE_PORT_BOOTLOADER="$(ls /dev/ttyACM* 2>/dev/null || echo '')"
-if [ "${uname_S}" = "Darwin" ]; then
-    DEVICE_PORT_BOOTLOADER="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
-    DEVICE_PORT_BOOTLOADER="${DEVICE_PORT_BOOTLOADER:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
-fi
-
-
-}
 
 
 ######

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -115,9 +115,3 @@ if [ ! -z "${AVR_GCC_PREFIX}" ]; then
     ARDUINO_AVR_GCC_PREFIX_PARAM="-prefs \"runtime.tools.avr-gcc.path=${AVR_GCC_PREFIX}\""
 fi
 
-if [ ! -z "${VERBOSE}" ] && [ "${VERBOSE}" -gt 0 ]; then
-    ARDUINO_VERBOSE="-verbose"
-else
-    ARDUINO_VERBOSE="-quiet"
-fi
-

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -105,29 +105,6 @@ BOARD_HARDWARE_PATH="${BOARD_HARDWARE_PATH:-${ARDUINO_LOCAL_LIB_PATH}/hardware}"
 BOOTLOADER_PATH="${BOOTLOADER_PATH:-${BOARD_HARDWARE_PATH}/keyboardio/avr/bootloaders/caterina/Caterina.hex}"
 
 
-######
-###### Build and output configuration
-######
-
-build_version () {
-	GIT_VERSION="$(cd $(find_sketch); git describe --abbrev=4 --dirty --always)"
-	LIB_VERSION="$(cd $(find_sketch); (grep version= ../../library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
-	
-	BUILD_PATH="${BUILD_PATH:-$(mktemp -d 2>/dev/null || mktemp -d -t 'build')}"
-	OUTPUT_DIR="${OUTPUT_DIR:-output/${LIBRARY}}"
-	OUTPUT_PATH="${OUTPUT_PATH:-${SOURCEDIR}/${OUTPUT_DIR}}"
-}
-
-build_filenames () {
-	OUTPUT_FILE_PREFIX="${SKETCH}-${LIB_VERSION}"
-	HEX_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.hex"
-	HEX_FILE_WITH_BOOTLOADER_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}-with-bootloader.hex"
-	ELF_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.elf"
-}
-
-
-
-
 
 ARDUINO_TOOLS_PARAM="-tools ${ARDUINO_TOOLS_PATH}"
 if [ -z "${ARDUINO_TOOLS_PATH}" ]; then

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -106,9 +106,8 @@ BOOTLOADER_PATH="${BOOTLOADER_PATH:-${BOARD_HARDWARE_PATH}/keyboardio/avr/bootlo
 
 
 
-ARDUINO_TOOLS_PARAM="-tools ${ARDUINO_TOOLS_PATH}"
-if [ -z "${ARDUINO_TOOLS_PATH}" ]; then
-    ARDUINO_TOOLS_PARAM=""
+if [ ! -z "${ARDUINO_TOOLS_PATH}" ]; then
+    ARDUINO_TOOLS_PARAM="-tools ${ARDUINO_TOOLS_PATH}"
 fi
 
 if [ ! -z "${AVR_GCC_PREFIX}" ]; then

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -1,13 +1,6 @@
 ## NEEDS: LIBRARY, SKETCH, ROOT, SOURCEDIR
 ## Should be included when the current directory is the dir of the Sketch.
 
-case "$0" in
-    */settings.sh)
-        echo "This file must be included, never run directly!" >&2
-        exit 1
-        ;;
-esac
-
 SKETCH="${SKETCH:-${DEFAULT_SKETCH}}"
 LIBRARY="${LIBRARY:-${SKETCH}}"
 

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -4,8 +4,6 @@
 SKETCH="${SKETCH:-${DEFAULT_SKETCH}}"
 LIBRARY="${LIBRARY:-${SKETCH}}"
 
-
-
 ########
 ######## Keyboard hardware definitions
 ########
@@ -18,11 +16,9 @@ else
   FQBN="${FQBN:-keyboardio:avr:${BOARD}}"
 fi
 
-
 ########
 ######## Host OS specific commands
 ########
-
 
 ## Platform-specific overrides
 # Shamelessly stolen from git's Makefile
@@ -48,54 +44,45 @@ find_device_port() {
 	DEVICE_PORT="$(perl ${DEVICE_PORT_PROBER} ${VID} ${SKETCH_PID})"
 }
 
-
 reset_device_cmd() {
 	stty -F ${DEVICE_PORT} 1200 hupcl
-
 }
-
-
-MD5="md5sum"
 
 find_bootloader_ports() {
   find_device_vid_pid
 	DIR=$(dirname "$(readlink -f "$0")")
 	DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
 	DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${VID} ${BOOTLOADER_PID})"
-
 }
 
-
+MD5="md5sum"
 
 if [ "${uname_S}" = "Darwin" ]; then
 
-find_device_port() {
-    DEVICE_PORT="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
-    DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCkbio* 2> /dev/null || echo '')}"
-    DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemHID* 2> /dev/null || echo '')}"
-    DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCHID* 2> /dev/null || echo '')}"
-    DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
-}
+  find_device_port() {
+      DEVICE_PORT="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
+      DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCkbio* 2> /dev/null || echo '')}"
+      DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemHID* 2> /dev/null || echo '')}"
+      DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCHID* 2> /dev/null || echo '')}"
+      DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
+  }
 
-reset_device_cmd() {
-    /bin/stty -f ${DEVICE_PORT} 1200
-}
+  reset_device_cmd() {
+      /bin/stty -f ${DEVICE_PORT} 1200
+  }
 
+  ARDUINO_PATH="${ARDUINO_PATH:-/Applications/Arduino.app/Contents/Java/}"
+  ARDUINO_PACKAGE_PATH="${ARDUINO_PACKAGE_PATH:-${HOME}/Library/Arduino15/packages}"
+  ARDUINO_LOCAL_LIB_PATH="${ARDUINO_LOCAL_LIB_PATH:-${HOME}/Documents/Arduino}"
 
-    ARDUINO_PATH="${ARDUINO_PATH:-/Applications/Arduino.app/Contents/Java/}"
-    ARDUINO_PACKAGE_PATH="${ARDUINO_PACKAGE_PATH:-${HOME}/Library/Arduino15/packages}"
-    ARDUINO_LOCAL_LIB_PATH="${ARDUINO_LOCAL_LIB_PATH:-${HOME}/Documents/Arduino}"
+  MD5="md5"
 
-    MD5="md5"
+  find_bootloader_ports() {
+      DEVICE_PORT_BOOTLOADER="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
+      DEVICE_PORT_BOOTLOADER="${DEVICE_PORT_BOOTLOADER:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
+  }
 
-    find_bootloader_ports() {
-        DEVICE_PORT_BOOTLOADER="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
-        DEVICE_PORT_BOOTLOADER="${DEVICE_PORT_BOOTLOADER:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
-    }
-    
 fi
-
-
 
 ######
 ###### Arduino tools configuration
@@ -119,16 +106,12 @@ AVR_OBJDUMP="${AVR_OBJDUMP:-${ARDUINO_TOOLS_PATH}/avr/bin/avr-objdump}"
 AVRDUDE="${AVRDUDE:-${ARDUINO_TOOLS_PATH}/avr/bin/avrdude}"
 AVRDUDE_CONF="${AVRDUDE_CONF:-${ARDUINO_TOOLS_PATH}/avr/etc/avrdude.conf}"
 
-
 ######
 ###### Source files and dependencies
 ######
 
-
 BOARD_HARDWARE_PATH="${BOARD_HARDWARE_PATH:-${ARDUINO_LOCAL_LIB_PATH}/hardware}"
 BOOTLOADER_PATH="${BOOTLOADER_PATH:-${BOARD_HARDWARE_PATH}/keyboardio/avr/bootloaders/caterina/Caterina.hex}"
-
-
 
 if [ ! -z "${ARDUINO_TOOLS_PATH}" ]; then
     ARDUINO_TOOLS_PARAM="-tools ${ARDUINO_TOOLS_PATH}"
@@ -137,4 +120,3 @@ fi
 if [ ! -z "${AVR_GCC_PREFIX}" ]; then
     ARDUINO_AVR_GCC_PREFIX_PARAM="-prefs \"runtime.tools.avr-gcc.path=${AVR_GCC_PREFIX}\""
 fi
-

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -10,8 +10,10 @@ LIBRARY="${LIBRARY:-${SKETCH}}"
 ######## Keyboard hardware definitions
 ########
 
-
-
+# These should be pulled from Arduino boards.txt
+VID="${VID:-1209}"
+BOOTLOADER_PID="${BOOTLOADER_PID:-2300}"
+SKETCH_PID="${SKEYCH_PID:-2301}"
 BOARD="${BOARD:-model01}"
 MCU="${MCU:-atmega32u4}"
 if [ "${BOARD}" = "virtual" ]; then
@@ -31,24 +33,43 @@ fi
 uname_S=$(uname -s 2>/dev/null || echo not)
 
 
-  
-DEVICE_PORT="$(ls /dev/ttyACM* 2>/dev/null || echo '')"
-RESET_DEVICE="stty -F ${DEVICE_PORT} 1200 hupcl"
+find_device_port() {
+	DIR=$(dirname "$(readlink -f "$0")")
+	DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
+	DEVICE_PORT="$(perl ${DEVICE_PORT_PROBER} ${VID} ${SKETCH_PID})"
+}
+
+
+reset_device_cmd() {
+	stty -F ${DEVICE_PORT} 1200 hupcl
+
+}
+
+
 MD5="md5sum"
 
 find_bootloader_ports() {
-	DEVICE_PORT_BOOTLOADER="$(ls /dev/ttyACM* 2>/dev/null || echo '')"
+	DIR=$(dirname "$(readlink -f "$0")")
+	DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
+	DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${VID} ${BOOTLOADER_PID})"
+
 }
 
 
 
 if [ "${uname_S}" = "Darwin" ]; then
+
+find_device_port() {
     DEVICE_PORT="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
     DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCkbio* 2> /dev/null || echo '')}"
     DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemHID* 2> /dev/null || echo '')}"
     DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCHID* 2> /dev/null || echo '')}"
     DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
-    RESET_DEVICE="/bin/stty -f ${DEVICE_PORT} 1200"
+}
+
+reset_device_cmd() {
+    /bin/stty -f ${DEVICE_PORT} 1200
+}
 
 
     ARDUINO_PATH="${ARDUINO_PATH:-/Applications/Arduino.app/Contents/Java/}"

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -10,10 +10,6 @@ LIBRARY="${LIBRARY:-${SKETCH}}"
 ######## Keyboard hardware definitions
 ########
 
-# These should be pulled from Arduino boards.txt
-VID="${VID:-1209}"
-BOOTLOADER_PID="${BOOTLOADER_PID:-2300}"
-SKETCH_PID="${SKEYCH_PID:-2301}"
 BOARD="${BOARD:-model01}"
 MCU="${MCU:-atmega32u4}"
 if [ "${BOARD}" = "virtual" ]; then
@@ -32,8 +28,21 @@ fi
 # Shamelessly stolen from git's Makefile
 uname_S=$(uname -s 2>/dev/null || echo not)
 
+find_device_vid_pid() {
+  VPIDS=$(${ARDUINO_BUILDER} \
+		          -hardware "${ARDUINO_PATH}/hardware" \
+		          -hardware "${BOARD_HARDWARE_PATH}" \
+		          ${ARDUINO_TOOLS_PARAM} \
+		          -tools "${ARDUINO_PATH}/tools-builder" \
+		          -fqbn "${FQBN}" \
+              -dump-prefs | grep "\.[vp]id=")
+  VID=${VID:-$(echo "${VPIDS}" | grep build.vid= | cut -dx -f2)}
+  SKETCH_PID=${SKETCH_PID:-$(echo "${VPIDS}" | grep build.pid= | cut -dx -f2)}
+  BOOTLOADER_PID=${BOOTLOADER_PID:-$(echo "${VPIDS}" | grep bootloader.pid= | cut -dx -f2)}
+}
 
 find_device_port() {
+  find_device_vid_pid
 	DIR=$(dirname "$(readlink -f "$0")")
 	DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
 	DEVICE_PORT="$(perl ${DEVICE_PORT_PROBER} ${VID} ${SKETCH_PID})"
@@ -49,6 +58,7 @@ reset_device_cmd() {
 MD5="md5sum"
 
 find_bootloader_ports() {
+  find_device_vid_pid
 	DIR=$(dirname "$(readlink -f "$0")")
 	DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
 	DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${VID} ${BOOTLOADER_PID})"


### PR DESCRIPTION
This is mostly @obra's work, I did a little cleaning up and made it grab the VID/PID/BOOTLOADER_PID from boards.txt.

I gave it *some* testing so far, with multiple devices plugged in, and at least under Linux, it is doing the right thing: flashing the first one of the appropriate devices. It is already a big improvement over the status quo. This will need a small update to `boards.txt` for the `BOOTLOADER_PID`, mind you. It does not function correctly otherwise.

There are many ways this can be further improved, like making it able to select a device if there are multiple present with the same VID/PID, but that is for another time.