### PR TITLE
Allow for constructor call based creation of instances of Key_

### DIFF
--- a/src/key_defs.h
+++ b/src/key_defs.h
@@ -25,6 +25,16 @@ typedef union Key_ {
   };
   uint16_t raw;
 
+  Key_() = default;
+
+  constexpr Key_(uint8_t __keyCode, uint8_t __flags)
+    : keyCode(__keyCode), flags(__flags) {
+  }
+
+  constexpr Key_(uint16_t __raw)
+    : raw(__raw) {
+  }
+
   inline bool operator==(uint16_t rhs) {
     return this->raw == rhs;
   }


### PR DESCRIPTION
Currently, the `Key_` union is lacking constructors that enable creation either via a keyCode/flags pair or raw data. In most places in the firmware, `Key_` instances are created via C-style struct initialization using initializer lists. It would be more convenient/complete to allowalso for class-style constructor initialization, e.g.
```cpp
Key_ a(128, 128); // keyCode/flags
Key_ b(12222); // raw
```
This PR adds the necessary constructors and keeps the default constructor to conserve initializer list based construction.