### PR TITLE
Added name demangling in disassemblies

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -220,13 +220,17 @@ size_map () {
     "${AVR_NM}" --size-sort -C -r -l "${ELF_FILE_PATH}"
 }
 
-decompile () {
+disassembly () {
 
     if [ ! -e "${HEX_FILE_PATH}" ]; then
         compile
     fi
 
-    "${AVR_OBJDUMP}" -d "${ELF_FILE_PATH}"
+    "${AVR_OBJDUMP}" -C -d "${ELF_FILE_PATH}"
+}
+
+decompile () {
+    disassembly
 }
 
 clean () {


### PR DESCRIPTION
Up to now, a `make decompile` caused mangled symbols to be displayed in the disassembly.
```
00000612 <_ZN17PluginHookAdapterI8HookLoopE4initEv>:
     612:       0e 94 1c 11     call    0x2238  ; 0x2238 <_ZN13MouseWrapper_5beginEv>
     616:       84 e2           ldi     r24, 0x24       ; 36
     618:       96 e0           ldi     r25, 0x06       ; 6
     61a:       0e 94 02 03     call    0x604   ; 0x604 <_ZN18KaleidoscopePlugin4initEv>
     61e:       84 e2           ldi     r24, 0x24       ; 36
     620:       96 e0           ldi     r25, 0x06       ; 6
     622:       0c 94 02 03     jmp     0x604   ; 0x604 <_ZN18KaleidoscopePlugin4initEv>
```

This PR adds the flag `-C` to the objdump command to allow for demangled C++ symbol names, e.g.
```
00000612 <PluginHookAdapter<HookLoop>::init()>:
     612:       0e 94 1c 11     call    0x2238  ; 0x2238 <MouseWrapper_::begin()>
     616:       84 e2           ldi     r24, 0x24       ; 36
     618:       96 e0           ldi     r25, 0x06       ; 6
     61a:       0e 94 02 03     call    0x604   ; 0x604 <KaleidoscopePlugin::init()>
     61e:       84 e2           ldi     r24, 0x24       ; 36
     620:       96 e0           ldi     r25, 0x06       ; 6
     622:       0c 94 02 03     jmp     0x604   ; 0x604 <KaleidoscopePluägin::init()>
```

I also couldn't resist to add another builder command/target `disassembly` as technically there is no such thing as a `decompile` (I wish there was). The original command/target name `decompile` remains untouched.
