### PR TITLE
Consistent indentation of kaleidoscope-builder & co

### DIFF
--- a/bin/find-device-port-linux-udev
+++ b/bin/find-device-port-linux-udev
@@ -2,29 +2,30 @@
 
 use warnings;
 use strict;
-my $vid = shift;
-my $pid = shift;
+my $vid    = shift;
+my $pid    = shift;
 my $prefix = '/dev/serial/by-id/';
-my @paths= `ls $prefix`;
+my @paths  = `ls $prefix`;
 my %devices;
 
 for my $path (@paths) {
     chomp($path);
-    next unless -l $prefix. $path;
+    next unless -l $prefix . $path;
     my @data = `udevadm info -q property --name=${prefix}${path}`;
     for my $line (@data) {
-	chomp ($line);
-	my ($key,$val) = split(/=/,$line,2);
-	$devices{$path}{$key} = $val;
+        chomp($line);
+        my ( $key, $val ) = split( /=/, $line, 2 );
+        $devices{$path}{$key} = $val;
     }
-    if (($devices{$path}{'ID_VENDOR_ID'} == $vid) &&
-	($devices{$path}{'ID_MODEL_ID'} == $pid) ) {
+    if (   ( $devices{$path}{'ID_VENDOR_ID'} == $vid )
+        && ( $devices{$path}{'ID_MODEL_ID'} == $pid ) )
+    {
 
-	if ($devices{$path}{'ID_MM_CANDIDATE'}) {
-	    warn "Yikes. ModemManager wants to pwn your keyboard";
-	}
+        if ( $devices{$path}{'ID_MM_CANDIDATE'} ) {
+            warn "Yikes. ModemManager wants to pwn your keyboard";
+        }
 
-	print $devices{$path}{DEVNAME};
-	exit(0);
+        print $devices{$path}{DEVNAME};
+        exit(0);
     }
 }

--- a/bin/find-device-port-linux-udev
+++ b/bin/find-device-port-linux-udev
@@ -9,22 +9,22 @@ my @paths= `ls $prefix`;
 my %devices;
 
 for my $path (@paths) {
-	chomp($path);
-	next unless -l $prefix. $path;
-	my @data = `udevadm info -q property --name=${prefix}${path}`;
-	for my $line (@data) {
+    chomp($path);
+    next unless -l $prefix. $path;
+    my @data = `udevadm info -q property --name=${prefix}${path}`;
+    for my $line (@data) {
 	chomp ($line);
 	my ($key,$val) = split(/=/,$line,2);
-		$devices{$path}{$key} = $val;
+	$devices{$path}{$key} = $val;
+    }
+    if (($devices{$path}{'ID_VENDOR_ID'} == $vid) &&
+	($devices{$path}{'ID_MODEL_ID'} == $pid) ) {
+
+	if ($devices{$path}{'ID_MM_CANDIDATE'}) {
+	    warn "Yikes. ModemManager wants to pwn your keyboard";
 	}
-	if (($devices{$path}{'ID_VENDOR_ID'} == $vid) &&
-	   ($devices{$path}{'ID_MODEL_ID'} == $pid) ) {
 
-	   if ($devices{$path}{'ID_MM_CANDIDATE'}) {
-         warn "Yikes. ModemManager wants to pwn your keyboard";
-     }
-
-     print $devices{$path}{DEVNAME};
-     exit(0);
-   }
+	print $devices{$path}{DEVNAME};
+	exit(0);
+    }
 }

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -7,28 +7,28 @@ set -e
 ######
 
 build_version () {
-	GIT_VERSION="$(cd $(find_sketch); git describe --abbrev=4 --dirty --always)"
-	LIB_VERSION="$(cd $(find_sketch); (grep version= ../../library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
+    GIT_VERSION="$(cd $(find_sketch); git describe --abbrev=4 --dirty --always)"
+    LIB_VERSION="$(cd $(find_sketch); (grep version= ../../library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
 
-	BUILD_PATH="${BUILD_PATH:-$(mktemp -d 2>/dev/null || mktemp -d -t 'build')}"
-	OUTPUT_DIR="${OUTPUT_DIR:-output/${LIBRARY}}"
-	OUTPUT_PATH="${OUTPUT_PATH:-${SOURCEDIR}/${OUTPUT_DIR}}"
+    BUILD_PATH="${BUILD_PATH:-$(mktemp -d 2>/dev/null || mktemp -d -t 'build')}"
+    OUTPUT_DIR="${OUTPUT_DIR:-output/${LIBRARY}}"
+    OUTPUT_PATH="${OUTPUT_PATH:-${SOURCEDIR}/${OUTPUT_DIR}}"
 }
 
 build_filenames () {
-	OUTPUT_FILE_PREFIX="${SKETCH}-${LIB_VERSION}"
-	HEX_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.hex"
-	HEX_FILE_WITH_BOOTLOADER_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}-with-bootloader.hex"
-	ELF_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.elf"
+    OUTPUT_FILE_PREFIX="${SKETCH}-${LIB_VERSION}"
+    HEX_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.hex"
+    HEX_FILE_WITH_BOOTLOADER_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}-with-bootloader.hex"
+    ELF_FILE_PATH="${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.elf"
 }
 
 firmware_size () {
     if [ "${BOARD}" = "virtual" ]; then
-      echo "[Size not computed for virtual build]"
-      return
+	echo "[Size not computed for virtual build]"
+	return
     fi
 
-	  ## This is a terrible hack, please don't hurt me. - algernon
+    ## This is a terrible hack, please don't hurt me. - algernon
 
     MAX_PROG_SIZE=28672
 
@@ -57,7 +57,7 @@ find_sketch () {
             return
         fi
     done
-        echo "Couldn't find sketch (.ino file)" >&2
+    echo "Couldn't find sketch (.ino file)" >&2
     exit 1
 }
 
@@ -84,9 +84,9 @@ flash_over_usb () {
 }
 
 flash_from_bootloader() {
-	prepare_to_flash
-	find_bootloader_ports
-	flash_over_usb || flash_over_usb
+    prepare_to_flash
+    find_bootloader_ports
+    flash_over_usb || flash_over_usb
 }
 
 program() {
@@ -96,12 +96,12 @@ program() {
 
 flash_with_programmer() {
     ${AVRDUDE} -v \
-			-C ${AVRDUDE_CONF} \
-		        -p${MCU} \
-		        -cusbtiny \
-		        -D \
-		        -B 1 \
-		        "-Uflash:w:${HEX_FILE_PATH}:i"
+	       -C ${AVRDUDE_CONF} \
+	       -p${MCU} \
+	       -cusbtiny \
+	       -D \
+	       -B 1 \
+	       "-Uflash:w:${HEX_FILE_PATH}:i"
 }
 
 hex_with_bootloader () {
@@ -109,11 +109,11 @@ hex_with_bootloader () {
         compile
     fi
 
-	  cat ${HEX_FILE_PATH} | awk '/^:00000001FF/ == 0' > ${HEX_FILE_WITH_BOOTLOADER_PATH}
-	  echo "Using ${BOOTLOADER_PATH}"
-	  ${MD5} ${BOOTLOADER_PATH}
-	  cat ${BOOTLOADER_PATH} >> ${HEX_FILE_WITH_BOOTLOADER_PATH}
-    	ln -sf "${HEX_FILE_WITH_BOOTLOADER_PATH}" "${OUTPUT_PATH}/${SKETCH}-latest-with-bootloader.hex"
+    cat ${HEX_FILE_PATH} | awk '/^:00000001FF/ == 0' > ${HEX_FILE_WITH_BOOTLOADER_PATH}
+    echo "Using ${BOOTLOADER_PATH}"
+    ${MD5} ${BOOTLOADER_PATH}
+    cat ${BOOTLOADER_PATH} >> ${HEX_FILE_WITH_BOOTLOADER_PATH}
+    ln -sf "${HEX_FILE_WITH_BOOTLOADER_PATH}" "${OUTPUT_PATH}/${SKETCH}-latest-with-bootloader.hex"
     cat <<EOF
 
 Combined firmware and bootloader are now at ${HEX_FILE_WITH_BOOTLOADER_PATH}
@@ -143,29 +143,29 @@ compile () {
 
     ARDUINO_PACKAGES=""
     if [ -d ${ARDUINO_PACKAGE_PATH} ]; then
-	      ARDUINO_PACKAGES="-hardware \"${ARDUINO_PACKAGE_PATH}\""
+	ARDUINO_PACKAGES="-hardware \"${ARDUINO_PACKAGE_PATH}\""
     fi
 
     ${ARDUINO_BUILDER} \
         -compile \
-		    ${ARDUINO_PACKAGES} \
-		    -hardware "${ARDUINO_PATH}/hardware" \
-		    -hardware "${BOARD_HARDWARE_PATH}" \
-		    ${ARDUINO_TOOLS_PARAM} \
-		    -tools "${ARDUINO_PATH}/tools-builder" \
-		    -fqbn "${FQBN}" \
-        	    -libraries "." \
-                    -libraries "${ROOT}" \
-		    -libraries "${BOARD_HARDWARE_PATH}/.." \
-        	    ${local_LIBS} \
-		    ${EXTRA_BUILDER_ARGS} \
-		    -build-path "${BUILD_PATH}" \
-		    -ide-version "${ARDUINO_IDE_VERSION}" \
-		    -prefs "compiler.cpp.extra_flags=-std=c++11 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
-		    -warnings all \
+	${ARDUINO_PACKAGES} \
+	-hardware "${ARDUINO_PATH}/hardware" \
+	-hardware "${BOARD_HARDWARE_PATH}" \
+	${ARDUINO_TOOLS_PARAM} \
+	-tools "${ARDUINO_PATH}/tools-builder" \
+	-fqbn "${FQBN}" \
+        -libraries "." \
+        -libraries "${ROOT}" \
+	-libraries "${BOARD_HARDWARE_PATH}/.." \
+        ${local_LIBS} \
+	${EXTRA_BUILDER_ARGS} \
+	-build-path "${BUILD_PATH}" \
+	-ide-version "${ARDUINO_IDE_VERSION}" \
+	-prefs "compiler.cpp.extra_flags=-std=c++11 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
+	-warnings all \
         ${ARDUINO_VERBOSE} \
-		    ${ARDUINO_AVR_GCC_PREFIX_PARAM} \
-		    "$(find_sketch)/${SKETCH}.ino"
+	${ARDUINO_AVR_GCC_PREFIX_PARAM} \
+	"$(find_sketch)/${SKETCH}.ino"
 
     cp "${BUILD_PATH}/${SKETCH}.ino.hex" "${HEX_FILE_PATH}"
     cp "${BUILD_PATH}/${SKETCH}.ino.elf" "${ELF_FILE_PATH}"
@@ -173,15 +173,15 @@ compile () {
     ln -sf "${OUTPUT_FILE_PREFIX}.elf" "${OUTPUT_PATH}/${SKETCH}-latest.elf"
 
     if [ "${ARDUINO_VERBOSE}" = "-verbose" ]; then
-	  echo "Build artifacts can be found in ${BUILD_PATH}";
+	echo "Build artifacts can be found in ${BUILD_PATH}";
     else
-	  rm -rf "${BUILD_PATH}" 
+	rm -rf "${BUILD_PATH}" 
     fi 
 }
 
 _find_all () {
     for plugin in ./*.ino \
-	    	   examples/* \
+	    	      examples/* \
                       src/*.ino; do
         if [ -d "$(dirname ${plugin})" ] || [ -f "${plugin}" ]; then
             p="$(basename "${plugin}" .ino)"
@@ -207,9 +207,9 @@ size () {
         compile
     fi
 
-	  echo "- Size: firmware/${LIBRARY}/${OUTPUT_FILE_PREFIX}.elf"
-	  firmware_size "${AVR_SIZE}" -C --mcu="${MCU}" "${ELF_FILE_PATH}"
-	  echo
+    echo "- Size: firmware/${LIBRARY}/${OUTPUT_FILE_PREFIX}.elf"
+    firmware_size "${AVR_SIZE}" -C --mcu="${MCU}" "${ELF_FILE_PATH}"
+    echo
 }
 
 size_map () {

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -1,3 +1,5 @@
+# -*- shell-script -*-
+
 ## NEEDS: LIBRARY, SKETCH, ROOT, SOURCEDIR
 ## Should be included when the current directory is the dir of the Sketch.
 
@@ -11,9 +13,9 @@ LIBRARY="${LIBRARY:-${SKETCH}}"
 BOARD="${BOARD:-model01}"
 MCU="${MCU:-atmega32u4}"
 if [ "${BOARD}" = "virtual" ]; then
-  FQBN="${FQBN:-keyboardio:x86:${BOARD}}"
+    FQBN="${FQBN:-keyboardio:x86:${BOARD}}"
 else
-  FQBN="${FQBN:-keyboardio:avr:${BOARD}}"
+    FQBN="${FQBN:-keyboardio:avr:${BOARD}}"
 fi
 
 ########
@@ -25,62 +27,62 @@ fi
 uname_S=$(uname -s 2>/dev/null || echo not)
 
 find_device_vid_pid() {
-  VPIDS=$(${ARDUINO_BUILDER} \
-		          -hardware "${ARDUINO_PATH}/hardware" \
-		          -hardware "${BOARD_HARDWARE_PATH}" \
-		          ${ARDUINO_TOOLS_PARAM} \
-		          -tools "${ARDUINO_PATH}/tools-builder" \
-		          -fqbn "${FQBN}" \
-              -dump-prefs | grep "\.[vp]id=")
-  VID=${VID:-$(echo "${VPIDS}" | grep build.vid= | cut -dx -f2)}
-  SKETCH_PID=${SKETCH_PID:-$(echo "${VPIDS}" | grep build.pid= | cut -dx -f2)}
-  BOOTLOADER_PID=${BOOTLOADER_PID:-$(echo "${VPIDS}" | grep bootloader.pid= | cut -dx -f2)}
+    VPIDS=$(${ARDUINO_BUILDER} \
+		-hardware "${ARDUINO_PATH}/hardware" \
+		-hardware "${BOARD_HARDWARE_PATH}" \
+		${ARDUINO_TOOLS_PARAM} \
+		-tools "${ARDUINO_PATH}/tools-builder" \
+		-fqbn "${FQBN}" \
+		-dump-prefs | grep "\.[vp]id=")
+    VID=${VID:-$(echo "${VPIDS}" | grep build.vid= | cut -dx -f2)}
+    SKETCH_PID=${SKETCH_PID:-$(echo "${VPIDS}" | grep build.pid= | cut -dx -f2)}
+    BOOTLOADER_PID=${BOOTLOADER_PID:-$(echo "${VPIDS}" | grep bootloader.pid= | cut -dx -f2)}
 }
 
 find_device_port() {
-  find_device_vid_pid
-	DIR=$(dirname "$(readlink -f "$0")")
-	DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
-	DEVICE_PORT="$(perl ${DEVICE_PORT_PROBER} ${VID} ${SKETCH_PID})"
+    find_device_vid_pid
+    DIR=$(dirname "$(readlink -f "$0")")
+    DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
+    DEVICE_PORT="$(perl ${DEVICE_PORT_PROBER} ${VID} ${SKETCH_PID})"
 }
 
 reset_device_cmd() {
-	stty -F ${DEVICE_PORT} 1200 hupcl
+    stty -F ${DEVICE_PORT} 1200 hupcl
 }
 
 find_bootloader_ports() {
-  find_device_vid_pid
-	DIR=$(dirname "$(readlink -f "$0")")
-	DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
-	DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${VID} ${BOOTLOADER_PID})"
+    find_device_vid_pid
+    DIR=$(dirname "$(readlink -f "$0")")
+    DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
+    DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${VID} ${BOOTLOADER_PID})"
 }
 
 MD5="md5sum"
 
 if [ "${uname_S}" = "Darwin" ]; then
 
-  find_device_port() {
-      DEVICE_PORT="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
-      DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCkbio* 2> /dev/null || echo '')}"
-      DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemHID* 2> /dev/null || echo '')}"
-      DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCHID* 2> /dev/null || echo '')}"
-      DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
-  }
+    find_device_port() {
+	DEVICE_PORT="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
+	DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCkbio* 2> /dev/null || echo '')}"
+	DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemHID* 2> /dev/null || echo '')}"
+	DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCHID* 2> /dev/null || echo '')}"
+	DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
+    }
 
-  reset_device_cmd() {
-      /bin/stty -f ${DEVICE_PORT} 1200
-  }
+    reset_device_cmd() {
+	/bin/stty -f ${DEVICE_PORT} 1200
+    }
 
-  ARDUINO_PATH="${ARDUINO_PATH:-/Applications/Arduino.app/Contents/Java/}"
-  ARDUINO_PACKAGE_PATH="${ARDUINO_PACKAGE_PATH:-${HOME}/Library/Arduino15/packages}"
-  ARDUINO_LOCAL_LIB_PATH="${ARDUINO_LOCAL_LIB_PATH:-${HOME}/Documents/Arduino}"
+    ARDUINO_PATH="${ARDUINO_PATH:-/Applications/Arduino.app/Contents/Java/}"
+    ARDUINO_PACKAGE_PATH="${ARDUINO_PACKAGE_PATH:-${HOME}/Library/Arduino15/packages}"
+    ARDUINO_LOCAL_LIB_PATH="${ARDUINO_LOCAL_LIB_PATH:-${HOME}/Documents/Arduino}"
 
-  MD5="md5"
+    MD5="md5"
 
-  find_bootloader_ports() {
-      DEVICE_PORT_BOOTLOADER="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
-      DEVICE_PORT_BOOTLOADER="${DEVICE_PORT_BOOTLOADER:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
-  }
+    find_bootloader_ports() {
+	DEVICE_PORT_BOOTLOADER="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
+	DEVICE_PORT_BOOTLOADER="${DEVICE_PORT_BOOTLOADER:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
+    }
 
 fi
 


### PR DESCRIPTION
I hesitate to suggest this, but it's so much easier to work with these scripts if they're indented consistently. All I did was set them up in a proper Emacs mode and run `indent-region` on the whole file.

Only whitespace should have changed at all, except for the one comment at the top of `kaleidoscope-builder.conf` to cause Emacs to open it in `shell-script` mode.