### PR TITLE
Better serial port detection for macOS

### DIFF
--- a/bin/find-device-port-macos
+++ b/bin/find-device-port-macos
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# Based on listArduinos.pl from https://github.com/todbot/usbSearch (License: MIT)
+# Original (C) 2012, Tod E. Kurt, http://todbot.com/blog/
+# This version by Michael Richters <gedankenexperimenter@gmail.com>
+
 use warnings;
 use strict;
 

--- a/bin/find-device-port-macos
+++ b/bin/find-device-port-macos
@@ -1,0 +1,76 @@
+#!/usr/bin/env perl
+
+use warnings;
+use strict;
+
+# ioreg might be more machine-readable than system_profiler, but I haven't been able to
+# get it to produce useful output
+my @output = qx(/usr/sbin/system_profiler SPUSBDataType);
+
+my $parse_state = 0;
+my $device      = {};
+
+LINE: foreach my $line (@output) {
+
+    chomp $line;
+
+    if ( $parse_state == 0 ) {
+        if ( $line =~ m/Model 01/ ) {
+            $parse_state = 1;
+            next LINE;
+        }
+    }
+
+    if ( $parse_state == 1 ) {
+        if ( $line =~ m/^\s*$/ ) {
+            $parse_state = 2;
+            next LINE;
+        }
+    }
+
+    if ( $parse_state == 2 ) {
+        if ( $line =~ m/Serial Number: (.+)$/ ) {
+            $device->{'serial_number'} = $1;
+            next LINE;
+        }
+        if ( $line =~ m/Location ID: (.+)$/ ) {
+            $device->{'location_id'} = $1;
+            next LINE;
+        }
+        if ( $line =~ m/Product ID: (.+)$/ ) {
+            $device->{'product_id'} = $1;
+            next LINE;
+        }
+        if ( $line =~ m/Vendor ID: (.+)$/ ) {
+            $device->{'vendor_id'} = $1;
+            next LINE;
+        }
+        if ( $line =~ m/^\s*$/ ) {
+            last LINE;
+        }
+    }
+
+}
+
+die "Can't find Model 01" if ( $device == {} );
+
+my $serial_port_name = "";
+
+if ( exists( $device->{'serial_number'} ) ) {
+    $serial_port_name = "/dev/cu.usbmodem" . $device->{'serial_number'};
+    if ( -e $serial_port_name ) {
+        print $serial_port_name;
+        exit 0;
+    }
+}
+
+if ( exists( $device->{'location_id'} ) ) {
+    my $loc = substr( $device->{'location_id'}, 2, 4 );
+    $serial_port_name = "/dev/cu.usbmodem" . $loc . 1;
+    if ( -e $serial_port_name ) {
+        print $serial_port_name;
+        exit 0;
+    }
+}
+
+die "Can't find Model 01 serial port name";

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -62,11 +62,9 @@ MD5="md5sum"
 if [ "${uname_S}" = "Darwin" ]; then
 
     find_device_port() {
-	DEVICE_PORT="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
-	DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCkbio* 2> /dev/null || echo '')}"
-	DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemHID* 2> /dev/null || echo '')}"
-	DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCHID* 2> /dev/null || echo '')}"
-	DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
+	DIR=$(dirname "$0")
+	DEVICE_PORT_PROBER="${DIR}/find-device-port-macos"
+	DEVICE_PORT="$(perl ${DEVICE_PORT_PROBER})"
     }
 
     reset_device_cmd() {
@@ -80,8 +78,9 @@ if [ "${uname_S}" = "Darwin" ]; then
     MD5="md5"
 
     find_bootloader_ports() {
-	DEVICE_PORT_BOOTLOADER="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
-	DEVICE_PORT_BOOTLOADER="${DEVICE_PORT_BOOTLOADER:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
+	DIR=$(dirname "$0")
+	DEVICE_PORT_PROBER="${DIR}/find-device-port-macos"
+	DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER})"
     }
 
 fi

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -1,3 +1,5 @@
+# -*- shell-script -*-
+
 ## NEEDS: LIBRARY, SKETCH, ROOT, SOURCEDIR
 ## Should be included when the current directory is the dir of the Sketch.
 
@@ -11,9 +13,9 @@ LIBRARY="${LIBRARY:-${SKETCH}}"
 BOARD="${BOARD:-model01}"
 MCU="${MCU:-atmega32u4}"
 if [ "${BOARD}" = "virtual" ]; then
-  FQBN="${FQBN:-keyboardio:x86:${BOARD}}"
+    FQBN="${FQBN:-keyboardio:x86:${BOARD}}"
 else
-  FQBN="${FQBN:-keyboardio:avr:${BOARD}}"
+    FQBN="${FQBN:-keyboardio:avr:${BOARD}}"
 fi
 
 ########
@@ -25,62 +27,62 @@ fi
 uname_S=$(uname -s 2>/dev/null || echo not)
 
 find_device_vid_pid() {
-  VPIDS=$(${ARDUINO_BUILDER} \
-		          -hardware "${ARDUINO_PATH}/hardware" \
-		          -hardware "${BOARD_HARDWARE_PATH}" \
-		          ${ARDUINO_TOOLS_PARAM} \
-		          -tools "${ARDUINO_PATH}/tools-builder" \
-		          -fqbn "${FQBN}" \
-              -dump-prefs | grep "\.[vp]id=")
-  VID=${VID:-$(echo "${VPIDS}" | grep build.vid= | cut -dx -f2)}
-  SKETCH_PID=${SKETCH_PID:-$(echo "${VPIDS}" | grep build.pid= | cut -dx -f2)}
-  BOOTLOADER_PID=${BOOTLOADER_PID:-$(echo "${VPIDS}" | grep bootloader.pid= | cut -dx -f2)}
+    VPIDS=$(${ARDUINO_BUILDER} \
+		-hardware "${ARDUINO_PATH}/hardware" \
+		-hardware "${BOARD_HARDWARE_PATH}" \
+		${ARDUINO_TOOLS_PARAM} \
+		-tools "${ARDUINO_PATH}/tools-builder" \
+		-fqbn "${FQBN}" \
+		-dump-prefs | grep "\.[vp]id=")
+    VID=${VID:-$(echo "${VPIDS}" | grep build.vid= | cut -dx -f2)}
+    SKETCH_PID=${SKETCH_PID:-$(echo "${VPIDS}" | grep build.pid= | cut -dx -f2)}
+    BOOTLOADER_PID=${BOOTLOADER_PID:-$(echo "${VPIDS}" | grep bootloader.pid= | cut -dx -f2)}
 }
 
 find_device_port() {
-  find_device_vid_pid
-	DIR=$(dirname "$(readlink -f "$0")")
-	DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
-	DEVICE_PORT="$(perl ${DEVICE_PORT_PROBER} ${VID} ${SKETCH_PID})"
+    find_device_vid_pid
+    DIR=$(dirname "$(readlink -f "$0")")
+    DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
+    DEVICE_PORT="$(perl ${DEVICE_PORT_PROBER} ${VID} ${SKETCH_PID})"
 }
 
 reset_device_cmd() {
-	stty -F ${DEVICE_PORT} 1200 hupcl
+    stty -F ${DEVICE_PORT} 1200 hupcl
 }
 
 find_bootloader_ports() {
-  find_device_vid_pid
-	DIR=$(dirname "$(readlink -f "$0")")
-	DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
-	DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${VID} ${BOOTLOADER_PID})"
+    find_device_vid_pid
+    DIR=$(dirname "$(readlink -f "$0")")
+    DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
+    DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${VID} ${BOOTLOADER_PID})"
 }
 
 MD5="md5sum"
 
 if [ "${uname_S}" = "Darwin" ]; then
 
-  find_device_port() {
-      DEVICE_PORT="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
-      DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCkbio* 2> /dev/null || echo '')}"
-      DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemHID* 2> /dev/null || echo '')}"
-      DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCHID* 2> /dev/null || echo '')}"
-      DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
-  }
+    find_device_port() {
+	DEVICE_PORT="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
+	DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCkbio* 2> /dev/null || echo '')}"
+	DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemHID* 2> /dev/null || echo '')}"
+	DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodemCHID* 2> /dev/null || echo '')}"
+	DEVICE_PORT="${DEVICE_PORT:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
+    }
 
-  reset_device_cmd() {
-      /bin/stty -f ${DEVICE_PORT} 1200
-  }
+    reset_device_cmd() {
+	/bin/stty -f ${DEVICE_PORT} 1200
+    }
 
-  ARDUINO_PATH="${ARDUINO_PATH:-/Applications/Arduino.app/Contents/Java/}"
-  ARDUINO_PACKAGE_PATH="${ARDUINO_PACKAGE_PATH:-${HOME}/Library/Arduino15/packages}"
-  ARDUINO_LOCAL_LIB_PATH="${ARDUINO_LOCAL_LIB_PATH:-${HOME}/Documents/Arduino}"
+    ARDUINO_PATH="${ARDUINO_PATH:-/Applications/Arduino.app/Contents/Java/}"
+    ARDUINO_PACKAGE_PATH="${ARDUINO_PACKAGE_PATH:-${HOME}/Library/Arduino15/packages}"
+    ARDUINO_LOCAL_LIB_PATH="${ARDUINO_LOCAL_LIB_PATH:-${HOME}/Documents/Arduino}"
 
-  MD5="md5"
+    MD5="md5"
 
-  find_bootloader_ports() {
-      DEVICE_PORT_BOOTLOADER="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
-      DEVICE_PORT_BOOTLOADER="${DEVICE_PORT_BOOTLOADER:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
-  }
+    find_bootloader_ports() {
+	DEVICE_PORT_BOOTLOADER="$(ls /dev/cu.usbmodemkbio* 2> /dev/null || echo '')"
+	DEVICE_PORT_BOOTLOADER="${DEVICE_PORT_BOOTLOADER:-$(ls /dev/cu.usbmodem14* 2> /dev/null || echo '')}"
+    }
 
 fi
 


### PR DESCRIPTION
I rewrote an Arduino-detection script for use in finding the correct serial port name for flashing the firmware on macOS, and set up `kaleidoscope-builder.conf` to use it. I've only tested it on the one iMac that I have access to, but it works well there.

Fixes #280 