### PR TITLE
Drop the HIDAdaptor includes

### DIFF
--- a/examples/AppSwitcher/AppSwitcher.ino
+++ b/examples/AppSwitcher/AppSwitcher.ino
@@ -18,7 +18,6 @@
  */
 
 #include "Kaleidoscope.h"
-#include "Kaleidoscope-HIDAdaptor-KeyboardioHID.h"
 #include "Kaleidoscope-HostOS.h"
 #include "Kaleidoscope/HostOS-select.h"
 

--- a/examples/Kaleidoscope/Kaleidoscope.ino
+++ b/examples/Kaleidoscope/Kaleidoscope.ino
@@ -8,7 +8,6 @@
 #include "Kaleidoscope-Macros.h"
 #include "Kaleidoscope-LEDControl.h"
 #include "Kaleidoscope-Numlock.h"
-#include "Kaleidoscope-HIDAdaptor-KeyboardioHID.h"
 #include "Kaleidoscope.h"
 
 #include "LED-Off.h"

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -2,8 +2,6 @@
 
 #include <Arduino.h>
 
-#include "Kaleidoscope-HIDAdaptor-KeyboardioHID.h"
-
 //end of add your includes here
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
We are moving towards including the Adaptor from the Hardware library, so we need not pull them in from user sketches (or from core).
