### PR TITLE
Treat device ID values as hex

### DIFF
--- a/bin/find-device-port-linux-udev
+++ b/bin/find-device-port-linux-udev
@@ -17,8 +17,8 @@ for my $path (@paths) {
         my ( $key, $val ) = split( /=/, $line, 2 );
         $devices{$path}{$key} = $val;
     }
-    if (   ( $devices{$path}{'ID_VENDOR_ID'} == $vid )
-        && ( $devices{$path}{'ID_MODEL_ID'} == $pid ) )
+    if (   ( hex $devices{$path}{'ID_VENDOR_ID'} == hex $vid )
+        && ( hex $devices{$path}{'ID_MODEL_ID'} == hex $pid ) )
     {
 
         if ( $devices{$path}{'ID_MM_CANDIDATE'} ) {


### PR DESCRIPTION
This avoids Perl warnings when trying to do numeric comparisons on
device IDs that don't consist solely of decimal numbers.

Without this patch I see the following:

    Argument "1d50" isn't numeric in numeric eq (==) at /home/jwakely/Arduino/hardware/keyboardio/avr/libraries/Kaleidoscope/bin/find-device-port-linux-udev line 20.