### PR TITLE
Check for missing bootloader port

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -79,6 +79,10 @@ flash () {
 }
 
 flash_over_usb () {
+    if [ -z "${DEVICE_PORT_BOOTLOADER}" ]; then
+        echo 'DEVICE_PORT_BOOTLOADER is empty (did you hold "Prog" to enable bootloader mode?)' >&2
+        return 1
+    fi
     sleep 1s
     ${AVRDUDE} -q -q -C ${AVRDUDE_CONF} -p${MCU} -cavr109 -D -P ${DEVICE_PORT_BOOTLOADER} -b57600 "-Uflash:w:${HEX_FILE_PATH}:i"
 }


### PR DESCRIPTION
Without this check forgetting to hold the `Prog` key gives the following errors, which are somewhat cryptic:

```
Press ENTER when ready...

avrdude: ser_open(): can't open device "-b57600": No such file or directory
avrdude: ser_open(): can't open device "-b57600": No such file or directory
make: *** [/home/jwakely/Arduino/hardware/keyboardio/avr/build-tools/makefiles//rules.mk:72: flash] Error 1
```

The problem is that the empty `${DEVICE_PORT_BOOTLOADER}` variable causes the next argument to be interpreted as the argument for the `-P` option.

Quoting the shell variable would result in `-P ""` when it's empty, which gives a more accurate error, though still doesn't tell you how to fix it:

```
avrdude: no port has been specified on the command line or the config file
         Specify a port using the -P option and try again


avrdude: no port has been specified on the command line or the config file
         Specify a port using the -P option and try again

make: *** [/home/jwakely/Arduino/hardware/keyboardio/avr/build-tools/makefiles//rules.mk:72: flash] Error 1
```
