### PR TITLE
Changed behaviour for layer-shift keys

### DIFF
--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -9,6 +9,7 @@ static uint32_t LayerState;
 #define MAX_LAYERS sizeof(LayerState) * 8;
 
 uint8_t Layer_::highestLayer;
+bool Layer_::shiftOn = false;
 Key Layer_::liveCompositeKeymap[ROWS][COLS];
 uint8_t Layer_::activeLayers[ROWS][COLS];
 Key(*Layer_::getKey)(uint8_t layer, byte row, byte col) = Layer.getKeyFromPROGMEM;
@@ -159,7 +160,7 @@ void Layer_::on(uint8_t layer) {
 
   // If the target layer is above the previous highest active layer,
   // update highestLayer
-  if (layer > highestLayer)
+  if (!shiftOn && layer > highestLayer)
     updateHighestLayer();
 
   // Update the keymap cache (but not liveCompositeKeymap; that gets
@@ -178,7 +179,7 @@ void Layer_::off(uint8_t layer) {
 
   // If the target layer was the previous highest active layer,
   // update highestLayer
-  if (layer == highestLayer)
+  if (! shiftOn && layer == highestLayer)
     updateHighestLayer();
 
   // Update the keymap cache (but not liveCompositeKeymap; that gets

--- a/src/layers.h
+++ b/src/layers.h
@@ -83,6 +83,7 @@ class Layer_ {
 
  private:
   static void updateHighestLayer(void);
+  static void handleKeymapKeyswitchEvent(Key keymapEntry, byte row, byte col, uint8_t keyState);
 
   static uint8_t highestLayer;
   static Key liveCompositeKeymap[ROWS][COLS];

--- a/src/layers.h
+++ b/src/layers.h
@@ -86,6 +86,7 @@ class Layer_ {
   static void handleKeymapKeyswitchEvent(Key keymapEntry, byte row, byte col, uint8_t keyState);
 
   static uint8_t highestLayer;
+  static bool shiftOn;
   static Key liveCompositeKeymap[ROWS][COLS];
   static uint8_t activeLayers[ROWS][COLS];
 };


### PR DESCRIPTION
With this change, layer shift keys set `highestLayer`, but don't affect `layerState`. This means that when holding a `ShiftToLayer(N)` key, layer N becomes the top active layer, and layers above N are ignored while that key is held. This should result in less surprising behaviour for users who are unfamiliar with the layer stack.

In addition, this means that only one layer shift can be active at a time. It also means that locked layers are not deactivated when a matching layer shift key is released.

To make this change, I turned `handleKeymapKeyswitchEvent()` into a private static member function so it could access the `highestLayer()` variable. It was already hidden from other translation units, so this shouldn't be a big deal. I also added `row` & `col` as parameters so that the key in question could be masked if it detects a change to `highestLayer` (e.g. from another layer shift key being pressed -- we don't want them fighting for control).

`updateActiveLayers()` was changed so that `highestLayer` always gets a lookup, regardless of its bit in `layerState`.