### PR TITLE
Run size target when flashing

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -64,6 +64,7 @@ find_sketch () {
 prepare_to_flash () {
     if [ ! -e "${HEX_FILE_PATH}" ]; then
         compile
+        size
     fi
 
     echo "Press ENTER when ready..."


### PR DESCRIPTION
When running `make flash`, it would be nice to get the program memory and SRAM size summary. As it is now, in order to get both that size summary and flash the keyboard, the user has to build everything twice, since (without some non-trivial setup of other tools) `make; make flash` doesn't use the files just compiled to flash the firmware.