### PR TITLE
Print size_map in decimal instead of hex

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -221,7 +221,7 @@ size_map () {
         compile
     fi
 
-    "${AVR_NM}" --size-sort -C -r -l "${ELF_FILE_PATH}"
+    "${AVR_NM}" --size-sort -C -r -l -t decimal "${ELF_FILE_PATH}"
 }
 
 disassemble () {


### PR DESCRIPTION
It's easier for most people to interpret numbers in decimal than hexadecimal; adding this option to avr-nm prints out the sizes in the size_map in a more intuitive format.