### PR TITLE
Improved fallbacks for macOS serial port detection

### DIFF
--- a/bin/find-device-port-macos
+++ b/bin/find-device-port-macos
@@ -66,14 +66,33 @@ if ( exists( $device->{'serial_number'} ) ) {
         print $serial_port_name;
         exit 0;
     }
+    # High Sierra sometimes has a mismatch between the serial number and the device
+    # filename. I'm not sure why, but system_profiler has a serial number ending in "E",
+    # whereas the device filename ends in "1". Another possibility is that the device
+    # filename simply always ends in a "1".
+    $serial_port_name =~ s/E$/1/;
+    if ( -e $serial_port_name ) {
+        print $serial_port_name;
+        exit 0;
+    }
 }
 
 if ( exists( $device->{'location_id'} ) ) {
-    my $loc = substr( $device->{'location_id'}, 2, 4 );
+    my $loc = substr( $device->{'location_id'}, 2, 3 );
     $serial_port_name = "/dev/cu.usbmodem" . $loc . 1;
     if ( -e $serial_port_name ) {
         print $serial_port_name;
         exit 0;
+    }
+}
+
+# If none of the above tests succeeds, just list the directory and see if there are any
+# files that have the device shortname that we expect:
+foreach my $line (qx(ls /dev/cu.usbmodem*)) {
+    if ( $line =~ m/kbio01/ ) {
+	chomp $line;
+	print $line;
+	exit 0;
     }
 }
 


### PR DESCRIPTION
Several people have reported difficulty flashing firmware on macOS High Sierra because the device port filename doesn't match the serial number from system_profiler. In particular, system_profiler would return a string ending in `E` whereas the device filename would have a `1`. This change adds a check for that filename explictily.

I also corrected the location_id fallback (the substring should have been just 3 characters long, not 4), and it works properly on my system if I make the device shortname 7 characters long, and the filename reverts to using the location id instead.

Last, I added one more check, simply listing the filenames, and searching for a match for the string `kbio01`, which should be present (although in one case, it wasn't).