### PR TITLE
Harden device detection/setup

### DIFF
--- a/bin/find-device-port-linux-udev
+++ b/bin/find-device-port-linux-udev
@@ -2,6 +2,8 @@
 
 use warnings;
 use strict;
+die "Usage: $0 VID PID\n" unless @ARGV == 2;
+
 my $vid    = shift;
 my $pid    = shift;
 my $prefix = '/dev/serial/by-id/';

--- a/bin/find-device-port-linux-udev
+++ b/bin/find-device-port-linux-udev
@@ -2,6 +2,9 @@
 
 use warnings;
 use strict;
+
+use FindBin qw{$Bin};
+
 die "Usage: $0 VID PID\n" unless @ARGV == 2;
 
 my $vid    = shift;
@@ -10,8 +13,16 @@ my $prefix = '/dev/serial/by-id/';
 my @paths  = `ls $prefix`;
 my %devices;
 
+sub debug {
+    print STDERR @_;
+}
+
+debug "Looking for USB device with vid=$vid and pid=$pid\n";
+
 for my $path (@paths) {
     chomp($path);
+    debug "Examining $path\n";
+    debug "  not symlink\n" unless -l $prefix . $path;
     next unless -l $prefix . $path;
     my @data = `udevadm info -q property --name=${prefix}${path}`;
     for my $line (@data) {
@@ -19,15 +30,36 @@ for my $path (@paths) {
         my ( $key, $val ) = split( /=/, $line, 2 );
         $devices{$path}{$key} = $val;
     }
-    if (   ( hex $devices{$path}{'ID_VENDOR_ID'} == hex $vid )
-        && ( hex $devices{$path}{'ID_MODEL_ID'} == hex $pid ) )
-    {
-
-        if ( $devices{$path}{'ID_MM_CANDIDATE'} ) {
-            warn "Yikes. ModemManager wants to pwn your keyboard";
-        }
-
-        print $devices{$path}{DEVNAME};
-        exit(0);
+    if ( hex $devices{$path}{'ID_VENDOR_ID'} != hex $vid ) {
+        debug "  ID_VENDOR_ID $devices{$path}{'ID_VENDOR_ID'} != $vid\n";
+        next;
     }
+    if ( hex $devices{$path}{'ID_MODEL_ID'} != hex $pid ) {
+        debug "  ID_MODEL_ID $devices{$path}{'ID_MODEL_ID'} != $pid\n";
+        next;
+    }
+
+    debug "  Found keyboard!\n";
+
+    if ( $devices{$path}{'ID_MM_DEVICE_IGNORE'} ) {
+        debug "  ID_MM_DEVICE_IGNORE is set - good!\n";
+    }
+
+    if ( $devices{$path}{'ID_MM_CANDIDATE'}) {
+      my $rules = "$Bin/../etc/99-kaleidoscope.rules";
+      debug <<EOWARN
+
+WARNING: your udev rules are currently configured to suggest
+that your keyboard is suitable for use by ModemManager.  This
+means that there is a risk of ModemManager interfering.  To avoid
+this, copy
+
+    $rules
+
+to /etc/udev/rules.d
+EOWARN
+    }
+
+    print $devices{$path}{DEVNAME};
+    exit(0);
 }

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -249,13 +249,27 @@ reset_device() {
 }
 
 check_device_port () {
-    if [ -z $DEVICE_PORT ]; then
-        echo "Couldn't autodetect the keyboard's serial port."
-        echo "If you see this message and your keyboard is connected to your computer,"
-        echo "it probably means that our serial port detection logic is buggy or incomplete."
-        echo
-        echo "Please report this issue at https://github.com/keyboardio/Kaleidoscope";
-        exit 0;
+    if [ -z "$DEVICE_PORT" ]; then
+        cat <<EOF >&2
+Couldn't autodetect the keyboard's serial port.
+If you see this message and your keyboard is connected to your computer,
+it probably means that our serial port detection logic is buggy or incomplete.
+
+Please report this issue at https://github.com/keyboardio/Kaleidoscope
+EOF
+        exit 1
+    elif echo "$DEVICE_PORT" | grep -q '[[:space:]]'; then
+        cat <<EOF >&2
+Unexpected whitespace found in detected serial port:
+
+    $DEVICE_PORT
+
+If you see this message, it means that our serial port
+detection logic is buggy or incomplete.
+
+Please report this issue at https://github.com/keyboardio/Kaleidoscope
+EOF
+        exit 1
     fi
 }
 

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -271,6 +271,26 @@ Please report this issue at https://github.com/keyboardio/Kaleidoscope
 EOF
         exit 1
     fi
+
+    if ! [ -w "$DEVICE_PORT" ]; then
+        cat <<EOF >&2
+
+$DEVICE_PORT is not writable:
+
+  `ls -l $DEVICE_PORT`
+
+You are currently in the following groups:
+
+  `id -Gn`
+
+Please ensure you have followed the instructions on setting up your
+account to be in the right group:
+
+https://github.com/keyboardio/Kaleidoscope/wiki/Install-Arduino-support-on-Linux
+
+EOF
+        exit 1
+    fi
 }
 
 usage () {

--- a/etc/99-kaleidoscope.rules
+++ b/etc/99-kaleidoscope.rules
@@ -1,4 +1,2 @@
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2300", SYMLINK+="model01", ENV{ID_MM_DEVICE_IGNORE}="1"
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2301", SYMLINK+="model01", ENV{ID_MM_DEVICE_IGNORE}="1"
-
-
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2300", SYMLINK+="model01", ENV{ID_MM_DEVICE_IGNORE}:="1", ENV{ID_MM_CANDIDATE}:="0"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2301", SYMLINK+="model01", ENV{ID_MM_DEVICE_IGNORE}:="1", ENV{ID_MM_CANDIDATE}:="0"


### PR DESCRIPTION
There are several things which can go wrong with detecting the keyboard device and ensuring it can be written to.  Often these are due to the user not following instructions exactly, so try to harden the code to gracefully handle failures and provide helpful advice / information.