### PR TITLE
Added keyboard report send policy choice

### DIFF
--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -3,6 +3,8 @@
 
 Kaleidoscope_::eventHandlerHook Kaleidoscope_::eventHandlers[HOOK_MAX];
 Kaleidoscope_::loopHook Kaleidoscope_::loopHooks[HOOK_MAX];
+uint8_t Kaleidoscope_::keyboardReportSendPolicy
+  = kaleidoscope::KeyboardReportSendCollective;
 
 Kaleidoscope_::Kaleidoscope_(void) {
 }
@@ -30,21 +32,43 @@ Kaleidoscope_::setup(void) {
 }
 
 void
-Kaleidoscope_::loop(void) {
+Kaleidoscope_::processKeyEvents(void) {
   KeyboardHardware.scanMatrix();
+}
+
+void
+Kaleidoscope_::preClearLoopHooks(void) {
 
   for (byte i = 0; loopHooks[i] != NULL && i < HOOK_MAX; i++) {
     loopHook hook = loopHooks[i];
     (*hook)(false);
   }
+}
 
-  kaleidoscope::hid::sendKeyboardReport();
-  kaleidoscope::hid::releaseAllKeys();
+void
+Kaleidoscope_::postClearLoopHooks(void) {
 
   for (byte i = 0; loopHooks[i] != NULL && i < HOOK_MAX; i++) {
     loopHook hook = loopHooks[i];
     (*hook)(true);
   }
+}
+
+void
+Kaleidoscope_::processLoopHooks(void) {
+
+  preClearLoopHooks();
+
+  kaleidoscope::hid::sendKeyboardReport();
+  kaleidoscope::hid::releaseAllKeys();
+
+  postClearLoopHooks();
+}
+
+void
+Kaleidoscope_::loop(void) {
+  processKeyEvents();
+  processLoopHooks();
 }
 
 void

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -90,6 +90,13 @@ class KaleidoscopePlugin {
   virtual void begin(void) { };
 };
 
+namespace kaleidoscope {
+enum KeyboardReportSendPolicy {
+  KeyboardReportSendCollective,
+  KeyboardReportSendOnEvent
+};
+}
+
 class Kaleidoscope_ {
  public:
   Kaleidoscope_(void);
@@ -100,6 +107,11 @@ class Kaleidoscope_ {
   }
   void setup(void);
   void loop(void);
+
+  void preClearLoopHooks(void);
+  void postClearLoopHooks(void);
+  void processKeyEvents(void);
+  void processLoopHooks(void);
 
   // ---- Kaleidoscope.use() ----
 
@@ -159,6 +171,17 @@ class Kaleidoscope_ {
   static void useLoopHook(loopHook hook);
 
   static bool focusHook(const char *command);
+
+  static void setKeyboardReportSendPolicy(uint8_t policy) {
+    keyboardReportSendPolicy = policy;
+  }
+  static uint8_t getKeyboardReportSendPolicy() {
+    return keyboardReportSendPolicy;
+  }
+
+ private:
+
+  static uint8_t keyboardReportSendPolicy;
 };
 
 extern Kaleidoscope_ Kaleidoscope;

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -30,13 +30,26 @@ static bool handleKeyswitchEventDefault(Key mappedKey, byte row, byte col, uint8
   //for every newly pressed button, figure out what logical key it is and send a key down event
   // for every newly released button, figure out what logical key it is and send a key up event
 
+  bool keyboardReportRequired = false;
+  bool keyboardReportSendImmediately =
+    (Kaleidoscope.getKeyboardReportSendPolicy() ==
+     kaleidoscope::KeyboardReportSendOnEvent);
+
   if (mappedKey.flags & SYNTHETIC) {
     handleSyntheticKeyswitchEvent(mappedKey, keyState);
   } else if (keyIsPressed(keyState)) {
     kaleidoscope::hid::pressKey(mappedKey);
-  } else if (keyToggledOff(keyState) && (keyState & INJECTED)) {
+    keyboardReportRequired = true;
+  } else if (keyToggledOff(keyState) &&
+             (keyboardReportSendImmediately || (keyState & INJECTED))) {
     kaleidoscope::hid::releaseKey(mappedKey);
+    keyboardReportRequired = true;
   }
+
+  if (keyboardReportSendImmediately && keyboardReportRequired) {
+    kaleidoscope::hid::sendKeyboardReport();
+  }
+
   return true;
 }
 


### PR DESCRIPTION
The original way of sending keyboard reports once per cycle,
proved to be too inflexible for some applications such as event queueing
plugins (e.g. Papageno or Qukeys).

To make development of such plugins possible/easier, the
original keyboard report send policy (collecting several key events during
matrix scan) was supplemented by a new additional send policy that sends
keyboard reports immediately whenever a key is toggled on/off.

The original policy is preserved as default.
The actual policy that is supposed to be used can be
selected by means of access functions setKeyboardReportSendPolicy()
and getKeyboardReportSendPolicy() of class Kaleidoscope_.
Possible policy choices are
kaleidoscope::KeyboardReportSendCollective (default) and
kaleidoscope::KeyboardReportSendOnEvent.

To allow for ommiting the keyreport that was originally send
once per cycle, the Kaleidoscope_ class gained four additional methods

void preClearLoopHooks(void);
void postClearLoopHooks(void);
void processKeyEvents(void);
void processLoopHooks(void);

that allow to call the original loops substeps individually
and thus to generate a custom main loop that ommits parts
of the default loop (e.g. to suppress the afforementioned keyboard report
submission in the middle of every cycle).

 [This forum discussion](https://community.keyboard.io/t/keyboard-report-clear-in-every-cycle-vs-report-on-key-event/1389) is related and somewhat explains the reason for this PR.