### PR TITLE
Mask held keys on keyboard boot

### DIFF
--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -27,6 +27,9 @@ Kaleidoscope_::setup(void) {
       Layer.updateLiveCompositeKeymap(row, col);
     }
   }
+
+  KeyboardHardware.readMatrix();
+  KeyboardHardware.maskHeldKeys();
 }
 
 void


### PR DESCRIPTION
When the keyboard boots, we should mask all held keys, to avoid nasty surprises. This is particularly important when flashing: if `Prog` is held past the keyboard reset, we'll see a keydown + keyup event from it during firmware boot. If the user mapped `Prog` to something, that will activate due to this.

Therefore, to fix this issue, in `Kaleidoscope_::setup()`, we first read the matrix, then mask any held keys. The only downside is that if someone does want to trigger a key during boot, that is not possible after this change. This should be a rare enough corner case that we can safely ignore it, and fix an issue for more users.

Fixes keyboardio/Kaleidoscope-Syster#3.
