### PR TITLE
A fix for rollover from a mod-flagged key

### DIFF
--- a/src/kaleidoscope/hid.h
+++ b/src/kaleidoscope/hid.h
@@ -9,6 +9,11 @@ namespace hid {
 
 extern void initializeKeyboard();
 
+extern bool isPureModifier(Key mappedKey);
+extern void addModFlags(byte flags);
+extern void setModFlagsMask(byte flags);
+extern void pressModFlags(byte flags);
+
 extern void pressKey(Key mappedKey);
 extern void releaseKey(Key mappedKey);
 extern void releaseAllKeys();

--- a/src/kaleidoscope/hid.h
+++ b/src/kaleidoscope/hid.h
@@ -9,7 +9,7 @@ namespace hid {
 
 extern void initializeKeyboard();
 
-extern void setLastKeyPress(Key mappedKey);
+extern void pressToggledOnKey(Key mappedKey);
 
 extern void pressKey(Key mappedKey);
 extern void releaseKey(Key mappedKey);

--- a/src/kaleidoscope/hid.h
+++ b/src/kaleidoscope/hid.h
@@ -9,10 +9,7 @@ namespace hid {
 
 extern void initializeKeyboard();
 
-extern bool isPureModifier(Key mappedKey);
-extern void addModFlags(byte flags);
-extern void setModFlagsMask(byte flags);
-extern void pressModFlags(byte flags);
+extern void setLastKeyPress(Key mappedKey);
 
 extern void pressKey(Key mappedKey);
 extern void releaseKey(Key mappedKey);

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -34,7 +34,7 @@ static bool handleKeyswitchEventDefault(Key mappedKey, byte row, byte col, uint8
   if (mappedKey.flags & SYNTHETIC) {
     handleSyntheticKeyswitchEvent(mappedKey, keyState);
   } else if (keyToggledOn(keyState)) {
-    kaleidoscope::hid::setLastKeyPress(mappedKey);
+    kaleidoscope::hid::pressToggledOnKey(mappedKey);
   } else if (keyIsPressed(keyState)) {
     kaleidoscope::hid::pressKey(mappedKey);
   } else if (keyToggledOff(keyState) && (keyState & INJECTED)) {

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -34,7 +34,7 @@ static bool handleKeyswitchEventDefault(Key mappedKey, byte row, byte col, uint8
   if (mappedKey.flags & SYNTHETIC) {
     handleSyntheticKeyswitchEvent(mappedKey, keyState);
   } else if (keyToggledOn(keyState)) {
-    kaleidoscope::hid::setModFlagsMask(mappedKey.flags);
+    kaleidoscope::hid::setLastKeyPress(mappedKey);
   } else if (keyIsPressed(keyState)) {
     kaleidoscope::hid::pressKey(mappedKey);
   } else if (keyToggledOff(keyState) && (keyState & INJECTED)) {

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -33,6 +33,8 @@ static bool handleKeyswitchEventDefault(Key mappedKey, byte row, byte col, uint8
 
   if (mappedKey.flags & SYNTHETIC) {
     handleSyntheticKeyswitchEvent(mappedKey, keyState);
+  } else if (keyToggledOn(keyState)) {
+    kaleidoscope::hid::setModFlagsMask(mappedKey.flags);
   } else if (keyIsPressed(keyState)) {
     kaleidoscope::hid::pressKey(mappedKey);
   } else if (keyToggledOff(keyState) && (keyState & INJECTED)) {


### PR DESCRIPTION
This (with the matching change to Kaleidoscope-HIDAdaptor-KeyboardioHID) makes it so a rollover from a key with a mod flag applied to one without will not result in the flag from the modified key affecting the next keypress.

This is the other half of keyboardio/Kaleidoscope-HIDAdaptor-KeyboardioHID#5. @noseglasses, please try it out and let me know how well this works for you.

(There is still a problem rolling over between two keys with different modifier flags but the same keycode, but that's a different issue, and not as easy to solve.)