### PR TITLE
Turn kaleidoscope::Hooks into a namespace

### DIFF
--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -11,7 +11,7 @@ Kaleidoscope_::Kaleidoscope_(void) {
 
 void
 Kaleidoscope_::setup(void) {
-  kaleidoscope::Hooks::onSetup();
+  kaleidoscope::hooks::onSetup();
 
   KeyboardHardware.setup();
 
@@ -35,11 +35,11 @@ Kaleidoscope_::setup(void) {
 
 void
 Kaleidoscope_::loop(void) {
-  kaleidoscope::Hooks::beforeEachCycle();
+  kaleidoscope::hooks::beforeEachCycle();
 
   KeyboardHardware.scanMatrix();
 
-  kaleidoscope::Hooks::beforeReportingState();
+  kaleidoscope::hooks::beforeReportingState();
 
 #if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API
   for (byte i = 0; loopHooks[i] != NULL && i < HOOK_MAX; i++) {
@@ -58,7 +58,7 @@ Kaleidoscope_::loop(void) {
   }
 #endif
 
-  kaleidoscope::Hooks::afterEachCycle();
+  kaleidoscope::hooks::afterEachCycle();
 }
 
 bool

--- a/src/kaleidoscope/hooks.cpp
+++ b/src/kaleidoscope/hooks.cpp
@@ -1,6 +1,7 @@
 #include "kaleidoscope/hooks.h"
 
 namespace kaleidoscope {
+namespace hooks {
 
 // The following weak symbols are overwritten by
 // using the KALEIDOSCOPE_INIT_PLUGINS(...) macro
@@ -16,12 +17,12 @@ namespace kaleidoscope {
     HOOK_NAME, SHOULD_ABORT_ON_CONSUMED_EVENT, SIGNATURE, ARGS_LIST)    __NL__ \
                                                                         __NL__ \
    __attribute__((weak))                                                __NL__ \
-   EventHandlerResult Hooks::HOOK_NAME SIGNATURE {                              __NL__ \
+   EventHandlerResult HOOK_NAME SIGNATURE {                             __NL__ \
       return EventHandlerResult::OK;                                    __NL__ \
    }
 
 _FOR_EACH_EVENT_HANDLER(INSTANTIATE_WEAK_HOOK_FUNCTION)
 
 #undef INSTANTIATE_WEAK_HOOK_FUNCTION
-
+}
 } // namespace kaleidoscope

--- a/src/kaleidoscope/hooks.h
+++ b/src/kaleidoscope/hooks.h
@@ -9,48 +9,21 @@ union Key;
 #include "plugin.h"
 #include "event_handlers.h"
 
-// Forward declaration required to enable friend declarations
-// in class Hooks.
-class kaleidoscope_;
-extern void handleKeyswitchEvent(kaleidoscope::Key mappedKey, byte row, byte col, uint8_t keyState);
-
 namespace kaleidoscope {
 
-// The reason why the hook routing entry point functions live within
-// class Hooks and not directly within a namespace is, that we want
-// to restrict who is allowed to trigger hooks, mainly to prevent
-// user code from calling hook methods.
-//
-// A note to maintainers: When you add new hooks that are supposed to
-// be called from other places than the friend classes and functions listed
-// below, just add a suitable friend declaration.
+// The reason why the hook routing entry point functions live within the hooks
+// namespace and not directly within a namespace is, that we want to prevent
+// accidental naming conflicts.
 
-class Hooks {
-
-  // The following friend declarations restrict access to
-  // the hook routing system.
-
-  // Kaleidoscope_ calls Hooks::onSetup, Hooks::beforeReportingState
-  // and Hooks::afterEachCycle.
-  friend class Kaleidoscope_;
-
-  // ::handleKeyswitchEvent(...) calls Hooks::onKeyswitchEvent.
-  friend void ::handleKeyswitchEvent(kaleidoscope::Key mappedKey,
-                                     byte row, byte col, uint8_t keyState);
-
- private:
-
-  // The following private functions are just to be called by classes
-  // and functions that are declared as friends above.
-
+namespace hooks {
 #define DEFINE_WEAK_HOOK_FUNCTION(                                             \
     HOOK_NAME, SHOULD_ABORT_ON_CONSUMED_EVENT, SIGNATURE, ARGS_LIST)    __NL__ \
                                                                         __NL__ \
-   static EventHandlerResult HOOK_NAME SIGNATURE;
+   EventHandlerResult HOOK_NAME SIGNATURE;
 
-  _FOR_EACH_EVENT_HANDLER(DEFINE_WEAK_HOOK_FUNCTION)
+_FOR_EACH_EVENT_HANDLER(DEFINE_WEAK_HOOK_FUNCTION)
 
 #undef DEFINE_WEAK_HOOK_FUNCTION
-};
+}
 
 }

--- a/src/kaleidoscope_internal/event_dispatch.h
+++ b/src/kaleidoscope_internal/event_dispatch.h
@@ -28,14 +28,14 @@
 // The EventDispatcher class implements a compile-time loop over all plugins, which
 // calls an event handler on each plugin.
 //
-// Each hook called by the firmware core compiles down to only a single
-// static function call (in class Hooks), rather than one for each plugin.
+// Each hook called by the firmware core compiles down to only a single static
+// function call (in the hooks namespace), rather than one for each plugin.
 //
 // This approach is better than using virtual event handlers in classes
 // derived from kaleidoscope::Plugin because it results in significantly fewer
 // virtual function calls and virtual function tables (vtables).
 //
-// The call to event handlers through kaleidoscope::Hooks and
+// The call to event handlers through kaleidoscope::hooks and
 // kaleidoscope_internal::EventDispatcher is templated to allow for compile time
 // static polymorphisms (plugins' EventHandlers aren't virtual).
 //
@@ -45,12 +45,12 @@
 // The compiler only cares that a method's signature matches, not that the plugin
 // is derived from kaleidoscope::Plugin.
 //
-// Static hook functions inside the Hooks class each use the EventDispatcher
+// Static hook functions inside the hooks namespace each use the EventDispatcher
 // helper class to cast an associated EventHandler on each plugin instance.
 
 
 // This defines an auxiliary class 'EventHandler_Foo' for each hook 'Foo'.
-// Kaleidoscope::Hooks calls the EventDispatcher class, which in turn invokes
+// Kaleidoscope::hooks calls the EventDispatcher class, which in turn invokes
 // the event handler method 'Foo' of each registered plugin with a given
 // set of arguments.
 
@@ -76,13 +76,13 @@
    } 	                                                                    __NL__ \
                                                                           __NL__ \
    namespace kaleidoscope {                                               __NL__ \
-                                                                          __NL__ \
-     EventHandlerResult Hooks::HOOK_NAME SIGNATURE {                      __NL__ \
+   namespace hooks {                                                      __NL__ \
+     EventHandlerResult HOOK_NAME SIGNATURE {                             __NL__ \
         return kaleidoscope_internal::EventDispatcher::template           __NL__ \
         apply<kaleidoscope_internal::EventHandler_ ## HOOK_NAME>          __NL__ \
              ARGS_LIST;                                                   __NL__ \
       }                                                                   __NL__ \
-                                                                          __NL__ \
+   }                                                                      __NL__ \
    }
 
 #define _INLINE_EVENT_HANDLER_FOR_PLUGIN(PLUGIN)                            \

--- a/src/key_events.cpp
+++ b/src/key_events.cpp
@@ -105,7 +105,7 @@ void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
 
   // New event handler interface
   //
-  if (kaleidoscope::Hooks::onKeyswitchEvent(mappedKey, row, col, keyState) != kaleidoscope::EventHandlerResult::OK)
+  if (kaleidoscope::hooks::onKeyswitchEvent(mappedKey, row, col, keyState) != kaleidoscope::EventHandlerResult::OK)
     return;
 
   mappedKey = Layer.eventHandler(mappedKey, row, col, keyState);


### PR DESCRIPTION
We want to allow plugins to have their own hooks, without having to touch the core firmware. For this reason, protecting the hooks via a class and friend declarations does not make sense. Nor does a class, for that matter, as it is not extensible from the outside. A namespace, however, is.

And this is what this change does: turns `kaleidoscope::Hooks` into a namespace called `kaleidoscope::hooks`. This way, plugins can declare new hooks within it, and don't need to sync with core.

Fixes #323.