### PR TITLE
kaleidoscope-builder: Improvements for easier ErgoDox support

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -30,8 +30,7 @@ firmware_size () {
 
     ## This is a terrible hack, please don't hurt me. - algernon
 
-    MAX_PROG_SIZE=28672
-
+    find_max_prog_size
     output="$("$@" | grep "\\(Program\\|Data\\):" | sed -e 's,^,  - ,' && echo)"
 
     PROGSIZE="$(echo "${output}" | grep "Program:" | cut -d: -f2 | awk '{print $1}')"

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -58,7 +58,9 @@ find_device_port() {
 }
 
 reset_device_cmd() {
-    stty -F ${DEVICE_PORT} 1200 hupcl
+    if [ -z ${NO_RESET} ]; then
+        stty -F ${DEVICE_PORT} 1200 hupcl
+    fi
 }
 
 find_bootloader_ports() {

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -26,6 +26,17 @@ fi
 # Shamelessly stolen from git's Makefile
 uname_S=$(uname -s 2>/dev/null || echo not)
 
+find_max_prog_size() {
+    VPIDS=$(${ARDUINO_BUILDER} \
+    -hardware "${ARDUINO_PATH}/hardware" \
+    -hardware "${BOARD_HARDWARE_PATH}" \
+    ${ARDUINO_TOOLS_PARAM} \
+    -tools "${ARDUINO_PATH}/tools-builder" \
+    -fqbn "${FQBN}" \
+    -dump-prefs | grep "upload\.maximum_size=")
+    MAX_PROG_SIZE=${MAX_PROG_SIZE:-$(echo "${VPIDS}" | grep upload.maximum_size | cut -d= -f2)}
+}
+
 find_device_vid_pid() {
     VPIDS=$(${ARDUINO_BUILDER} \
 		-hardware "${ARDUINO_PATH}/hardware" \


### PR DESCRIPTION
This changes a few things around, adding enough knobs so that one can flash an ErgoDox EZ after these are applied.