### PR TITLE
kaleidoscope-builder: Use a stable build directory

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -10,9 +10,11 @@ build_version () {
     GIT_VERSION="$(cd "$(find_sketch)"; git describe --abbrev=4 --dirty --always)"
     LIB_VERSION="$(cd "$(find_sketch)"; (grep version= ../../library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
 
-    BUILD_PATH="${BUILD_PATH:-"$(mktemp -d 2>/dev/null || mktemp -d -t 'build')"}"
+    BUILD_PATH="$(pwd)/_build/"
     OUTPUT_DIR="${OUTPUT_DIR:-output/${LIBRARY}}"
     OUTPUT_PATH="${OUTPUT_PATH:-${SOURCEDIR}/${OUTPUT_DIR}}"
+
+    install -d "${BUILD_PATH}"
 }
 
 build_filenames () {
@@ -203,8 +205,6 @@ compile () {
 
     if [ "${ARDUINO_VERBOSE}" = "-verbose" ]; then
 	      echo "Build artifacts can be found in ${BUILD_PATH}";
-    else
-	      rm -rf "${BUILD_PATH}"
     fi
 }
 
@@ -263,7 +263,7 @@ decompile () {
 }
 
 clean () {
-    rm -rf -- "${OUTPUT_PATH}"
+    rm -rf -- "${OUTPUT_PATH}" "${BUILD_PATH}"
 }
 
 reset_device() {


### PR DESCRIPTION
Use ./_build/ for the build path by default, and do not delete it at the end of compilation, only when doing a clean.

Fixes #315.