### PR TITLE
Update build flag to compile using C++14

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -192,7 +192,7 @@ compile () {
 	      ${EXTRA_BUILDER_ARGS} \
 	      -build-path "${BUILD_PATH}" \
 	      -ide-version "${ARDUINO_IDE_VERSION}" \
-	      -prefs "compiler.cpp.extra_flags=-std=c++11 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
+	      -prefs "compiler.cpp.extra_flags=-std=c++14 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
 	      -warnings all \
         ${ARDUINO_VERBOSE} \
 	      ${ARDUINO_AVR_GCC_PREFIX_PARAM} \


### PR DESCRIPTION
Triggerd by a recent bugfix commit I noticed that Kaleidoscope is build using C++11. I briefly looked for a discussion of this but did not find any. Since the fix is very small, I thought I just push my luck and directly propose an update. I appologise if I missed something here.

I am on Debian Stretch, downloaded somewhen the recent version of ArduinoIDE and build command line only. Using '-std=c++17' was not recognised by avr-g++ but '-std=c++14' was. Thus I chose the latter.

The benefit of this is that it allows some neat new syntax and relaxes the constraints on constexpr functions greatly. Especially the latter could turn out to be very beneficial to get both readable and zero footprint code.