### PR TITLE
Make the V1 plugin API ifdefs broader

### DIFF
--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -3,8 +3,11 @@
 
 namespace kaleidoscope {
 
+#if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API
 Kaleidoscope_::eventHandlerHook Kaleidoscope_::eventHandlers[HOOK_MAX];
 Kaleidoscope_::loopHook Kaleidoscope_::loopHooks[HOOK_MAX];
+#endif
+
 uint32_t Kaleidoscope_::millis_at_cycle_start_;
 
 Kaleidoscope_::Kaleidoscope_(void) {
@@ -115,67 +118,55 @@ Kaleidoscope_ Kaleidoscope;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
+#if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API
 void
 Kaleidoscope_::replaceEventHandlerHook(eventHandlerHook oldHook, eventHandlerHook newHook) {
-#if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API
   for (byte i = 0; i < HOOK_MAX; i++) {
     if (eventHandlers[i] == oldHook) {
       eventHandlers[i] = newHook;
       return;
     }
   }
-#endif
 }
 
 void
 Kaleidoscope_::appendEventHandlerHook(eventHandlerHook hook) {
-#if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API
   replaceEventHandlerHook((eventHandlerHook)NULL, hook);
-#endif
 }
 
 void
 Kaleidoscope_::useEventHandlerHook(eventHandlerHook hook) {
-#if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API
   for (byte i = 0; i < HOOK_MAX; i++) {
     if (eventHandlers[i] == hook)
       return;
   }
   appendEventHandlerHook(hook);
-#endif
 }
 
 void
 Kaleidoscope_::replaceLoopHook(loopHook oldHook, loopHook newHook) {
-#if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API
   for (byte i = 0; i < HOOK_MAX; i++) {
     if (loopHooks[i] == oldHook) {
       loopHooks[i] = newHook;
       return;
     }
   }
-#endif
 }
 
 void
 Kaleidoscope_::appendLoopHook(loopHook hook) {
-#if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API
   replaceLoopHook((loopHook)NULL, hook);
-#endif
 }
 
 void
 Kaleidoscope_::useLoopHook(loopHook hook) {
-#if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API
   for (byte i = 0; i < HOOK_MAX; i++) {
     if (loopHooks[i] == hook)
       return;
   }
   appendLoopHook(hook);
-#endif
 }
 
-#if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API
 void event_handler_hook_use(Kaleidoscope_::eventHandlerHook hook) {
   Kaleidoscope.useEventHandlerHook(hook);
 }

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -162,8 +162,12 @@ class Kaleidoscope_ {
    * functions will, on the other hand, just append the hooks, and not care about
    * protection.
    */
+#if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API
   typedef Key(*eventHandlerHook)(Key mappedKey, byte row, byte col, uint8_t keyState);
+  typedef void (*loopHook)(bool postClear);
+
   static eventHandlerHook eventHandlers[HOOK_MAX];
+  static loopHook loopHooks[HOOK_MAX];
 
   static void replaceEventHandlerHook(eventHandlerHook oldHook, eventHandlerHook newHook)
   DEPRECATED(EVENT_HANDLER_HOOK);
@@ -172,15 +176,13 @@ class Kaleidoscope_ {
   static void useEventHandlerHook(eventHandlerHook hook)
   DEPRECATED(EVENT_HANDLER_HOOK);
 
-  typedef void (*loopHook)(bool postClear);
-  static loopHook loopHooks[HOOK_MAX];
-
   static void replaceLoopHook(loopHook oldHook, loopHook newHook)
   DEPRECATED(LOOP_HOOK);
   static void appendLoopHook(loopHook hook)
   DEPRECATED(LOOP_HOOK);
   static void useLoopHook(loopHook hook)
   DEPRECATED(LOOP_HOOK);
+#endif
 
   static bool focusHook(const char *command);
 
@@ -208,6 +210,7 @@ using kaleidoscope::Kaleidoscope;
                                            "layer.getState")
 
 /* -- DEPRECATED aliases; remove them when there are no more users. -- */
+#if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API
 
 void event_handler_hook_use(kaleidoscope::Kaleidoscope_::eventHandlerHook hook)
 DEPRECATED(EVENT_HANDLER_HOOK);
@@ -217,6 +220,8 @@ DEPRECATED(LOOP_HOOK);
 void __USE_PLUGINS(kaleidoscope::Plugin *plugin, ...) DEPRECATED(USE);
 
 #define USE_PLUGINS(...) __USE_PLUGINS(__VA_ARGS__, NULL)
+
+#endif
 
 // Use this function macro to register plugins with Kaleidoscope's
 // hooking system. The macro accepts a list of plugin instances that


### PR DESCRIPTION
Instead of only having an ifdef in the body of deprecated methods, and leaving it up to the compiler to optimize out the empty & unused, explicitly wrap the declaration of them within an ifdef too. This will make it easier to remove everything V1 at a later point, and we're not at the mercy of the compiler, either.

Fixes #327.