### PR TITLE
Revert "kaleidoscope-builder: Use a stable build directory"

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -10,11 +10,9 @@ build_version () {
     GIT_VERSION="$(cd "$(find_sketch)"; git describe --abbrev=4 --dirty --always)"
     LIB_VERSION="$(cd "$(find_sketch)"; (grep version= ../../library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
 
-    BUILD_PATH="$(pwd)/_build/"
+    BUILD_PATH="${BUILD_PATH:-"$(mktemp -d 2>/dev/null || mktemp -d -t 'build')"}"
     OUTPUT_DIR="${OUTPUT_DIR:-output/${LIBRARY}}"
     OUTPUT_PATH="${OUTPUT_PATH:-${SOURCEDIR}/${OUTPUT_DIR}}"
-
-    install -d "${BUILD_PATH}"
 }
 
 build_filenames () {
@@ -205,6 +203,8 @@ compile () {
 
     if [ "${ARDUINO_VERBOSE}" = "-verbose" ]; then
 	      echo "Build artifacts can be found in ${BUILD_PATH}";
+    else
+	      rm -rf "${BUILD_PATH}"
     fi
 }
 
@@ -263,7 +263,7 @@ decompile () {
 }
 
 clean () {
-    rm -rf -- "${OUTPUT_PATH}" "${BUILD_PATH}"
+    rm -rf -- "${OUTPUT_PATH}"
 }
 
 reset_device() {


### PR DESCRIPTION
Reverts keyboardio/Kaleidoscope#330, because the stable build directory is unreliable, I often get errors, on every second or third compile, along these lines:

```
Building output/Model01-Firmware/Model01-Firmware (0.0.0-gv1.22-15-g33bc) ...
open .../Model01-Firmware/_build/preproc/ctags_target_for_gcc_minus_e.cpp: no such file or directory
.../hardware/keyboardio/avr/build-tools/makefiles//rules.mk:72: recipe for target 'build-all' failed
```

This wastes much more time than it saves *when* it works.