### PR TITLE
Remove some long-deprecated methods and symbols

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -71,41 +71,6 @@ If any of this does not make sense to you, or you have trouble updating your
 .ino sketch, do not hesitate to write us at help@keyboard.io, we can help you
 fix it.
 
-### Sheduled for removal by 2018-05-26
-
-These APIs and functions have been deprecated for a long time, and as far as we
-can tell, aren't used by any third party or user code anymore.
-
-#### Kaleidoscope.setup(KEYMAP_SIZE)
-
-The `Kaleidoscope.setup()` method is still around, and is **not** deprecated,
-but the variant of it that takes a keymap size is, and has been since October
-2017.
-
-Instead, one should use the argument-less `Kaleidoscope.setup()`, and the new
-`KEYMAP()` macros to define a keymap.
-
-#### event_handler_hook_use, loop_hook_use, and USE_PLUGINS
-
-Deprecated in October 2017, these are old aliases that should no longer be in
-use. They were replaced by `Kaleidoscope.useEventHandlerHook`,
-`Kaleidoscope.useLoopHook`, and `Kaleidoscope.use`, respectively.
-
-The replacements themselves are also deprecated - see below -, but their removal
-will come at a later date.
-
-#### MOMENTARY_OFFSET
-
-Deprecated in October 2017, replaced by `LAYER_SHIFT_OFFSET`.
-
-This symbol was meant to be used by plugins, not user code, and as far as we
-know, no third party plugin ever used it.
-
-#### key_was_pressed, key_is_pressed, key_toggled_on, key_toggled_off
-
-Deprecated in July 2017, replaced by `keyWasPressed`, `keyIsPressed`,
-`keyToggledOn`, and `keyToggledOff`, respectively.
-
 ### Sheduled for removal by 2018-07-12
 
 We aim at making a new release by mid-July, and APIs we deprecate now, will be
@@ -173,3 +138,42 @@ public:
 
 Plugins are supposed to implement this new API, and then be initialised via
 `KALEIDOSCOPE_INIT_PLUGINS`.
+
+Deprecated and removed APIs
+---------------------------
+
+### Removed on 2018-06-10 (originally scheduled for 2018-05-27)
+
+These APIs and functions have been deprecated for a long time, and as far as we
+can tell, aren't used by any third party or user code anymore. They were removed
+as of the June 10th, 2018.
+
+#### Kaleidoscope.setup(KEYMAP_SIZE)
+
+The `Kaleidoscope.setup()` method is still around, and is **not** deprecated,
+but the variant of it that takes a keymap size is, and has been since October
+2017.
+
+Instead, one should use the argument-less `Kaleidoscope.setup()`, and the new
+`KEYMAP()` macros to define a keymap.
+
+#### event_handler_hook_use, loop_hook_use, and USE_PLUGINS
+
+Deprecated in October 2017, these are old aliases that should no longer be in
+use. They were replaced by `Kaleidoscope.useEventHandlerHook`,
+`Kaleidoscope.useLoopHook`, and `Kaleidoscope.use`, respectively.
+
+The replacements themselves are also deprecated - see below -, but their removal
+will come at a later date.
+
+#### MOMENTARY_OFFSET
+
+Deprecated in October 2017, replaced by `LAYER_SHIFT_OFFSET`.
+
+This symbol was meant to be used by plugins, not user code, and as far as we
+know, no third party plugin ever used it.
+
+#### key_was_pressed, key_is_pressed, key_toggled_on, key_toggled_off
+
+Deprecated in July 2017, replaced by `keyWasPressed`, `keyIsPressed`,
+`keyToggledOn`, and `keyToggledOff`, respectively.

--- a/src/Kaleidoscope.cpp
+++ b/src/Kaleidoscope.cpp
@@ -166,25 +166,6 @@ Kaleidoscope_::useLoopHook(loopHook hook) {
   }
   appendLoopHook(hook);
 }
-
-void event_handler_hook_use(Kaleidoscope_::eventHandlerHook hook) {
-  Kaleidoscope.useEventHandlerHook(hook);
-}
-
-void loop_hook_use(Kaleidoscope_::loopHook hook) {
-  Kaleidoscope.useLoopHook(hook);
-}
-
-void __USE_PLUGINS(kaleidoscope::Plugin *plugin, ...) {
-  va_list ap;
-
-  Kaleidoscope.use(plugin);
-
-  va_start(ap, plugin);
-  while ((plugin = (kaleidoscope::Plugin *)va_arg(ap, kaleidoscope::Plugin *)) != NULL)
-    Kaleidoscope.use(plugin);
-  va_end(ap);
-}
 #endif
 
 #pragma GCC diagnostic pop // restore diagnostic options

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -68,17 +68,12 @@ static_assert(KALEIDOSCOPE_REQUIRED_API_VERSION == KALEIDOSCOPE_API_VERSION,
               " available, but version " xstr(KALEIDOSCOPE_REQUIRED_API_VERSION) " is required.");
 #endif
 
-const uint8_t KEYMAP_SIZE DEPRECATED(KEYMAP_SIZE) = 0;
-
 namespace kaleidoscope {
 
 class Kaleidoscope_ {
  public:
   Kaleidoscope_(void);
 
-  void setup(const byte keymap_count) DEPRECATED(KEYMAP_SIZE) {
-    setup();
-  }
   void setup(void);
   void loop(void);
 
@@ -208,20 +203,6 @@ using kaleidoscope::Kaleidoscope;
                                            "layer.on\n"             \
                                            "layer.off\n"            \
                                            "layer.getState")
-
-/* -- DEPRECATED aliases; remove them when there are no more users. -- */
-#if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API
-
-void event_handler_hook_use(kaleidoscope::Kaleidoscope_::eventHandlerHook hook)
-DEPRECATED(EVENT_HANDLER_HOOK);
-void loop_hook_use(kaleidoscope::Kaleidoscope_::loopHook hook)
-DEPRECATED(LOOP_HOOK);
-
-void __USE_PLUGINS(kaleidoscope::Plugin *plugin, ...) DEPRECATED(USE);
-
-#define USE_PLUGINS(...) __USE_PLUGINS(__VA_ARGS__, NULL)
-
-#endif
 
 // Use this function macro to register plugins with Kaleidoscope's
 // hooking system. The macro accepts a list of plugin instances that

--- a/src/kaleidoscope_internal/deprecations.h
+++ b/src/kaleidoscope_internal/deprecations.h
@@ -11,10 +11,6 @@
 
 /* Messages */
 
-#define _DEPRECATED_MESSAGE_KEYMAP_SIZE                                    \
-  "Kaleidoscope.setup() does not require KEYMAP_SIZE anymore. It can be\n" \
-  "safely removed."
-
 #define _DEPRECATED_MESSAGE_USE                                                    \
    "Your sketch uses Kaleidoscope.use(), an old-style API to initialize\n"         \
    "plugins. To fix this, you need to modify your .ino sketch file, and\n"         \

--- a/src/key_defs_keymaps.h
+++ b/src/key_defs_keymaps.h
@@ -2,7 +2,6 @@
 
 #include "kaleidoscope_internal/deprecations.h"
 
-static const uint8_t MOMENTARY_OFFSET DEPRECATED(USE_INSTEAD("LAYER_SHIFT_OFFSET")) = 42;
 static const uint8_t LAYER_SHIFT_OFFSET = 42;
 
 #define KEYMAP_0     0

--- a/src/keyswitch_state.h
+++ b/src/keyswitch_state.h
@@ -34,19 +34,3 @@
  *   "key-up" event.
  */
 #define keyToggledOff(keyState) (keyWasPressed(keyState) && ! keyIsPressed(keyState))
-
-
-// Deprecated - Remove once the core has transitioned
-
-inline uint8_t DEPRECATED(USE_INSTEAD("keyWasPressed")) key_was_pressed(uint8_t keyState) {
-  return keyWasPressed(keyState);
-}
-inline uint8_t DEPRECATED(USE_INSTEAD("keyIsPressed")) key_is_pressed(uint8_t keyState) {
-  return keyIsPressed(keyState);
-}
-inline uint8_t DEPRECATED(USE_INSTEAD("keyToggledOn")) key_toggled_on(uint8_t keyState) {
-  return keyToggledOn(keyState);
-}
-inline uint8_t DEPRECATED(USE_INSTEAD("keyToggledOff")) key_toggled_off(uint8_t keyState) {
-  return keyToggledOff(keyState);
-}


### PR DESCRIPTION
As per UPGRADE.md, remove `Kaleidoscope.setup(KEYMAP_SIZE)`, `event_handler_hook_use`, `loop_hook_use`, `USE_PLUGINS`, `MOMENTARY_OFFSET`, `key_was_pressed`, `key_is_pressed`, `key_toggled_on`, and `key_toggled_off`.

These were deprecated between July and October 2017, and have been marked for deletion for over a month.

Also updated UPGRADE.md, moving the section about these to a new, "deprecated and removed" section.