### PR TITLE
Fix the AppSwitcher and Kaleidoscope examples

### DIFF
--- a/examples/AppSwitcher/AppSwitcher.ino
+++ b/examples/AppSwitcher/AppSwitcher.ino
@@ -64,5 +64,6 @@ void setup() {
 }
 
 void loop() {
+  macroAppSwitchLoop();
   Kaleidoscope.loop();
 }

--- a/examples/AppSwitcher/Macros.cpp
+++ b/examples/AppSwitcher/Macros.cpp
@@ -41,11 +41,6 @@ const macro_t *macroAppSwitch(uint8_t keyState) {
   if (keyToggledOff(keyState)) {
     return MACRO(U(Tab), Dr(mod));
   }
-  // Key is not pressed, and was not just released.
-  // if appSwitchActive is true, we continue holding Alt.
-  if (appSwitchActive) {
-    return MACRO(Dr(mod));
-  }
   // otherwise we do nothing
   return MACRO_NONE;
 }
@@ -54,4 +49,16 @@ const macro_t *macroAppCancel(uint8_t keyState) {
   if (keyToggledOn(keyState))
     appSwitchActive = false;
   return MACRO_NONE;
+}
+
+void macroAppSwitchLoop() {
+  Key mod = Key_LeftAlt;
+
+  if (HostOS.os() == H::OSX)
+    mod = Key_LeftGui;
+
+  // if appSwitchActive is true, we continue holding Alt.
+  if (appSwitchActive) {
+    handleKeyswitchEvent(mod, UNKNOWN_KEYSWITCH_LOCATION, IS_PRESSED);
+  }
 }

--- a/examples/AppSwitcher/Macros.h
+++ b/examples/AppSwitcher/Macros.h
@@ -28,3 +28,4 @@ enum {
 
 const macro_t *macroAppSwitch(uint8_t keyState);
 const macro_t *macroAppCancel(uint8_t keyState);
+void macroAppSwitchLoop();

--- a/examples/Kaleidoscope/Kaleidoscope.ino
+++ b/examples/Kaleidoscope/Kaleidoscope.ino
@@ -7,7 +7,7 @@
 #include "Kaleidoscope-MouseKeys.h"
 #include "Kaleidoscope-Macros.h"
 #include "Kaleidoscope-LEDControl.h"
-#include "Kaleidoscope-Numlock.h"
+#include "Kaleidoscope-NumPad.h"
 #include "Kaleidoscope.h"
 
 #include "LED-Off.h"
@@ -87,14 +87,14 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
 KALEIDOSCOPE_INIT_PLUGINS(TestMode,
                           LEDControl, LEDOff,
                           solidRed, solidOrange, solidYellow, solidGreen, solidBlue, solidIndigo, solidViolet,
-                          LEDBreatheEffect, LEDRainbowEffect, LEDChaseEffect, NumLock,
+                          LEDBreatheEffect, LEDRainbowEffect, LEDChaseEffect, NumPad,
                           Macros,
                           MouseKeys);
 
 void setup() {
   Kaleidoscope.setup();
 
-  NumLock.numPadLayer = NUMPAD_KEYMAP;
+  NumPad.numPadLayer = NUMPAD_KEYMAP;
   LEDOff.activate();
 }
 


### PR DESCRIPTION
* The Kaleidoscope example was still using the `Numlock` plugin, move it to `NumPad` instead.
* AppSwitcher relied on events being fired even in the idle case, which is not the case anymore. Move some of the logic to `loop()` to make the example functional again.