### PR TITLE
Add a LIB_PROPERTIES_PATH option to the build system

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -8,7 +8,8 @@ set -e
 
 build_version () {
     GIT_VERSION="$(cd "$(find_sketch)"; git describe --abbrev=4 --dirty --always)"
-    LIB_VERSION="$(cd "$(find_sketch)"; (grep version= ../../library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
+    LIB_PROPERTIES_PATH="${LIB_PROPERTIES_PATH:-"../.."}"
+    LIB_VERSION="$(cd "$(find_sketch)"; (grep version= ${LIB_PROPERTIES_PATH}/library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
 
     BUILD_PATH="${BUILD_PATH:-"$(mktemp -d 2>/dev/null || mktemp -d -t 'build')"}"
     OUTPUT_DIR="${OUTPUT_DIR:-output/${LIBRARY}}"

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -9,7 +9,7 @@ set -e
 build_version () {
     GIT_VERSION="$(cd "$(find_sketch)"; git describe --abbrev=4 --dirty --always)"
     LIB_PROPERTIES_PATH="${LIB_PROPERTIES_PATH:-"../.."}"
-    LIB_VERSION="$(cd "$(find_sketch)"; (grep version= ${LIB_PROPERTIES_PATH}/library.properties 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
+    LIB_VERSION="$(cd "$(find_sketch)"; (grep version= "${LIB_PROPERTIES_PATH}/library.properties" 2>/dev/null || echo version=0.0.0) | cut -d= -f2)-g${GIT_VERSION}"
 
     BUILD_PATH="${BUILD_PATH:-"$(mktemp -d 2>/dev/null || mktemp -d -t 'build')"}"
     OUTPUT_DIR="${OUTPUT_DIR:-output/${LIBRARY}}"


### PR DESCRIPTION
Add a variable to specify where the "library.properties" file can be
found so that the build can include a user-define version number.