### PR TITLE
WIP: EEPROM hooks

### DIFF
--- a/src/kaleidoscope/hooks.h
+++ b/src/kaleidoscope/hooks.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include <EEPROM.h>
 
 namespace kaleidoscope {
 union Key;
@@ -38,7 +39,34 @@ class Hooks {
   friend void ::handleKeyswitchEvent(kaleidoscope::Key mappedKey,
                                      byte row, byte col, uint8_t keyState);
 
- private:
+ public:
+
+  static EventHandlerResult onStorageReport();
+
+  template<typename T>
+  T& getFromStorage(kaleidoscope::Plugin &plugin, uint16_t offset, T& t) {
+    uint16_t plugin_offset = getStorageOffset(plugin);
+    return EEPROM.get(plugin_offset + offset, t);
+  }
+
+  template<typename T>
+  T& getFromStorage(kaleidoscope::Plugin &plugin, T& t) {
+    return getFromStorage(plugin, 0, t);
+  }
+
+  template<typename T>
+  const T& putToStorage(kaleidoscope::Plugin &plugin, uint16_t offset, T& t) {
+    uint16_t plugin_offset = getStorageOffset(plugin);
+    return EEPROM.put(plugin_offset + offset, t);
+  }
+
+  template<typename T>
+  const T& putToStorage(kaleidoscope::Plugin &plugin, T& t) {
+    return putToStorage(plugin, 0, t);
+  }
+
+  template<typename Plugin__>
+  static uint16_t getStorageOffset(Plugin__ &plugin);
 
   // The following private functions are just to be called by classes
   // and functions that are declared as friends above.

--- a/src/kaleidoscope_internal/event_dispatch.h
+++ b/src/kaleidoscope_internal/event_dispatch.h
@@ -22,6 +22,7 @@
 #include "kaleidoscope/hooks.h"
 #include "eventhandler_signature_check.h"
 #include "event_handlers.h"
+#include "storage.h"
 
 // Some words about the design of hook routing:
 //
@@ -108,6 +109,8 @@
   namespace kaleidoscope_internal {                                           __NL__ \
   struct EventDispatcher {                                                    __NL__ \
                                                                               __NL__ \
+    __KALEIDOSCOPE_INIT_STORAGE_PLUGINS(__VA_ARGS__)                          __NL__ \
+                                                                              __NL__ \
     /* Iterate through plugins, calling each one's event handler with      */ __NL__ \
     /* the arguments passed to the hook                                    */ __NL__ \
     template<typename EventHandler__, typename... Args__ >                    __NL__ \
@@ -130,4 +133,5 @@
   /*                                                                       */ __NL__ \
   /* TODO(anyone): Move this somewhere else, outside of _internal, once    */ __NL__ \
   /*               the V1 API is removed.                                  */ __NL__ \
-  _FOR_EACH_EVENT_HANDLER(_REGISTER_EVENT_HANDLER)
+  _FOR_EACH_EVENT_HANDLER(_REGISTER_EVENT_HANDLER)                            __NL__ \
+  _KALEIDOSCOPE_INIT_STORAGE_HANDLERS()

--- a/src/kaleidoscope_internal/storage.h
+++ b/src/kaleidoscope_internal/storage.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#define _INLINE_STORAGE_HANDLER_FOR_PLUGIN(PLUGIN)                                       __NL__ \
+  EventHandler__::call(PLUGIN, current_offset, hook_args...);                            __NL__ \
+  current_offset += PLUGIN.storageSize();
+
+#define _INLINE_STORAGE_OFFSET_COUNTER(PLUGIN)                                           __NL__ \
+  if ((uint16_t)&PLUGIN == (uint16_t)&plugin)                                            __NL__ \
+    return current_offset;                                                               __NL__ \
+  current_offset += PLUGIN.storageSize();
+
+#define __KALEIDOSCOPE_INIT_STORAGE_PLUGINS(...)                                         __NL__ \
+  /* Iterate through plugins, calling onStorageReport for each of them. */               __NL__ \
+  template<typename EventHandler__, typename... Args__ >                                 __NL__ \
+  static kaleidoscope::EventHandlerResult                                                __NL__ \
+  apply_storage(Args__&&... hook_args) {                                                 __NL__ \
+    uint16_t current_offset = 0;                                                         __NL__ \
+    MAP(_INLINE_STORAGE_HANDLER_FOR_PLUGIN, __VA_ARGS__)                                 __NL__ \
+    return kaleidoscope::EventHandlerResult::OK;                                         __NL__ \
+  }                                                                                      __NL__ \
+                                                                                         __NL__ \
+  template<typename EventHandler__, typename Plugin__>                                   __NL__ \
+  static uint16_t apply_offsetCount(Plugin__ &plugin) {                                  __NL__ \
+    uint16_t current_offset = 0;                                                         __NL__ \
+    MAP(_INLINE_STORAGE_OFFSET_COUNTER, __VA_ARGS__)                                     __NL__ \
+    return current_offset;                                                               __NL__ \
+  }
+
+#define _KALEIDOSCOPE_INIT_STORAGE_HANDLERS()                                            __NL__ \
+  namespace kaleidoscope_internal {                                                      __NL__ \
+  struct EventHandler_onStorageReport {                                                  __NL__ \
+    template<typename Plugin__>                                                          __NL__ \
+    static kaleidoscope::EventHandlerResult                                              __NL__ \
+    call(Plugin__ &plugin, uint16_t offset) {                                            __NL__ \
+      if (plugin.storageSize()) {                                                        __NL__ \
+        Serial.print(plugin.name());                                                     __NL__ \
+        Serial.print(" ");                                                               __NL__ \
+        Serial.print(offset, DEC);                                                       __NL__ \
+        Serial.print(" - ");                                                             __NL__ \
+        Serial.println(offset + plugin.storageSize() - 1, DEC);                          __NL__ \
+      }                                                                                  __NL__ \
+      return kaleidoscope::EventHandlerResult::OK;                                       __NL__ \
+    }                                                                                    __NL__ \
+  };                                                                                     __NL__ \
+                                                                                         __NL__ \
+  struct EventHandler_getStorageOffset {                                                 __NL__ \
+    template<typename Plugin__>                                                          __NL__ \
+    static uint16_t                                                                      __NL__ \
+    call(Plugin__ &plugin) {                                                             __NL__ \
+      return plugin.storageSize();                                                       __NL__ \
+    }                                                                                    __NL__ \
+  };                                                                                     __NL__ \
+  }                                                                                      __NL__ \
+                                                                                         __NL__ \
+  namespace kaleidoscope {                                                               __NL__ \
+    EventHandlerResult Hooks::onStorageReport() {                                        __NL__ \
+      return kaleidoscope_internal::EventDispatcher::template                            __NL__ \
+        apply_storage<kaleidoscope_internal::EventHandler_onStorageReport>();            __NL__ \
+    }                                                                                    __NL__ \
+                                                                                         __NL__ \
+    template<typename Plugin__>                                                          __NL__ \
+    uint16_t Hooks::getStorageOffset(Plugin__ &plugin) {                                 __NL__ \
+      return kaleidoscope_internal::EventDispatcher::template                            __NL__ \
+        apply_offsetCount<kaleidoscope_internal::EventHandler_getStorageOffset>(plugin); __NL__ \
+    }                                                                                    __NL__ \
+  }

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -42,6 +42,14 @@ class EventHandlerBasePlugin {
 
   _FOR_EACH_EVENT_HANDLER(DEFINE_AND_IMPLEMENT_EVENT_HANDLER_METHOD)
 
+  const uint16_t storageSize() {
+    return 0;
+  }
+
+  const __FlashStringHelper *name() {
+    return F("<unknown>");
+  }
+
 #undef DEFINE_AND_IMPLEMENT_EVENT_HANDLER_METHOD
 };
 


### PR DESCRIPTION
This implements two new.... hooks. They aren't *technically* hooks, because the plugins themselves implement two other methods: `name()` and `storageSize()`, the new hooks use these two to do their thing.

The new hooks are `onStorageReport()`, which prints a `name start - end` line for each plugin that has a `storageSize()` greater than zero; and `getStorageOffset()`, which returns the offset in EEPROM given to a particular plugin, by iterating over each plugin, and summing up `storageSize()`es up to - but not including - the requested plugin.

On top of these I built `Kaleidoscope.Storage.get()` and `Kaleidoscope.Storage.put()`, which take a plugin, an optional offset, and a struct to read. They're thin mappers around `EEPROM.get()` and `EEPROM.put()`. These will be eventually pushed to the hardware plugins, with these being thin wrappers around those.

All of this is a work in progress, I'd love some feedback on naming, and where to put the `.Storage.get()`/`.Storage.put()` functions.

By the way, the `onStorageReport()` and `getStorageOffset()` hooks are currently public. They'll be made private before finalizing the pull request, but for now, having them public makes testing a little bit easier.