### PR TITLE
Give a nice error message on Kaleidoscope.use() when compiling with V2 API only

### DIFF
--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -140,6 +140,11 @@ class Kaleidoscope_ {
     use(plugins...);
 #pragma GCC diagnostic pop
   }
+#else
+  // NOTE: Do **NOT** remove this when sunsetting the V1 API!
+  inline void use(...) {
+    static_assert(false, _DEPRECATE(_DEPRECATED_MESSAGE_USE));
+  }
 #endif
 
   // ---- hooks ----


### PR DESCRIPTION
In preparation for the sunset of the V1 API, when using the V2 API only, give a nice error message on `Kaleidoscope.use()`, instead of simply not defining it. This makes the upgrade path a little easier.
