### PR TITLE
Fix the way we trigger an error on Kaleidoscope.use() with V2 API

### DIFF
--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -142,8 +142,9 @@ class Kaleidoscope_ {
   }
 #else
   // NOTE: Do **NOT** remove this when sunsetting the V1 API!
-  inline void use(...) {
-    static_assert(false, _DEPRECATE(_DEPRECATED_MESSAGE_USE));
+  template <typename Plugin__>
+  inline void use(Plugin__ first, ...) {
+    static_assert(sizeof(Plugin__) < 0, _DEPRECATE(_DEPRECATED_MESSAGE_USE));
   }
 #endif
 


### PR DESCRIPTION
When using `Kaleidoscope.use()` and the V1 API is disabled, we want to display an error. The current method of doing that is not reliable, it sometimes works, sometimes will error out even when not using `Kaleidoscope.use()`. To fix this, make the assert a tiny bit more complicated, so that the compiler won't act too smart.

(Note: I'm not entirely sure *why* this works, but it appears to do the trick.)