### PR TITLE
clarify what happened to flag B00100000

### DIFF
--- a/src/key_defs.h
+++ b/src/key_defs.h
@@ -79,6 +79,7 @@ typedef kaleidoscope::Key Key_;
 #define RALT_HELD         B00000100
 #define SHIFT_HELD        B00001000
 #define GUI_HELD          B00010000
+// #define IS_MACRO       B00100000  // defined in Kaleidoscope-Macros/src/MacroKeyDefs.h
 #define SYNTHETIC         B01000000
 #define RESERVED          B10000000
 


### PR DESCRIPTION
This is just to clarify to anyone who may be reading the sources as to why B00100000 is missing from the flags defs. Not a big deal but I thought it would be useful…