### PR TITLE
add MILLIS macro

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -18,7 +18,7 @@ easier to use and develop for:
 ### Kaleidoscope.millisAtCycleStart()
 
 Many plugins use timers, and most of them will call `millis()`, which isn't
-wrong, but isn't the most efficient either. While `millis()` isn't terribly
+wrong, but isn't the most efficient way either. While `millis()` isn't terribly
 expensive, it's not cheap either. For most cases, we do not need an exact timer,
 and one updated once per cycle is enough - which is what `.millisAtCycleStart()`
 is. Having a timer that is consistent throughout the whole cycle may also be
@@ -27,6 +27,10 @@ beneficial.
 While `millis()` should continue to work forever, plugins and user code should,
 as a general rule, use `Kaleidoscope.millisAtCycleStart()` rather than
 `millis()`.
+
+To make using this easier, and thus encourage plugin authors to use it, the
+short but capitalized form `MILLIS()` is provided as a synonym for
+`Kaleidoscope.millisAtCycleStart()`.
 
 ### Kaleidoscope.detachFromHost() and Kaleidoscope.attachToHost()
 

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -105,6 +105,7 @@ class Kaleidoscope_ {
    * implies. It is recommended to use this in plugins over millis() unless
    * there is good reason not to.
    */
+#define MILLIS Kaleidoscope.millisAtCycleStart
   static uint32_t millisAtCycleStart() {
     return millis_at_cycle_start_;
   }


### PR DESCRIPTION
I didn't even know of the “`millisAtCyclesStart`” thing till earlier today (or yesterday, I forget).

And to expect plugin authors to use `Kaleidoscope.millisAtCyclesStart()` to be efficient seems… well awkward. I propose adding this macro with the capitalized spelling so that all that people who are ready to be efficient need to do is to select the word `millis` and hit **Ctrl+U** or such in their editor.

IMO the very capitalization is sufficient to indicate that this something different than ordinary Arduino `millis()` but if you want another name to disambiguate better then I'm open to suggestions but obviously they should be short to not defeat the purpose.

Also, we should look into changing standard plugin code to use this where possible because (at least in my case) that is what one reads before writing one's own plugins… As such, Kaleidoscope's README.md does not document any of the methods it provides and one has to read the (well-commented) header files, and I have placed this macro right next to the `millisAtCyclesStart()` definition to guarantee it at least that kind of visibility.