### PR TITLE
appswitcher example: add the line actually needed to make this work!

### DIFF
--- a/examples/AppSwitcher/Macros.cpp
+++ b/examples/AppSwitcher/Macros.cpp
@@ -28,6 +28,7 @@ namespace H = kaleidoscope::hostos;
 static bool appSwitchActive = false;
 
 const macro_t *macroAppSwitch(uint8_t keyState) {
+  appSwitchActive = true;
   Key mod = Key_LeftAlt;
 
   if (HostOS.os() == H::OSX)


### PR DESCRIPTION
The value of `appSwitchActive` is nowhere set to `true` so this example would not work at all!

@algernon Please check.