### PR TITLE
kaleidoscope-builder: Support boards with multiple max sizes

### DIFF
--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -34,7 +34,7 @@ find_max_prog_size() {
     -tools "${ARDUINO_PATH}/tools-builder" \
     -fqbn "${FQBN}" \
     -dump-prefs | grep "upload\.maximum_size=")
-    MAX_PROG_SIZE=${MAX_PROG_SIZE:-$(echo "${VPIDS}" | grep upload.maximum_size | cut -d= -f2)}
+    MAX_PROG_SIZE=${MAX_PROG_SIZE:-$(echo "${VPIDS}" | grep upload.maximum_size | head -n 1 | cut -d= -f2)}
 }
 
 find_device_vid_pid() {


### PR DESCRIPTION
With the Atreus, we have a board that has a different max upload size depending on what MCU is used. Until we figure out how to properly support that in the CLI builder, default to using the first value. That's a reasonable approximation in most cases.