### PR TITLE
.travis.yml: Remove shellcheck from the script step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ install:
   - git clone --depth 1 --recurse-submodules https://github.com/keyboardio/Kaleidoscope-Bundle-Keyboardio hardware/keyboardio
 script:
   - make travis-test BOARD_HARDWARE_PATH=$(pwd)/hardware
-  - shellcheck bin/kaleidoscope-builder
 notifications:
   irc:
     channels:


### PR DESCRIPTION
With keyboardio/Kaleidoscope-Build-Tools#2, it is now done by the `travis-test` target. We still need to install the shellcheck package, however.

Fixes #356.
