### PR TITLE
Declare layer_count extern, so that plugins outside of core can use it too

### DIFF
--- a/src/layers.h
+++ b/src/layers.h
@@ -27,6 +27,7 @@
   const Key keymaps[][ROWS][COLS] PROGMEM = { layers };		\
   uint8_t layer_count = sizeof(keymaps) / sizeof(*keymaps);
 
+extern uint8_t layer_count;
 
 class Layer_ {
  public:


### PR DESCRIPTION
Without declaring it extern, other plugins will not have access to the symbol.
