### PR TITLE
Store key_led_map in PROGMEM

### DIFF
--- a/src/kaleidoscope/hardware/Model01.cpp
+++ b/src/kaleidoscope/hardware/Model01.cpp
@@ -30,7 +30,7 @@ bool Model01::isLEDChanged = true;
 keydata_t Model01::leftHandMask;
 keydata_t Model01::rightHandMask;
 
-static constexpr uint8_t key_led_map[4][16] = {
+static constexpr uint8_t key_led_map[4][16] PROGMEM = {
   {3, 4, 11, 12, 19, 20, 26, 27,     36, 37, 43, 44, 51, 52, 59, 60},
   {2, 5, 10, 13, 18, 21, 25, 28,     35, 38, 42, 45, 50, 53, 58, 61},
   {1, 6, 9, 14, 17, 22, 24, 29,     34, 39, 41, 46, 49, 54, 57, 62},
@@ -104,11 +104,11 @@ void Model01::setCrgbAt(uint8_t i, cRGB crgb) {
 }
 
 void Model01::setCrgbAt(byte row, byte col, cRGB color) {
-  setCrgbAt(key_led_map[row][col], color);
+  setCrgbAt(getLedIndex(row, col), color);
 }
 
 uint8_t Model01::getLedIndex(byte row, byte col) {
-  return key_led_map[row][col];
+  return pgm_read_byte(&(key_led_map[row][col]));
 }
 
 cRGB Model01::getCrgbAt(uint8_t i) {


### PR DESCRIPTION
This saves 64 bytes of SRAM, but maybe it's slower.

Originally by @gedankenexperimenter, as keyboardio/Kaleidoscope-Hardware-Model01#17.