### PR TITLE
LEDs: Guard a few places with #if LED_COUNT > 0

### DIFF
--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -109,9 +109,11 @@ void LEDControl::set_all_leds_to(uint8_t r, uint8_t g, uint8_t b) {
 }
 
 void LEDControl::set_all_leds_to(cRGB color) {
+#if LED_COUNT > 0
   for (uint8_t i = 0; i < LED_COUNT; i++) {
     setCrgbAt(i, color);
   }
+#endif
 }
 
 void LEDControl::setCrgbAt(uint8_t i, cRGB crgb) {
@@ -248,6 +250,7 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
     break;
   }
   case THEME: {
+#if LED_COUNT > 0
     if (Serial.peek() == '\n') {
       for (uint8_t idx = 0; idx < LED_COUNT; idx++) {
         cRGB c = ::LEDControl.getCrgbAt(idx);
@@ -268,6 +271,7 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
       ::LEDControl.setCrgbAt(idx, color);
       idx++;
     }
+#endif
     break;
   }
   }

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
@@ -19,6 +19,7 @@
 namespace kaleidoscope {
 namespace plugin {
 void LEDChaseEffect::update(void) {
+#if LED_COUNT > 0
   // Check to see if it's time to change the positions of the red and blue lights
   if (current_chase_counter++ < chase_threshold) {
     return;
@@ -58,6 +59,7 @@ void LEDChaseEffect::update(void) {
   ::LEDControl.setCrgbAt(pos, {0, 0, 255});
   if (pos2 < LED_COUNT)
     ::LEDControl.setCrgbAt(pos2, {255, 0, 0});
+#endif
 }
 
 }

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
@@ -48,6 +48,7 @@ void LEDRainbowEffect::update_delay(byte delay) {
 // ---------
 
 void LEDRainbowWaveEffect::update(void) {
+#if LED_COUNT > 0
   uint16_t now = millis();
   if ((now - rainbow_last_update) < rainbow_update_delay) {
     return;
@@ -67,6 +68,7 @@ void LEDRainbowWaveEffect::update(void) {
   if (rainbow_hue >= 255) {
     rainbow_hue -= 255;
   }
+#endif
 }
 
 void LEDRainbowWaveEffect::brightness(byte brightness) {


### PR DESCRIPTION
For keyboards without LEDs, `LED_COUNT` is set to zero. Some code assumed it to be non-zero, which worked fine while they were separate plugins (they weren't included, so no compilation happened), but now that we're a monorepo, these get compiled anyway, and emit warnings for these keyboards.

Guard these places with `#if LED_COUNT > 0 ... #endif` to silence the warnings. The rest of the code isn't guarded in any way, because we still expect people not to include LED plugins non LED-less keyboards.

This may not be the best solution, but it is one of the most straightforward ones.

Fixes #385.