### PR TITLE
hardware: ROWS, COLS, LED_COUNT and a bit of int8_t

### DIFF
--- a/src/kaleidoscope/Kaleidoscope.h
+++ b/src/kaleidoscope/Kaleidoscope.h
@@ -97,6 +97,8 @@ class Kaleidoscope_ {
   void setup(void);
   void loop(void);
 
+  static constexpr bool has_leds = (KeyboardHardware.led_count > 0);
+
   /** Detaching from / attaching to the host.
    *
    * These two functions wrap the hardware plugin's similarly named functions.

--- a/src/kaleidoscope/Kaleidoscope.h
+++ b/src/kaleidoscope/Kaleidoscope.h
@@ -37,6 +37,13 @@ void setup();
 #include <stdint.h>
 
 #include KALEIDOSCOPE_HARDWARE_H
+
+extern HARDWARE_IMPLEMENTATION KeyboardHardware;
+
+#define ROWS (KeyboardHardware.matrix_rows)
+#define COLS (KeyboardHardware.matrix_columns)
+#define LED_COUNT (KeyboardHardware.led_count)
+
 #include "kaleidoscope/key_events.h"
 #include "kaleidoscope/hid.h"
 #include "kaleidoscope/layers.h"
@@ -46,8 +53,6 @@ void setup();
 #include "kaleidoscope/plugin.h"
 
 #define HOOK_MAX 64
-
-extern HARDWARE_IMPLEMENTATION KeyboardHardware;
 
 #ifndef VERSION
 #define VERSION "locally-built"

--- a/src/kaleidoscope/hardware/Atreus.h
+++ b/src/kaleidoscope/hardware/Atreus.h
@@ -48,16 +48,16 @@ class Atreus {
 
   static constexpr byte matrix_columns = 11;
   static constexpr byte matrix_rows = 4;
-  static constexpr uint8_t led_count = 0;
+  static constexpr int8_t led_count = 0;
 
   void syncLeds(void) {}
   void setCrgbAt(byte row, byte col, cRGB color) {}
-  void setCrgbAt(uint8_t i, cRGB crgb) {}
-  cRGB getCrgbAt(uint8_t i) {
+  void setCrgbAt(int8_t i, cRGB crgb) {}
+  cRGB getCrgbAt(int8_t i) {
     return CRGB(0, 0, 0);
   }
-  uint8_t getLedIndex(byte row, byte col) {
-    return 0;
+  int8_t getLedIndex(byte row, byte col) {
+    return -1;
   }
 
   void scanMatrix(void);

--- a/src/kaleidoscope/hardware/Atreus.h
+++ b/src/kaleidoscope/hardware/Atreus.h
@@ -37,10 +37,6 @@ struct cRGB {
   uint8_t r, g, b;
 };
 
-#define COLS 11
-#define ROWS 4
-#define LED_COUNT 0
-
 #define CRGB(r,g,b) (cRGB){b, g, r}
 
 namespace kaleidoscope {
@@ -49,6 +45,10 @@ namespace hardware {
 class Atreus {
  public:
   Atreus(void) {}
+
+  static constexpr byte matrix_columns = 11;
+  static constexpr byte matrix_rows = 4;
+  static constexpr uint8_t led_count = 0;
 
   void syncLeds(void) {}
   void setCrgbAt(byte row, byte col, cRGB color) {}
@@ -127,16 +127,16 @@ class Atreus {
   static uint8_t debounce;
 
  private:
-  static uint16_t previousKeyState_[ROWS];
-  static uint16_t keyState_[ROWS];
-  static uint16_t masks_[ROWS];
+  static uint16_t previousKeyState_[matrix_rows];
+  static uint16_t keyState_[matrix_rows];
+  static uint16_t masks_[matrix_rows];
 
   static void readMatrixRow(uint8_t row);
   static uint16_t readCols();
   static void selectRow(uint8_t row);
   static void unselectRow(uint8_t row);
 
-  static uint8_t debounce_matrix_[ROWS][COLS];
+  static uint8_t debounce_matrix_[matrix_rows][matrix_columns];
   static uint16_t debounceMaskForRow(uint8_t row);
   static void debounceRow(uint16_t change, uint8_t row);
 };
@@ -183,7 +183,7 @@ class Atreus {
  * user-facing code.
  */
 constexpr byte keyIndex(byte row, byte col) {
-  return row * COLS + col + 1;
+  return row * kaleidoscope::hardware::Atreus::matrix_columns + col + 1;
 }
 
 constexpr byte R0C0  = keyIndex(0, 0);

--- a/src/kaleidoscope/hardware/ErgoDox.h
+++ b/src/kaleidoscope/hardware/ErgoDox.h
@@ -40,10 +40,6 @@ struct cRGB {
   uint8_t r, g, b;
 };
 
-#define COLS 6
-#define ROWS 14
-#define LED_COUNT 0
-
 #define CRGB(r,g,b) (cRGB){b, g, r}
 
 namespace kaleidoscope {
@@ -52,6 +48,10 @@ namespace hardware {
 class ErgoDox {
  public:
   ErgoDox(void) {}
+
+  static constexpr byte matrix_columns = 6;
+  static constexpr byte matrix_rows = 14;
+  static constexpr uint8_t led_count = 0;
 
   void syncLeds(void) {}
   void setCrgbAt(byte row, byte col, cRGB color) {}
@@ -135,10 +135,10 @@ class ErgoDox {
 
  private:
   static ErgoDoxScanner scanner_;
-  static uint8_t previousKeyState_[ROWS];
-  static uint8_t keyState_[ROWS];
-  static uint8_t masks_[ROWS];
-  static uint8_t debounce_matrix_[ROWS][COLS];
+  static uint8_t previousKeyState_[matrix_rows];
+  static uint8_t keyState_[matrix_rows];
+  static uint8_t masks_[matrix_rows];
+  static uint8_t debounce_matrix_[matrix_rows][matrix_columns];
 
   static uint8_t debounceMaskForRow(uint8_t row);
   static void debounceRow(uint8_t change, uint8_t row);
@@ -196,7 +196,7 @@ class ErgoDox {
  * user-facing code.
  */
 constexpr byte keyIndex(byte row, byte col) {
-  return row * COLS + col + 1;
+  return row * kaleidoscope::hardware::ErgoDox::matrix_columns + col + 1;
 }
 
 constexpr byte R0C0  = keyIndex(0, 0);

--- a/src/kaleidoscope/hardware/ErgoDox.h
+++ b/src/kaleidoscope/hardware/ErgoDox.h
@@ -51,16 +51,16 @@ class ErgoDox {
 
   static constexpr byte matrix_columns = 6;
   static constexpr byte matrix_rows = 14;
-  static constexpr uint8_t led_count = 0;
+  static constexpr int8_t led_count = 0;
 
   void syncLeds(void) {}
   void setCrgbAt(byte row, byte col, cRGB color) {}
-  void setCrgbAt(uint8_t i, cRGB crgb) {}
-  cRGB getCrgbAt(uint8_t i) {
+  void setCrgbAt(int8_t i, cRGB crgb) {}
+  cRGB getCrgbAt(int8_t i) {
     return CRGB(0, 0, 0);
   }
-  uint8_t getLedIndex(byte row, byte col) {
-    return 0;
+  int8_t getLedIndex(byte row, byte col) {
+    return -1;
   }
 
   void scanMatrix(void);

--- a/src/kaleidoscope/hardware/Model01.cpp
+++ b/src/kaleidoscope/hardware/Model01.cpp
@@ -30,7 +30,7 @@ bool Model01::isLEDChanged = true;
 keydata_t Model01::leftHandMask;
 keydata_t Model01::rightHandMask;
 
-static constexpr uint8_t key_led_map[4][16] PROGMEM = {
+static constexpr int8_t key_led_map[4][16] PROGMEM = {
   {3, 4, 11, 12, 19, 20, 26, 27,     36, 37, 43, 44, 51, 52, 59, 60},
   {2, 5, 10, 13, 18, 21, 25, 28,     35, 38, 42, 45, 50, 53, 58, 61},
   {1, 6, 9, 14, 17, 22, 24, 29,     34, 39, 41, 46, 49, 54, 57, 62},
@@ -85,7 +85,7 @@ void Model01::setup(void) {
 }
 
 
-void Model01::setCrgbAt(uint8_t i, cRGB crgb) {
+void Model01::setCrgbAt(int8_t i, cRGB crgb) {
   if (i < 32) {
     cRGB oldColor = getCrgbAt(i);
     isLEDChanged |= !(oldColor.r == crgb.r && oldColor.g == crgb.g && oldColor.b == crgb.b);
@@ -107,11 +107,11 @@ void Model01::setCrgbAt(byte row, byte col, cRGB color) {
   setCrgbAt(getLedIndex(row, col), color);
 }
 
-uint8_t Model01::getLedIndex(byte row, byte col) {
+int8_t Model01::getLedIndex(byte row, byte col) {
   return pgm_read_byte(&(key_led_map[row][col]));
 }
 
-cRGB Model01::getCrgbAt(uint8_t i) {
+cRGB Model01::getCrgbAt(int8_t i) {
   if (i < 32) {
     return leftHand.ledData.leds[i];
   } else if (i < 64) {

--- a/src/kaleidoscope/hardware/Model01.h
+++ b/src/kaleidoscope/hardware/Model01.h
@@ -38,13 +38,13 @@ class Model01 {
 
   static constexpr byte matrix_rows = 4;
   static constexpr byte matrix_columns = 16;
-  static constexpr uint8_t led_count = 64;
+  static constexpr int8_t led_count = 64;
 
   void syncLeds(void);
   void setCrgbAt(byte row, byte col, cRGB color);
-  void setCrgbAt(uint8_t i, cRGB crgb);
-  cRGB getCrgbAt(uint8_t i);
-  uint8_t getLedIndex(byte row, byte col);
+  void setCrgbAt(int8_t i, cRGB crgb);
+  cRGB getCrgbAt(int8_t i);
+  int8_t getLedIndex(byte row, byte col);
 
   void scanMatrix(void);
   void readMatrix(void);

--- a/src/kaleidoscope/hardware/Model01.h
+++ b/src/kaleidoscope/hardware/Model01.h
@@ -27,9 +27,6 @@
 
 #include "kaleidoscope/macro_helpers.h"
 
-#define COLS 16
-#define ROWS 4
-
 #define CRGB(r,g,b) (cRGB){b, g, r}
 
 namespace kaleidoscope {
@@ -38,6 +35,11 @@ namespace hardware {
 class Model01 {
  public:
   Model01(void);
+
+  static constexpr byte matrix_rows = 4;
+  static constexpr byte matrix_columns = 16;
+  static constexpr uint8_t led_count = 64;
+
   void syncLeds(void);
   void setCrgbAt(byte row, byte col, cRGB color);
   void setCrgbAt(uint8_t i, cRGB crgb);
@@ -49,7 +51,6 @@ class Model01 {
   void actOnMatrixScan(void);
   void setup();
   void rebootBootloader();
-
 
   /** Detaching from / attaching to the host.
    *
@@ -147,7 +148,7 @@ class Model01 {
  * user-facing code.
  */
 constexpr byte keyIndex(byte row, byte col) {
-  return row * COLS + col + 1;
+  return row * kaleidoscope::hardware::Model01::matrix_columns + col + 1;
 }
 
 constexpr byte R0C0  = keyIndex(0, 0);
@@ -215,9 +216,6 @@ constexpr byte R3C12 = keyIndex(3, 12);
 constexpr byte R3C13 = keyIndex(3, 13);
 constexpr byte R3C14 = keyIndex(3, 14);
 constexpr byte R3C15 = keyIndex(3, 15);
-
-
-#define LED_COUNT 64
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 

--- a/src/kaleidoscope/plugin/Colormap.cpp
+++ b/src/kaleidoscope/plugin/Colormap.cpp
@@ -39,13 +39,16 @@ void ColormapEffect::max_layers(uint8_t max_) {
 }
 
 void ColormapEffect::onActivate(void) {
+  if (!Kaleidoscope.has_leds)
+    return;
+
   last_highest_layer_ = Layer.top();
   if (last_highest_layer_ <= max_layers_)
     ::LEDPaletteTheme.updateHandler(map_base_, last_highest_layer_);
 }
 
 void ColormapEffect::update(void) {
-  if (Layer.top() == last_highest_layer_)
+  if (!Kaleidoscope.has_leds || Layer.top() == last_highest_layer_)
     return;
 
   onActivate();

--- a/src/kaleidoscope/plugin/FingerPainter.cpp
+++ b/src/kaleidoscope/plugin/FingerPainter.cpp
@@ -47,7 +47,7 @@ void FingerPainter::toggle(void) {
 }
 
 EventHandlerResult FingerPainter::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
-  if (!edit_mode_)
+  if (!Kaleidoscope.has_leds || !edit_mode_)
     return EventHandlerResult::OK;
 
   if (!keyToggledOn(key_state)) {

--- a/src/kaleidoscope/plugin/Heatmap.cpp
+++ b/src/kaleidoscope/plugin/Heatmap.cpp
@@ -125,6 +125,9 @@ void Heatmap::resetMap(void) {
 }
 
 EventHandlerResult Heatmap::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
+  if (!Kaleidoscope.has_leds)
+    return EventHandlerResult::OK;
+
   // this methode is called frequently by Kaleidoscope
   // even if the module isn't activated
 
@@ -155,6 +158,9 @@ EventHandlerResult Heatmap::onKeyswitchEvent(Key &mapped_key, byte row, byte col
 }
 
 EventHandlerResult Heatmap::beforeEachCycle() {
+  if (!Kaleidoscope.has_leds)
+    return EventHandlerResult::OK;
+
   // this methode is called frequently by Kaleidoscope
   // even if the module isn't activated
 
@@ -171,6 +177,9 @@ EventHandlerResult Heatmap::beforeEachCycle() {
 }
 
 void Heatmap::update(void) {
+  if (!Kaleidoscope.has_leds)
+    return;
+
   // this methode is called frequently by the LEDControl::loopHook
 
   // do nothing if we didn't reach next_heatmap_comp_time_ yet

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -29,6 +29,9 @@ cRGB ActiveModColorEffect::highlight_color = (cRGB) {
 cRGB ActiveModColorEffect::sticky_color = CRGB(0xff, 0x00, 0x00);
 
 EventHandlerResult ActiveModColorEffect::beforeReportingState() {
+  if (!Kaleidoscope.has_leds)
+    return EventHandlerResult::OK;
+
   for (byte r = 0; r < ROWS; r++) {
     for (byte c = 0; c < COLS; c++) {
       Key k = Layer.lookupOnActiveLayer(r, c);

--- a/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
@@ -64,6 +64,9 @@ static const uint16_t alphabet[] PROGMEM = {
 cRGB AlphaSquare::color = {0x80, 0x80, 0x80};
 
 void AlphaSquare::display(Key key, uint8_t row, uint8_t col, cRGB key_color) {
+  if (!Kaleidoscope.has_leds)
+    return;
+
   if (key < Key_A || key > Key_0)
     return;
 
@@ -78,6 +81,9 @@ void AlphaSquare::display(Key key, uint8_t row, uint8_t col) {
 }
 
 void AlphaSquare::display(uint16_t symbol, uint8_t row, uint8_t col, cRGB key_color) {
+  if (!Kaleidoscope.has_leds)
+    return;
+
   for (uint8_t r = 0; r < 4; r++) {
     for (uint8_t c = 0; c < 4; c++) {
       uint8_t pixel = bitRead(symbol, r * 4 + c);

--- a/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
@@ -25,6 +25,9 @@ uint32_t AlphaSquareEffect::end_time_left_, AlphaSquareEffect::end_time_right_;
 Key AlphaSquareEffect::last_key_left_, AlphaSquareEffect::last_key_right_;
 
 void AlphaSquareEffect::update(void) {
+  if (!Kaleidoscope.has_leds)
+    return;
+
   if (end_time_left_ && millis() > end_time_left_) {
     ::AlphaSquare.clear(last_key_left_);
     end_time_left_ = 0;
@@ -36,6 +39,9 @@ void AlphaSquareEffect::update(void) {
 }
 
 EventHandlerResult AlphaSquareEffect::onKeyswitchEvent(Key &mappedKey, byte row, byte col, uint8_t keyState) {
+  if (!Kaleidoscope.has_leds)
+    return EventHandlerResult::OK;
+
   if (::LEDControl.get_mode() != &::AlphaSquareEffect)
     return EventHandlerResult::OK;
 

--- a/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -37,6 +37,9 @@ uint16_t LEDPaletteTheme::reserveThemes(uint8_t max_themes) {
 }
 
 void LEDPaletteTheme::updateHandler(uint16_t theme_base, uint8_t theme) {
+  if (!Kaleidoscope.has_leds)
+    return;
+
   uint16_t map_base = theme_base + (theme * ROWS * COLS / 2);
 
   for (uint16_t pos = 0; pos < ROWS * COLS; pos++) {
@@ -46,6 +49,9 @@ void LEDPaletteTheme::updateHandler(uint16_t theme_base, uint8_t theme) {
 }
 
 void LEDPaletteTheme::refreshAt(uint16_t theme_base, uint8_t theme, byte row, byte col) {
+  if (!Kaleidoscope.has_leds)
+    return;
+
   uint16_t map_base = theme_base + (theme * ROWS * COLS / 2);
   uint16_t pos = KeyboardHardware.getLedIndex(row, col);
 
@@ -94,6 +100,9 @@ void LEDPaletteTheme::updateColorIndexAtPosition(uint16_t map_base, uint16_t pos
 }
 
 EventHandlerResult LEDPaletteTheme::onFocusEvent(const char *command) {
+  if (!Kaleidoscope.has_leds)
+    return EventHandlerResult::OK;
+
   const char *cmd = PSTR("palette");
 
   if (::Focus.handleHelp(command, cmd))
@@ -135,6 +144,9 @@ EventHandlerResult LEDPaletteTheme::themeFocusEvent(const char *command,
     const char *expected_command,
     uint16_t theme_base,
     uint8_t max_themes) {
+  if (!Kaleidoscope.has_leds)
+    return EventHandlerResult::OK;
+
   if (::Focus.handleHelp(command, expected_command))
     return EventHandlerResult::OK;
 

--- a/src/kaleidoscope/plugin/LED-Stalker.cpp
+++ b/src/kaleidoscope/plugin/LED-Stalker.cpp
@@ -33,6 +33,9 @@ void StalkerEffect::onActivate(void) {
 }
 
 EventHandlerResult StalkerEffect::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState) {
+  if (!Kaleidoscope.has_leds)
+    return EventHandlerResult::OK;
+
   if (row >= ROWS || col >= COLS)
     return EventHandlerResult::OK;
 
@@ -44,6 +47,9 @@ EventHandlerResult StalkerEffect::onKeyswitchEvent(Key &mapped_key, byte row, by
 }
 
 void StalkerEffect::update(void) {
+  if (!Kaleidoscope.has_leds)
+    return;
+
   if (!variant)
     return;
 

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -101,6 +101,9 @@ int8_t LEDControl::mode_add(LEDMode *mode) {
 }
 
 void LEDControl::set_all_leds_to(uint8_t r, uint8_t g, uint8_t b) {
+  if (!Kaleidoscope.has_leds)
+    return;
+
   cRGB color;
   color.r = r;
   color.g = g;
@@ -183,6 +186,9 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
     AT,
     THEME,
   } subCommand;
+
+  if (!Kaleidoscope.has_leds)
+    return EventHandlerResult::OK;
 
   if (::Focus.handleHelp(command, PSTR("led.at\n"
                                        "led.setAll\n"

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -112,12 +112,12 @@ void LEDControl::set_all_leds_to(uint8_t r, uint8_t g, uint8_t b) {
 }
 
 void LEDControl::set_all_leds_to(cRGB color) {
-  for (uint8_t i = 0; i < LED_COUNT; i++) {
+  for (int8_t i = 0; i < LED_COUNT; i++) {
     setCrgbAt(i, color);
   }
 }
 
-void LEDControl::setCrgbAt(uint8_t i, cRGB crgb) {
+void LEDControl::setCrgbAt(int8_t i, cRGB crgb) {
   KeyboardHardware.setCrgbAt(i, crgb);
 }
 
@@ -125,7 +125,7 @@ void LEDControl::setCrgbAt(byte row, byte col, cRGB color) {
   KeyboardHardware.setCrgbAt(row, col, color);
 }
 
-cRGB LEDControl::getCrgbAt(uint8_t i) {
+cRGB LEDControl::getCrgbAt(int8_t i) {
   return KeyboardHardware.getCrgbAt(i);
 }
 
@@ -255,7 +255,7 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
   }
   case THEME: {
     if (Serial.peek() == '\n') {
-      for (uint8_t idx = 0; idx < LED_COUNT; idx++) {
+      for (int8_t idx = 0; idx < LED_COUNT; idx++) {
         cRGB c = ::LEDControl.getCrgbAt(idx);
 
         ::Focus.printColor(c.r, c.g, c.b);
@@ -265,7 +265,7 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
       break;
     }
 
-    uint8_t idx = 0;
+    int8_t idx = 0;
     while (idx < LED_COUNT && Serial.peek() != '\n') {
       cRGB color;
 

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -139,9 +139,9 @@ class LEDControl : public kaleidoscope::Plugin {
 
   static int8_t mode_add(LEDMode *mode);
 
-  static void setCrgbAt(uint8_t i, cRGB crgb);
+  static void setCrgbAt(int8_t i, cRGB crgb);
   static void setCrgbAt(byte row, byte col, cRGB color);
-  static cRGB getCrgbAt(uint8_t i);
+  static cRGB getCrgbAt(int8_t i);
   static void syncLeds(void);
 
   static void set_all_leds_to(uint8_t r, uint8_t g, uint8_t b);

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -109,10 +109,16 @@ class LEDControl : public kaleidoscope::Plugin {
   static void prev_mode(void);
   static void setup(void);
   static void update(void) {
+    if (!Kaleidoscope.has_leds)
+      return;
+
     if (modes[mode])
       modes[mode]->update();
   }
   static void refreshAt(byte row, byte col) {
+    if (!Kaleidoscope.has_leds)
+      return;
+
     if (modes[mode])
       modes[mode]->refreshAt(row, col);
   }
@@ -120,6 +126,9 @@ class LEDControl : public kaleidoscope::Plugin {
   static uint8_t get_mode_index();
   static LEDMode *get_mode();
   static void refreshAll() {
+    if (!Kaleidoscope.has_leds)
+      return;
+
     if (paused)
       return;
 

--- a/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
@@ -45,6 +45,9 @@ EventHandlerResult BootAnimationEffect::onSetup() {
 }
 
 EventHandlerResult BootAnimationEffect::afterEachCycle() {
+  if (!Kaleidoscope.has_leds)
+    return EventHandlerResult::OK;
+
   //If already done or we're not in a ready state, bail
   if (done_) {
     return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
@@ -61,6 +61,9 @@ void BootGreetingEffect::findLed(void) {
 }
 
 EventHandlerResult BootGreetingEffect::afterEachCycle() {
+  if (!Kaleidoscope.has_leds)
+    return EventHandlerResult::OK;
+
   //If already done or we're not in a ready state, bail
   if (done_) {
     return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/LEDEffect-Breathe.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Breathe.cpp
@@ -21,6 +21,9 @@
 namespace kaleidoscope {
 namespace plugin {
 void LEDBreatheEffect::update(void) {
+  if (!Kaleidoscope.has_leds)
+    return;
+
   uint16_t now = Kaleidoscope.millisAtCycleStart();
   if ((now - last_update_) < UPDATE_INTERVAL)
     return;

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
@@ -30,7 +30,7 @@ void LEDChaseEffect::update(void) {
 
   // The red LED is at `pos`; the blue one follows behind. `chase_sign` is either +1 or
   // -1; `chase_pixels` is the gap between them.
-  byte pos2 = pos - (chase_sign * chase_pixels);
+  int8_t pos2 = pos - (chase_sign * chase_pixels);
 
   // First, we turn off the LEDs that were turned on in the previous update. `pos` is
   // always in the valid range (0 <= pos < LED_COUNT), but after it changes direction, for

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
@@ -19,6 +19,9 @@
 namespace kaleidoscope {
 namespace plugin {
 void LEDChaseEffect::update(void) {
+  if (!Kaleidoscope.has_leds)
+    return;
+
   // Check to see if it's time to change the positions of the red and blue lights
   if (current_chase_counter++ < chase_threshold) {
     return;

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.h
@@ -28,7 +28,7 @@ class LEDChaseEffect : public LEDMode {
   void update(void) final;
 
  private:
-  uint8_t pos = 0;
+  int8_t pos = 0;
   int8_t chase_sign = 1; //negative values when it's going backwar
   uint8_t chase_pixels = 5;
   uint8_t current_chase_counter = 0;

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
@@ -20,6 +20,9 @@ namespace kaleidoscope {
 namespace plugin {
 
 void LEDRainbowEffect::update(void) {
+  if (!Kaleidoscope.has_leds)
+    return;
+
   uint16_t now = millis();
   if ((now - rainbow_last_update) < rainbow_update_delay) {
     return;
@@ -48,6 +51,9 @@ void LEDRainbowEffect::update_delay(byte delay) {
 // ---------
 
 void LEDRainbowWaveEffect::update(void) {
+  if (!Kaleidoscope.has_leds)
+    return;
+
   uint16_t now = millis();
   if ((now - rainbow_last_update) < rainbow_update_delay) {
     return;

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
@@ -61,7 +61,7 @@ void LEDRainbowWaveEffect::update(void) {
     rainbow_last_update = now;
   }
 
-  for (uint8_t i = 0; i < LED_COUNT; i++) {
+  for (int8_t i = 0; i < LED_COUNT; i++) {
     uint16_t key_hue = rainbow_hue + 16 * (i / 4);
     if (key_hue >= 255)          {
       key_hue -= 255;


### PR DESCRIPTION
The ultimate goal of this pull request was to eliminate the warnings emitted for boards with no LEDs. To achieve this, we changed the led index type from `uint8_t` to `int8_t`. But while there, the code has been cleaned up a little, by moving `ROWS`, `COLS` and `LED_COUNT` into the hardware classes, with the `#define`'d names referencing those.

Furthermore, to make sure that the LED code does not cause any issues when included into boards with no LEDs, the code has been augmented with `if (!Kaleidoscope.has_leds) return;` -like constructs, so that they bail out early on led-less keyboards.

This fixed #385.