### PR TITLE
OneShot: Fix EscapeOneShot so that it cancels stickies too

### DIFF
--- a/src/kaleidoscope/plugin/Escape-OneShot.cpp
+++ b/src/kaleidoscope/plugin/Escape-OneShot.cpp
@@ -28,8 +28,9 @@ EventHandlerResult EscapeOneShot::onKeyswitchEvent(Key &mapped_key, byte row, by
       !keyToggledOn(keyState))
     return EventHandlerResult::OK;
 
-  if (!::OneShot.isActive() || ::OneShot.isPressed())
+  if ((!::OneShot.isActive() || ::OneShot.isPressed()) && !::OneShot.isSticky()) {
     return EventHandlerResult::OK;
+  }
 
   KeyboardHardware.maskKey(row, col);
 

--- a/src/kaleidoscope/plugin/OneShot.h
+++ b/src/kaleidoscope/plugin/OneShot.h
@@ -37,6 +37,9 @@ class OneShot : public kaleidoscope::Plugin {
   static bool isPressed() {
     return !!pressed_state_.all;
   }
+  static bool isSticky() {
+    return !!sticky_state_.all;
+  }
   static bool isActive(Key key);
   static bool isSticky(Key key);
   static void cancel(bool with_stickies);


### PR DESCRIPTION
EscapeOneShot needs to stop bailing out early when a oneshot is pressed (sticky appears pressed), and continue with its process if there's a sticky oneshot. This makes stickies cancelable via the EscapeOneShot plugin.

For this to work, OneShot needed an `.isSticky()` method, much like `.isActive()` and `.isPressed()`.

Fixes #413 and likely addresses part of #408 too.