### PR TITLE
Remove now-obsolete idle checks from a few plugins

### DIFF
--- a/src/kaleidoscope/plugin/Leader.cpp
+++ b/src/kaleidoscope/plugin/Leader.cpp
@@ -85,13 +85,6 @@ EventHandlerResult Leader::onKeyswitchEvent(Key &mapped_key, byte row, byte col,
   if (keyState & INJECTED)
     return EventHandlerResult::OK;
 
-  if (!keyIsPressed(keyState) && !keyWasPressed(keyState)) {
-    if (isLeader(mapped_key)) {
-      return EventHandlerResult::EVENT_CONSUMED;
-    }
-    return EventHandlerResult::OK;
-  }
-
   if (!isActive() && !isLeader(mapped_key))
     return EventHandlerResult::OK;
 

--- a/src/kaleidoscope/plugin/OneShot.cpp
+++ b/src/kaleidoscope/plugin/OneShot.cpp
@@ -121,9 +121,6 @@ EventHandlerResult OneShot::onKeyswitchEvent(Key &mapped_key, byte row, byte col
     return EventHandlerResult::EVENT_CONSUMED;
   }
 
-  if (!keyIsPressed(keyState) && !keyWasPressed(keyState))
-    return EventHandlerResult::OK;
-
   if (isOneShotKey(mapped_key)) {
     if (isSticky_(idx)) {
       if (keyToggledOn(keyState)) {  // maybe on _off instead?

--- a/src/kaleidoscope/plugin/TapDance.cpp
+++ b/src/kaleidoscope/plugin/TapDance.cpp
@@ -123,14 +123,6 @@ EventHandlerResult TapDance::onKeyswitchEvent(Key &mapped_key, byte row, byte co
   if (keyState & INJECTED)
     return EventHandlerResult::OK;
 
-  if (!keyIsPressed(keyState) && !keyWasPressed(keyState)) {
-    if (isTapDance(mapped_key)) {
-      return EventHandlerResult::EVENT_CONSUMED;
-    }
-
-    return EventHandlerResult::OK;
-  }
-
   if (!isTapDance(mapped_key)) {
     if (!isActive())
       return EventHandlerResult::OK;


### PR DESCRIPTION
A long-long time ago, Kaleidoscope used to call `onKeyswitchEvent` (or rather, it's then-current incarnation) even when keys were idle. For a number of plugins, this was a case they didn't want to handle, and bailed out early.

When we changed Kaleidoscope to not call the event handlers for idle keys, these plugins weren't modified at the same time, and the superfluous check remained, making the firmware both larger and marginally slower.

Since the event handlers are never called when idle, it is safe to remove these checks.

Affected plugins are `Leader`, `OneShot`, and `TapDance`.