### PR TITLE
Redial: Improved the way it remembers keys

### DIFF
--- a/src/kaleidoscope/plugin/Redial.cpp
+++ b/src/kaleidoscope/plugin/Redial.cpp
@@ -23,18 +23,27 @@ namespace plugin {
 
 Key Redial::key;
 Key Redial::key_to_redial_;
+Key Redial::last_key_;
+bool Redial::redial_held_ = false;
 
 EventHandlerResult Redial::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
   if (key == Key_NoKey)
     return EventHandlerResult::OK;
 
   if (mapped_key == key) {
+    if (keyToggledOff(key_state))
+      key_to_redial_ = last_key_;
+
     mapped_key = key_to_redial_;
+    redial_held_ = keyIsPressed(key_state);
+
     return EventHandlerResult::OK;
   }
 
   if (keyToggledOn(key_state) && shouldRemember(mapped_key)) {
-    key_to_redial_ = mapped_key;
+    last_key_ = mapped_key;
+    if (!redial_held_)
+      key_to_redial_ = mapped_key;
   }
 
   return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/Redial.h
+++ b/src/kaleidoscope/plugin/Redial.h
@@ -35,6 +35,8 @@ class Redial : public kaleidoscope::Plugin {
 
  private:
   static Key key_to_redial_;
+  static Key last_key_;
+  static bool redial_held_;
 };
 
 }


### PR DESCRIPTION
Instead of remembering a key whenever a new one toggles on, remember only when Redial itself is not held. We keep track of the last pressed key while Redial is held, though, so we can update the key to redial when we're released ourselves.

This should fix #396.