### PR TITLE
LED-AlphaSquare: Implement AlphaSquareEffect.refreshAt()

### DIFF
--- a/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
@@ -101,6 +101,40 @@ void AlphaSquare::display(uint16_t symbol, uint8_t row, uint8_t col) {
   display(symbol, row, col, color);
 }
 
+bool AlphaSquare::isSymbolPart(Key key,
+                               uint8_t display_row, uint8_t display_col,
+                               uint8_t row, uint8_t col) {
+  if (!Kaleidoscope.has_leds)
+    return false;
+
+  if (key < Key_A || key > Key_0)
+    return false;
+
+  uint8_t index = key.keyCode - Key_A.keyCode;
+  uint16_t symbol = pgm_read_word(&alphabet[index]);
+
+  return isSymbolPart(symbol, display_row, display_col, row, col);
+}
+
+bool AlphaSquare::isSymbolPart(uint16_t symbol,
+                               uint8_t display_row, uint8_t display_col,
+                               uint8_t row, uint8_t col) {
+  if (!Kaleidoscope.has_leds)
+    return false;
+
+  for (uint8_t r = 0; r < 4; r++) {
+    for (uint8_t c = 0; c < 4; c++) {
+      uint8_t pixel = bitRead(symbol, r * 4 + c);
+
+      if (display_row + r == row &&
+          display_col + c == col)
+        return !!pixel;
+    }
+  }
+
+  return false;
+}
+
 }
 }
 

--- a/src/kaleidoscope/plugin/LED-AlphaSquare.h
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare.h
@@ -75,6 +75,13 @@ class AlphaSquare : public kaleidoscope::Plugin {
     clear(symbol, 0, 2);
   }
 
+  static bool isSymbolPart(Key key,
+                           uint8_t display_row, uint8_t display_col,
+                           uint8_t row, uint8_t col);
+  static bool isSymbolPart(uint16_t symbol,
+                           uint8_t display_row, uint8_t display_col,
+                           uint8_t row, uint8_t col);
+
   static cRGB color;
 };
 

--- a/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
@@ -38,6 +38,23 @@ void AlphaSquareEffect::update(void) {
   }
 }
 
+void AlphaSquareEffect::refreshAt(byte row, byte col) {
+  bool timed_out;
+  uint8_t display_col = 2;
+  Key key = last_key_left_;
+
+  if (col < COLS / 2) {
+    timed_out = !end_time_left_ || (end_time_left_ && millis() > end_time_left_);
+  } else {
+    key = last_key_right_;
+    display_col = 10;
+    timed_out = !end_time_right_ || (end_time_right_ && millis() > end_time_right_);
+  }
+
+  if (!::AlphaSquare.isSymbolPart(key, 0, display_col, row, col) || timed_out)
+    ::LEDControl.setCrgbAt(row, col, CRGB(0, 0, 0));
+}
+
 EventHandlerResult AlphaSquareEffect::onKeyswitchEvent(Key &mappedKey, byte row, byte col, uint8_t keyState) {
   if (!Kaleidoscope.has_leds)
     return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
@@ -32,6 +32,7 @@ class AlphaSquareEffect : public LEDMode {
 
  protected:
   void update(void) final;
+  void refreshAt(byte row, byte col) final;
 
  private:
   static uint32_t end_time_left_, end_time_right_;


### PR DESCRIPTION
To make the interaction with plugins that work on top of LEDModes (such as `ActiveModColor`), we need a `refreshAt()` method. For AlphaSquare, we'll return black when a pixel has timed out, or if a key is not part of the currently lit symbol.

Fixes #401.
