### PR TITLE
Oneshot: use default value to overload for cancel

### DIFF
--- a/src/kaleidoscope/plugin/OneShot.h
+++ b/src/kaleidoscope/plugin/OneShot.h
@@ -42,10 +42,7 @@ class OneShot : public kaleidoscope::Plugin {
   }
   static bool isActive(Key key);
   static bool isSticky(Key key);
-  static void cancel(bool with_stickies);
-  static void cancel(void) {
-    cancel(false);
-  }
+  static void cancel(bool with_stickies = false);
   static uint16_t time_out;
   static int16_t double_tap_time_out;
   static uint16_t hold_time_out;


### PR DESCRIPTION
Instead of having two variants of `cancel()`, have only one with a default value for its argument. No functional change at all, but nicer code.

This was extracted from keyboardio/Kaleidoscope-OneShot#45 by @jamadagni.