### PR TITLE
IdleLEDs: Make timeout calculation more efficient, and avoid an overflow

### DIFF
--- a/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -22,13 +22,11 @@ namespace kaleidoscope {
 namespace plugin {
 
 uint16_t IdleLEDs::idle_time_limit = 600; // 10 minutes
-uint32_t IdleLEDs::last_keypress_time_;
+uint32_t IdleLEDs::end_time_;
 
 EventHandlerResult IdleLEDs::beforeEachCycle() {
-  uint32_t idle_limit = idle_time_limit * 1000;
-
   if (!::LEDControl.paused &&
-      Kaleidoscope.millisAtCycleStart() - last_keypress_time_ >= idle_limit) {
+      (Kaleidoscope.millisAtCycleStart() >= end_time_)) {
     ::LEDControl.set_all_leds_to(CRGB(0, 0, 0));
     ::LEDControl.syncLeds();
 
@@ -45,7 +43,7 @@ EventHandlerResult IdleLEDs::onKeyswitchEvent(Key &mapped_key, byte row, byte co
     ::LEDControl.refreshAll();
   }
 
-  last_keypress_time_ = Kaleidoscope.millisAtCycleStart();
+  end_time_ = Kaleidoscope.millisAtCycleStart() + idle_time_limit * 1000;
 
   return EventHandlerResult::OK;
 }

--- a/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -43,7 +43,7 @@ EventHandlerResult IdleLEDs::onKeyswitchEvent(Key &mapped_key, byte row, byte co
     ::LEDControl.refreshAll();
   }
 
-  end_time_ = Kaleidoscope.millisAtCycleStart() + idle_time_limit * 1000;
+  end_time_ = Kaleidoscope.millisAtCycleStart() + (uint32_t)idle_time_limit * 1000;
 
   return EventHandlerResult::OK;
 }

--- a/src/kaleidoscope/plugin/IdleLEDs.h
+++ b/src/kaleidoscope/plugin/IdleLEDs.h
@@ -29,14 +29,14 @@ class IdleLEDs: public kaleidoscope::Plugin {
   static uint16_t idle_time_limit;
 
   EventHandlerResult onSetup() {
-    last_keypress_time_ = millis();
+    end_time_ = millis() + idle_time_limit * 1000;
     return EventHandlerResult::OK;
   }
   EventHandlerResult beforeEachCycle();
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
 
  private:
-  static uint32_t last_keypress_time_;
+  static uint32_t end_time_;
 };
 }
 }


### PR DESCRIPTION
The first patch changes how idle timeouts are calculated: instead of calculating it every cycle in `beforeEachCycle`, do so in `onKeyswitchEvent` (which will be called less often). This improves efficiency a little.

The more important part is the second: we need to explicitly cast `idle_time_limit` to 32-bits, otherwise `idle_time_limit*1000` will be performed as a 16-bit operation, resulting in an overflow, effectively capping us at 65 seconds. If we cast it to 32-bit first, we avoid the overflow.

Many thanks to @nevd for the report, and for the help in debugging the issue, and testing the fix.