### PR TITLE
Fix ledIndex < 0 handling, and fix Chase

### DIFF
--- a/src/kaleidoscope/hardware/Model01.cpp
+++ b/src/kaleidoscope/hardware/Model01.cpp
@@ -86,6 +86,9 @@ void Model01::setup(void) {
 
 
 void Model01::setCrgbAt(int8_t i, cRGB crgb) {
+  if (i < 0) {
+    return;
+  }
   if (i < 32) {
     cRGB oldColor = getCrgbAt(i);
     isLEDChanged |= !(oldColor.r == crgb.r && oldColor.g == crgb.g && oldColor.b == crgb.b);
@@ -112,12 +115,13 @@ int8_t Model01::getLedIndex(byte row, byte col) {
 }
 
 cRGB Model01::getCrgbAt(int8_t i) {
+  if (i < 0 || i > 64)
+    return {0, 0, 0};
+
   if (i < 32) {
     return leftHand.ledData.leds[i];
-  } else if (i < 64) {
-    return rightHand.ledData.leds[i - 32] ;
   } else {
-    return {0, 0, 0};
+    return rightHand.ledData.leds[i - 32] ;
   }
 }
 

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
@@ -48,7 +48,7 @@ void LEDChaseEffect::update(void) {
   // will be out of bounds. The simplest way to do this is to assign it a value that is
   // known to be invalid (LED_COUNT).
   pos += chase_sign;
-  if (pos < LED_COUNT) {
+  if (pos < LED_COUNT && pos > 0) {
     pos2 += chase_sign;
   } else {
     chase_sign = -chase_sign;


### PR DESCRIPTION
This fixes two semi-related problems, both found while debuging #448: first, the keyboard hardware needs to account for negative LED indexes now that we've switched to signed ints.

Second, Chase needs to flip over the direction when the main position goes below zero.

Both of these together fix #448.