### PR TITLE
LEDUtils: breath improvements

### DIFF
--- a/src/kaleidoscope/plugin/LEDControl/LEDUtils.cpp
+++ b/src/kaleidoscope/plugin/LEDControl/LEDUtils.cpp
@@ -17,13 +17,25 @@
 #include "kaleidoscope/plugin/LEDControl/LEDUtils.h"
 
 cRGB
-breath_compute(uint8_t hue, uint8_t saturation) {
+breath_compute(uint8_t hue, uint8_t saturation, uint8_t phase_offset) {
   // This code is adapted from FastLED lib8tion.h as of dd5d96c6b289cb6b4b891748a4aeef3ddceaf0e6
   // Eventually, we should consider just using FastLED
 
+  // The phase offset is provided in case one wants more than one breathe effect
+  // differing in phase at the same time. This may be useful for individual
+  // indicators that need to contrast with any other overall breathe effect.
+  // (Offset value 128 giving 50% ie opposite phase is especially nice.)
+  //
+  // The actual breathe computation function has a period of 4096. The input
+  // phase offset ranges from 0 to 255. This is to be scaled to the actual
+  // period 0 to 4096. To allow precise offsets of 25%, 50% etc, and for
+  // computational convenience and speed (and since one would not meaningfully
+  // request an offset of 4096 for 255 to be mapped to it), we merely multiply
+  // the input offset by 16 (== 4096/256), or equivalently lshift it by 4.
+
   // We do a bit shift here instead of division to ensure that there's no discontinuity
   // in the output brightness when the integer overflows.
-  uint8_t i = (uint16_t)millis() >> 4;
+  uint8_t i = ((uint16_t)Kaleidoscope.millisAtCycleStart() + (phase_offset << 4)) >> 4;
 
   if (i & 0x80) {
     i = 255 - i;

--- a/src/kaleidoscope/plugin/LEDControl/LEDUtils.h
+++ b/src/kaleidoscope/plugin/LEDControl/LEDUtils.h
@@ -18,5 +18,5 @@
 
 #include <Kaleidoscope.h>
 
-cRGB breath_compute(uint8_t hue = 170, uint8_t saturation = 255);
+cRGB breath_compute(uint8_t hue = 170, uint8_t saturation = 255, uint8_t phase_offset = 0);
 cRGB hsvToRgb(uint16_t h, uint16_t s, uint16_t v);


### PR DESCRIPTION
Based on work by Shriramana Sharma (@jamadagni) in keyboardio/Kaleidoscope-LEDControl#27, this adds an optional `phase_offset` argument to `breath_computer`. This allows one to have multiple breath effects active at the same time, at different phases.

To make these synchronized, use `Kaleidoscope.millisAtCycleStart()` instead of `millis()`.
