### PR TITLE
Unicode: Add a way to slow it all down

### DIFF
--- a/doc/plugin/Unicode.md
+++ b/doc/plugin/Unicode.md
@@ -67,6 +67,14 @@ functionality.
 
 > Finishes the Unicode input method, in an OS-specific way.
 
+### `.input_delay([delay])`
+
+> Sets or returns (if called without an argument) the number of milliseconds to
+> wait between inputting each part of the sequence. In some cases, inputting too
+> fast does not give the host enough time to process, and a delay is needed.
+>
+> Defaults to zero, no delay.
+
 ## Overrideable methods
 
 ### `hexToKey(hex_digit)`

--- a/src/kaleidoscope/plugin/Unicode.cpp
+++ b/src/kaleidoscope/plugin/Unicode.cpp
@@ -21,6 +21,8 @@
 namespace kaleidoscope {
 namespace plugin {
 
+uint8_t Unicode::input_delay_;
+
 void Unicode::start(void) {
   switch (::HostOS.os()) {
   case hostos::LINUX:
@@ -62,6 +64,7 @@ void Unicode::input(void) {
     unicodeCustomInput();
     break;
   }
+  delay(input_delay_);
 }
 
 void Unicode::end(void) {

--- a/src/kaleidoscope/plugin/Unicode.h
+++ b/src/kaleidoscope/plugin/Unicode.h
@@ -32,6 +32,15 @@ class Unicode : public kaleidoscope::Plugin {
 
   static void type(uint32_t unicode);
   static void typeCode(uint32_t unicode);
+
+  static void input_delay(uint8_t delay) {
+    input_delay_ = delay;
+  }
+  static uint8_t input_delay() {
+    return input_delay_;
+  }
+ private:
+  static uint8_t input_delay_;
 };
 }
 }


### PR DESCRIPTION
In certain cases we need to delay the unicode input sequence, otherwise the host is unable to process the input properly. Introduce the `.input_delay()` setter/getter for this purpose. We're defaulting to zero (no delay) nevertheless.
