### PR TITLE
previous_key in cycleAction now contains modifier key flags

### DIFF
--- a/doc/plugin/Cycle.md
+++ b/doc/plugin/Cycle.md
@@ -25,9 +25,11 @@ Key_Cycle
 
 // later in the Sketch:
 void cycleAction(Key previous_key, uint8_t cycle_count) {
-  if (previous_key.raw == Key_A.raw) {
-    cycleThrough (Key_B, Key_C, Key_D);
-  }
+  bool is_shifted = previous_key.flags & SHIFT_HELD;
+  if (previous_key.keyCode == Key_A.keyCode && is_shifted)
+      cycleThrough (LSHIFT(Key_A), LSHIFT(Key_B), LSHIFT(Key_C));
+  if (previous_key.keyCode == Key_A.keyCode && !is_shifted)
+      cycleThrough (Key_A, Key_B, Key_C);
 }
 
 KALEIDOSCOPE_INIT_PLUGINS(Cycle);

--- a/examples/Cycle/Cycle.ino
+++ b/examples/Cycle/Cycle.ino
@@ -47,9 +47,12 @@ void cycleAction(Key previous_key, uint8_t cycle_count) {
       Cycle.replace(Key_G);
     }
   }
-  if (previous_key.raw == Key_A.raw) {
+
+  bool is_shifted = previous_key.flags & SHIFT_HELD;
+  if (previous_key.keyCode == Key_A.keyCode && is_shifted)
+    cycleThrough(LSHIFT(Key_A), LSHIFT(Key_B), LSHIFT(Key_C), LSHIFT(Key_D));
+  if (previous_key.keyCode == Key_A.keyCode && !is_shifted)
     cycleThrough(Key_A, Key_B, Key_C, Key_D);
-  }
 }
 
 KALEIDOSCOPE_INIT_PLUGINS(Cycle);

--- a/src/kaleidoscope/plugin/Cycle.h
+++ b/src/kaleidoscope/plugin/Cycle.h
@@ -39,8 +39,10 @@ class Cycle : public kaleidoscope::Plugin {
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
 
  private:
+  static uint8_t toModFlag(uint8_t keyCode);
   static Key last_non_cycle_key_;
   static uint8_t cycle_count_;
+  static uint8_t current_modifier_flags_;
 };
 }
 }


### PR DESCRIPTION
See keyboardio/Kaleidoscope-Cycle#2 for the original pull request. This is just that rebased on top of Kaleidoscope master, with the example changed to support modifiers.