### PR TITLE
Atreus: Minor refactoring around row selection during scan

### DIFF
--- a/src/kaleidoscope/hardware/Atreus.cpp
+++ b/src/kaleidoscope/hardware/Atreus.cpp
@@ -46,12 +46,15 @@ uint16_t Atreus::masks_[ROWS];
 uint8_t Atreus::debounce_matrix_[ROWS][COLS];
 uint8_t Atreus::debounce = 3;
 
+constexpr uint8_t Atreus::row_pins[4];
+
 void Atreus::setup(void) {
   wdt_disable();
   delay(100);
 
   for (uint8_t i = 0; i < ROWS; i++) {
-    unselectRow(i);
+    DDRD |= _BV(row_pins[i]);
+    PORTD |= _BV(row_pins[i]);
     keyState_[i] = previousKeyState_[i] = 0;
   }
 
@@ -82,50 +85,8 @@ void Atreus::setup(void) {
   TIMSK1 = _BV(TOIE1);
 }
 
-void Atreus::selectRow(uint8_t row) {
-  switch (row) {
-  case 0:
-    DDRD  |= (_BV(0));
-    PORTD &= ~(_BV(0));
-    break;
-  case 1:
-    DDRD  |= (_BV(1));
-    PORTD &= ~(_BV(1));
-    break;
-  case 2:
-    DDRD  |= (_BV(3));
-    PORTD &= ~(_BV(3));
-    break;
-  case 3:
-    DDRD  |= (_BV(2));
-    PORTD &= ~(_BV(2));
-    break;
-  default:
-    break;
-  }
-}
-
-void Atreus::unselectRow(uint8_t row) {
-  switch (row) {
-  case 0:
-    DDRD  &= ~(_BV(0));
-    PORTD |= (_BV(0));
-    break;
-  case 1:
-    DDRD  &= ~(_BV(1));
-    PORTD |= (_BV(1));
-    break;
-  case 2:
-    DDRD  &= ~(_BV(3));
-    PORTD |= (_BV(3));
-    break;
-  case 3:
-    DDRD  &= ~(_BV(2));
-    PORTD |= (_BV(2));
-    break;
-  default:
-    break;
-  }
+void Atreus::toggleRow(uint8_t row) {
+  PORTD ^= _BV(row_pins[row]);
 }
 
 uint16_t Atreus::readCols() {
@@ -149,9 +110,9 @@ void Atreus::readMatrixRow(uint8_t current_row) {
 
   mask = debounceMaskForRow(current_row);
 
-  selectRow(current_row);
+  toggleRow(current_row);
   cols = (readCols() & mask) | (keyState_[current_row] & ~mask);
-  unselectRow(current_row);
+  toggleRow(current_row);
   debounceRow(cols ^ keyState_[current_row], current_row);
   keyState_[current_row] = cols;
 }

--- a/src/kaleidoscope/hardware/Atreus.cpp
+++ b/src/kaleidoscope/hardware/Atreus.cpp
@@ -52,11 +52,9 @@ void Atreus::setup(void) {
   wdt_disable();
   delay(100);
 
-  for (uint8_t i = 0; i < ROWS; i++) {
-    DDRD |= _BV(row_pins[i]);
-    PORTD |= _BV(row_pins[i]);
-    keyState_[i] = previousKeyState_[i] = 0;
-  }
+  // Initialize rows
+  DDRD |= _BV(0) | _BV(1) | _BV(3) | _BV(2);
+  PORTD |= _BV(0) | _BV(1) | _BV(3) | _BV(2);
 
   // Initialize columns
   DDRB &= ~(_BV(5) | _BV(4) | _BV(6) | _BV(7));

--- a/src/kaleidoscope/hardware/Atreus.h
+++ b/src/kaleidoscope/hardware/Atreus.h
@@ -127,14 +127,15 @@ class Atreus {
   static uint8_t debounce;
 
  private:
+  static constexpr uint8_t row_pins[4] = {0, 1, 3, 2};
+
   static uint16_t previousKeyState_[matrix_rows];
   static uint16_t keyState_[matrix_rows];
   static uint16_t masks_[matrix_rows];
 
   static void readMatrixRow(uint8_t row);
   static uint16_t readCols();
-  static void selectRow(uint8_t row);
-  static void unselectRow(uint8_t row);
+  static void toggleRow(uint8_t row);
 
   static uint8_t debounce_matrix_[matrix_rows][matrix_columns];
   static uint16_t debounceMaskForRow(uint8_t row);


### PR DESCRIPTION
This has two parts: the first part moves the plugin towards having a `toggleRow` function instead of `selectRow` and `unselectRow`, which saves us an instruction or two per cycle, at the cost of four bytes of RAM. This is mostly for code clarity, and to enable later optimizations, and I borrowed the idea from @obra.

The second commit is the big one: it unrolls the row initialization loop in `setup()`, and we end up saving 94(!) bytes of PROGMEM at the cost of 4 bytes of RAM.

The cleaned up code will be a tiny bit easier to rebuild on top of a common 32u4 scanner, too.