### PR TITLE
hardware/ATMegaKeyboard: Don't hardcode the list of keyboards

### DIFF
--- a/src/Kaleidoscope-Hardware-OLKB-Planck.h
+++ b/src/Kaleidoscope-Hardware-OLKB-Planck.h
@@ -17,4 +17,6 @@
  */
 
 #pragma once
+
+#define KALEIDOSCOPE_WITH_ATMEGA_KEYBOARD 1
 #include "kaleidoscope/hardware/olkb/Planck.h"

--- a/src/Kaleidoscope-Hardware-Technomancy-Atreus.h
+++ b/src/Kaleidoscope-Hardware-Technomancy-Atreus.h
@@ -17,4 +17,6 @@
  */
 
 #pragma once
+
+#define KALEIDOSCOPE_WITH_ATMEGA_KEYBOARD 1
 #include "kaleidoscope/hardware/technomancy/Atreus.h"

--- a/src/kaleidoscope/hardware/ATMegaKeyboard.cpp
+++ b/src/kaleidoscope/hardware/ATMegaKeyboard.cpp
@@ -15,9 +15,10 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if ARDUINO_AVR_PLANCK || ARDUINO_AVR_ATREUS
-
 #include "Kaleidoscope.h"
+
+#if KALEIDOSCOPE_WITH_ATMEGA_KEYBOARD
+
 #include "kaleidoscope/hardware/ATMegaKeyboard.h"
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/hardware/ATMegaKeyboard.h
+++ b/src/kaleidoscope/hardware/ATMegaKeyboard.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#if ARDUINO_AVR_PLANCK || ARDUINO_AVR_ATREUS
+#if KALEIDOSCOPE_WITH_ATMEGA_KEYBOARD
 
 #include <Arduino.h>
 #include <KeyboardioHID.h>


### PR DESCRIPTION
Instead of guarding the ATMegaKeyboard files with an `#if` that hard-coded which keyboards are based on the class, guard them with `KALEIDOSCOPE_WITH_ATMEGA_KEYBOARD`, set by the main hardware headers. Those headers get included early, and are as such, a perfect way to guard these things.

This way if we add a new keyboard using the base class, we don't have to modify the base class itself, and the new hardware plugin can be entirely self-contained.
