### PR TITLE
Macros: Add a way to have more control over when reports are sent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -75,6 +75,10 @@ In certain cases we need to delay the unicode input sequence, otherwise the host
 
 The [Cycle](doc/plugin/Cycle.md) plugin has much better support for cycling through keys with modifiers applied to them, such as `LSHIFT(Key_A)`. Please see the documentation and the updated example for more information.
 
+### More control over when to send reports during Macro playback
+
+There are situations where one would like to disable sending a report after each and every step of a macro, and rather have direct control over when reports are sent. The new `WITH_EXPLICIT_REPORT`, `WITH_IMPLICIT_REPORT` and `SEND_REPORT` steps help with that. Please see the [Macros](doc/plugin/Macros.md) documentation for more information.
+
 ## New hardware support
 
 Kaleidoscope has been ported to the following devices:

--- a/doc/plugin/Macros.md
+++ b/doc/plugin/Macros.md
@@ -142,7 +142,7 @@ need to define them in a special way, using the `MACRO` helper (or its
 
 ## `MACRO` steps
 
-Macro steps can be divided into two groups:
+Macro steps can be divided into the following groups:
 
 ### Delays
 
@@ -170,6 +170,23 @@ not supported by this compact representation.
 * `D(key)`, `Dr(key)`, `Dc(key)`: Simulates a key being pressed (pushed down).
 * `U(key)`, `Ur(key)`, `Uc(key)`: Simulates a key being released (going up).
 * `T(key)`, `Tr(key)`, `Tc(key)`: Simulates a key being tapped (pressed first, then released).
+
+### Controlling when to send reports
+
+While the plugin will - by default - send a report after every step, that is not
+always desirable. For this reason, we allow turning this implicit reporting off,
+and switching to explicit reporting instead. Note that the tap steps (`T()`,
+`Tr()`, and `Tc()`) will always send an implicit report, and so will
+`Macros.type()`.
+
+To control when to send reports, the following steps can be used:
+
+* `WITH_EXPLICIT_REPORT`: Prevents the plugin from sending an implicit report
+  after every step. To send a report, one needs to have a `SEND_REPORT` step
+  too.
+* `WITH_IMPLICIT_REPORT`: Enables sending an implicit report after every step
+  (the default).
+* `SEND_REPORT`: Send a report.
 
 ## Overrideable methods
 

--- a/src/kaleidoscope/plugin/Macros/MacroSteps.h
+++ b/src/kaleidoscope/plugin/Macros/MacroSteps.h
@@ -29,6 +29,10 @@ typedef enum {
   MACRO_ACTION_STEP_KEYCODEDOWN,
   MACRO_ACTION_STEP_KEYCODEUP,
   MACRO_ACTION_STEP_TAPCODE,
+
+  MACRO_ACTION_STEP_EXPLICIT_REPORT,
+  MACRO_ACTION_STEP_IMPLICIT_REPORT,
+  MACRO_ACTION_STEP_SEND_REPORT,
 } MacroActionStepType;
 
 typedef uint8_t macro_t;
@@ -50,5 +54,9 @@ typedef uint8_t macro_t;
 #define Dc(k) MACRO_ACTION_STEP_KEYCODEDOWN, (Key_ ## k).keyCode
 #define Uc(k) MACRO_ACTION_STEP_KEYCODEUP, (Key_ ## k).keyCode
 #define Tc(k) MACRO_ACTION_STEP_TAPCODE, (Key_ ## k).keyCode
+
+#define WITH_EXPLICIT_REPORT MACRO_ACTION_STEP_EXPLICIT_REPORT
+#define WITH_IMPLICIT_REPORT MACRO_ACTION_STEP_IMPLICIT_REPORT
+#define SEND_REPORT MACRO_ACTION_STEP_SEND_REPORT
 
 __attribute__((deprecated("END is no longer required to end macros"))) const MacroActionStepType END = MACRO_ACTION_END;


### PR DESCRIPTION
Sometimes we'd like to be in control of when reports are sent during macro playback. This implements a way to achieve that.

Fixes #368.
