### PR TITLE
kaleidoscope-builder: Support bootloaders with a different VID

### DIFF
--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -48,6 +48,7 @@ find_device_vid_pid() {
     VID=${VID:-$(echo "${VPIDS}" | grep build.vid= | cut -dx -f2)}
     SKETCH_PID=${SKETCH_PID:-$(echo "${VPIDS}" | grep build.pid= | cut -dx -f2)}
     BOOTLOADER_PID=${BOOTLOADER_PID:-$(echo "${VPIDS}" | grep bootloader.pid= | cut -dx -f2)}
+    BOOTLOADER_VID=${BOOTLOADER_VID:-$(echo "${VPIDS}" | grep bootloader.vid= | cut -dx -f2)}
 }
 
 find_device_port() {
@@ -66,8 +67,9 @@ reset_device_cmd() {
 find_bootloader_ports() {
     find_device_vid_pid
     DIR=$(dirname "$(readlink -f "$0")")
+    BOOTLOADER_VID="${BOOTLOADER_VID:-${VID}}"
     DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
-    DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${VID} ${BOOTLOADER_PID})"
+    DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${BOOTLOADER_VID} ${BOOTLOADER_PID})"
 }
 
 MD5="md5sum"


### PR DESCRIPTION
We already support bootloaders that have the same vendor ID as the keyboard, but a different product ID. We should also support bootloaders that have a different vendor ID too.