### PR TITLE
hardware/ATMegaKeyboard: Only define cRGB if required

### DIFF
--- a/src/kaleidoscope/hardware/ATMegaKeyboard.h
+++ b/src/kaleidoscope/hardware/ATMegaKeyboard.h
@@ -29,11 +29,15 @@
 
 #include <avr/wdt.h>
 
+#ifndef CRGB
+
 struct cRGB {
   uint8_t r, g, b;
 };
 
 #define CRGB(r,g,b) (cRGB){b, g, r}
+
+#endif
 
 #define ROW_PIN_LIST(...)  __VA_ARGS__
 #define COL_PIN_LIST(...)  __VA_ARGS__


### PR DESCRIPTION
If we wish to support hardware that has LEDs, we should not define the `cRGB` struct and the `CRGB` macro unconditionally. Define them only if the macro is undefined. This way any hardware that has LEDs, and still wishes to use `ATMegaKeyboard` as a base can define the macro prior to including the header.

Such hardware will override the LED functions anyway, so there's nothing else we need to do to support such a scenario.
