### PR TITLE
FocusSerial: New, simplified API

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -101,7 +101,7 @@ Upgrading from `Focus` to `onFocusEvent` and `FocusSerial` is a reasonably simpl
 
 ##### The most trivial example
 
-The biggest difference between `Focus` and `onFocusEvent` is that the former required explicit registering of hooks, while the latter does it automatically: every plugin that implements the `onFocusEvent` method will be part of the system. As a consequence, only plugins are able to supply new commands: there is no explicit registration, thus, no way to inject a command that isn't part of a plugin. This also means that these functions now return `kaleidoscope::EventHandlerResult` instead of `bool`. Lets see a trivial example!
+The biggest difference between `Focus` and `onFocusEvent` is that the former required explicit registering of hooks, while the latter does it automatically: every plugin that implements the `onFocusEvent` method will be part of the system. As a consequence, only plugins are able to supply new commands: there is no explicit registration, thus, no way to inject a command that isn't part of a plugin. This also means that these functions now return `kaleidoscope::EventHandlerResult` instead of `bool`. Furthermore, with `FocusSerial`, all communication is expected to go through it, instead of using `Serial` directly. Lets see a trivial example!
 
 ###### Focus
 
@@ -136,7 +136,7 @@ class FocusExampleCommand : public Plugin {
     if (strcmp_P(command, PSTR("example")) != 0)
       return EventHandlerResult::OK;
 
-    Serial.println(F("This is an example response. Hello world!"));
+    ::Focus.send(F("This is an example response. Hello world!"));
     return EventHandlerResult::EVENT_CONSUMED;
   }
 };
@@ -212,7 +212,7 @@ class ExamplePlugin : public Plugin {
       return EventHandlerResult::OK;
 
     example_toggle_ = !example_toggle_;
-    ::Focus.printBool(example_toggle_);
+    ::Focus.send(example_toggle_);
 
     return EventHandlerResult::EVENT_CONSUMED;
   }
@@ -271,7 +271,7 @@ class ExampleOptionalCommand : public Plugin {
     if (strcmp_P(command, PSTR("optional")) != 0)
       return EventHandlerResult::OK;
 
-    Serial.println(Layer.getLayerState(), BIN);
+    ::Focus.send(Layer.getLayerState());
     return EventHandlerResult::EVENT_CONSUMED;
   }
 };

--- a/examples/Features/FocusSerial/FocusSerial.ino
+++ b/examples/Features/FocusSerial/FocusSerial.ino
@@ -51,7 +51,7 @@ class FocusTestCommand : public Plugin {
       return EventHandlerResult::OK;
 
     if (strcmp_P(command, cmd) == 0) {
-      Serial.println(F("ok!"));
+      ::Focus.send(F("ok!"));
       return EventHandlerResult::EVENT_CONSUMED;
     }
 

--- a/src/kaleidoscope/plugin/CycleTimeReport.cpp
+++ b/src/kaleidoscope/plugin/CycleTimeReport.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope-CycleTimeReport.h>
+#include <Kaleidoscope-FocusSerial.h>
 
 namespace kaleidoscope {
 namespace plugin {
@@ -55,8 +56,7 @@ EventHandlerResult CycleTimeReport::afterEachCycle() {
 }
 
 __attribute__((weak)) void cycleTimeReport(void) {
-  Serial.print(F("# average loop time: "));
-  Serial.println(CycleTimeReport.average_loop_time);
+  Focus.send(Focus.COMMENT, F("average loop time:"), CycleTimeReport.average_loop_time);
 }
 
 kaleidoscope::plugin::CycleTimeReport CycleTimeReport;

--- a/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -143,24 +143,23 @@ EventHandlerResult FocusSettingsCommand::onFocusEvent(const char *command) {
 
   switch (sub_command) {
   case DEFAULT_LAYER: {
-    if (Serial.peek() == '\n') {
-      Serial.println(::EEPROMSettings.default_layer());
+    if (::Focus.isEOL()) {
+      ::Focus.send(::EEPROMSettings.default_layer());
     } else {
-      ::EEPROMSettings.default_layer(Serial.parseInt());
+      uint8_t layer;
+      ::Focus.read(layer);
+      ::EEPROMSettings.default_layer(layer);
     }
     break;
   }
   case IS_VALID:
-    ::Focus.printBool(::EEPROMSettings.isValid());
-    Serial.println();
+    ::Focus.send(::EEPROMSettings.isValid());
     break;
   case GET_VERSION:
-    Serial.println(::EEPROMSettings.version());
+    ::Focus.send(::EEPROMSettings.version());
     break;
   case CRC:
-    Serial.print(::CRC.crc, HEX);
-    Serial.print(F("/"));
-    Serial.println(::EEPROMSettings.crc(), HEX);
+    ::Focus.sendRaw(::CRC.crc, F("/"), ::EEPROMSettings.crc());
     break;
   }
 
@@ -185,16 +184,15 @@ EventHandlerResult FocusEEPROMCommand::onFocusEvent(const char *command) {
 
   switch (sub_command) {
   case CONTENTS: {
-    if (Serial.peek() == '\n') {
+    if (::Focus.isEOL()) {
       for (uint16_t i = 0; i < EEPROM.length(); i++) {
         uint8_t d = EEPROM[i];
-        ::Focus.printNumber(d);
-        ::Focus.printSpace();
+        ::Focus.send(d);
       }
-      Serial.println();
     } else {
-      for (uint16_t i = 0; i < EEPROM.length() && Serial.peek() != '\n'; i++) {
-        uint8_t d = Serial.parseInt();
+      for (uint16_t i = 0; i < EEPROM.length() && !::Focus.isEOL(); i++) {
+        uint8_t d;
+        ::Focus.read(d);
         EEPROM.update(i, d);
       }
     }
@@ -202,7 +200,7 @@ EventHandlerResult FocusEEPROMCommand::onFocusEvent(const char *command) {
     break;
   }
   case FREE:
-    Serial.println(EEPROM.length() - ::EEPROMSettings.used());
+    ::Focus.send(EEPROM.length() - ::EEPROMSettings.used());
     break;
   }
 

--- a/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -50,7 +50,7 @@ EventHandlerResult FocusSerial::beforeReportingState() {
 
   Kaleidoscope.onFocusEvent(command_);
 
-  Serial.println(F("."));
+  Serial.println(F("\r\n."));
 
   drain();
 
@@ -74,34 +74,8 @@ EventHandlerResult FocusSerial::onFocusEvent(const char *command) {
   return EventHandlerResult::OK;
 }
 
-void FocusSerial::printSpace(void) {
-  Serial.print(F(" "));
-}
-
-void FocusSerial::printNumber(uint16_t num) {
-  Serial.print(num);
-}
-
-void FocusSerial::printColor(uint8_t r, uint8_t g, uint8_t b) {
-  printNumber(r);
-  printSpace();
-  printNumber(g);
-  printSpace();
-  printNumber(b);
-}
-
-void FocusSerial::printSeparator(void) {
-  Serial.print(F(" | "));
-}
-
 void FocusSerial::printBool(bool b) {
   Serial.print((b) ? F("true") : F("false"));
-}
-
-void FocusSerial::readColor(cRGB &color) {
-  color.r = Serial.parseInt();
-  color.g = Serial.parseInt();
-  color.b = Serial.parseInt();
 }
 
 }

--- a/src/kaleidoscope/plugin/FocusSerial.h
+++ b/src/kaleidoscope/plugin/FocusSerial.h
@@ -28,14 +28,61 @@ class FocusSerial : public kaleidoscope::Plugin {
   bool handleHelp(const char *command,
                   const char *help_message);
 
-  /* Helpers */
-  static void printNumber(uint16_t number);
-  static void printSpace(void);
-  static void printColor(uint8_t r, uint8_t g, uint8_t b);
-  static void printSeparator(void);
-  static void printBool(bool b);
+  void send() {}
+  void send(const cRGB color) {
+    send(color.r, color.g, color.b);
+  }
+  void send(const Key key) {
+    send(key.raw);
+    Serial.print(SEPARATOR);
+  }
+  void send(const bool b) {
+    printBool(b);
+    Serial.print(SEPARATOR);
+  }
+  template <typename V>
+  void send(V v) {
+    Serial.print(v);
+    Serial.print(SEPARATOR);
+  }
+  template <typename Var, typename... Vars>
+  void send(Var v, const Vars&... vars) {
+    send(v);
+    send(vars...);
+  }
 
-  static void readColor(cRGB &color);
+  void sendRaw() {}
+  template <typename Var, typename... Vars>
+  void sendRaw(Var v, const Vars&... vars) {
+    Serial.print(v);
+    sendRaw(vars...);
+  }
+
+  const char peek() {
+    return Serial.peek();
+  }
+
+  void read(Key &key) {
+    key.raw = Serial.parseInt();
+  }
+  void read(cRGB &color) {
+    color.r = Serial.parseInt();
+    color.g = Serial.parseInt();
+    color.b = Serial.parseInt();
+  }
+  void read(uint8_t &u8) {
+    u8 = Serial.parseInt();
+  }
+  void read(uint16_t &u16) {
+    u16 = Serial.parseInt();
+  }
+
+  bool isEOL() {
+    return Serial.peek() == '\n';
+  }
+
+  static constexpr char COMMENT = '#';
+  static constexpr char SEPARATOR = ' ';
 
   /* Hooks */
   EventHandlerResult onSetup() {
@@ -49,6 +96,7 @@ class FocusSerial : public kaleidoscope::Plugin {
   static char command_[32];
 
   static void drain(void);
+  static void printBool(bool b);
 };
 }
 }

--- a/src/kaleidoscope/plugin/HostOS-Focus.cpp
+++ b/src/kaleidoscope/plugin/HostOS-Focus.cpp
@@ -29,14 +29,14 @@ EventHandlerResult FocusHostOSCommand::onFocusEvent(const char *command) {
   if (strcmp_P(command, cmd) != 0)
     return EventHandlerResult::OK;
 
-  if (Serial.peek() == '\n') {
-    Serial.println(::HostOS.os());
+  if (::Focus.isEOL()) {
+    ::Focus.send(::HostOS.os());
   } else {
-    uint8_t new_os = Serial.parseInt();
+    uint8_t new_os;
+    ::Focus.read(new_os);
     ::HostOS.os((hostos::Type) new_os);
   }
 
-  Serial.read();
   return EventHandlerResult::EVENT_CONSUMED;
 }
 

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -214,17 +214,18 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
 
   switch (subCommand) {
   case AT: {
-    uint8_t idx = Serial.parseInt();
+    uint8_t idx;
 
-    if (Serial.peek() == '\n') {
+    ::Focus.read(idx);
+
+    if (::Focus.isEOL()) {
       cRGB c = ::LEDControl.getCrgbAt(idx);
 
-      ::Focus.printColor(c.r, c.g, c.b);
-      Serial.println();
+      ::Focus.send(c);
     } else {
       cRGB c;
 
-      ::Focus.readColor(c);
+      ::Focus.read(c);
 
       ::LEDControl.setCrgbAt(idx, c);
     }
@@ -233,46 +234,43 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
   case SETALL: {
     cRGB c;
 
-    ::Focus.readColor(c);
+    ::Focus.read(c);
 
     ::LEDControl.set_all_leds_to(c);
 
     break;
   }
   case MODE: {
-    char peek = Serial.peek();
+    char peek = ::Focus.peek();
     if (peek == '\n') {
-      Serial.println(::LEDControl.get_mode_index());
+      ::Focus.send(::LEDControl.get_mode_index());
     } else if (peek == 'n') {
       ::LEDControl.next_mode();
-      Serial.read();
     } else if (peek == 'p') {
       ::LEDControl.prev_mode();
-      Serial.read();
     } else {
-      uint8_t mode = Serial.parseInt();
+      uint8_t mode;
 
+      ::Focus.read(mode);
       ::LEDControl.set_mode(mode);
     }
     break;
   }
   case THEME: {
-    if (Serial.peek() == '\n') {
+    if (::Focus.isEOL()) {
       for (int8_t idx = 0; idx < LED_COUNT; idx++) {
         cRGB c = ::LEDControl.getCrgbAt(idx);
 
-        ::Focus.printColor(c.r, c.g, c.b);
-        ::Focus.printSpace();
+        ::Focus.send(c);
       }
-      Serial.println();
       break;
     }
 
     int8_t idx = 0;
-    while (idx < LED_COUNT && Serial.peek() != '\n') {
+    while (idx < LED_COUNT && !::Focus.isEOL()) {
       cRGB color;
 
-      ::Focus.readColor(color);
+      ::Focus.read(color);
 
       ::LEDControl.setCrgbAt(idx, color);
       idx++;

--- a/src/kaleidoscope/plugin/TypingBreaks.cpp
+++ b/src/kaleidoscope/plugin/TypingBreaks.cpp
@@ -165,38 +165,38 @@ EventHandlerResult TypingBreaks::onFocusEvent(const char *command) {
 
   switch (subCommand) {
   case IDLE_TIME_LIMIT:
-    if (Serial.peek() == '\n') {
-      Serial.println(settings.idle_time_limit);
+    if (::Focus.isEOL()) {
+      ::Focus.send(settings.idle_time_limit);
     } else {
-      settings.idle_time_limit = Serial.parseInt();
+      ::Focus.read(settings.idle_time_limit);
     }
     break;
   case LOCK_TIMEOUT:
-    if (Serial.peek() == '\n') {
-      Serial.println(settings.lock_time_out);
+    if (::Focus.isEOL()) {
+      ::Focus.send(settings.lock_time_out);
     } else {
-      settings.lock_time_out = Serial.parseInt();
+      ::Focus.read(settings.lock_time_out);
     }
     break;
   case LOCK_LENGTH:
-    if (Serial.peek() == '\n') {
-      Serial.println(settings.lock_length);
+    if (::Focus.isEOL()) {
+      ::Focus.send(settings.lock_length);
     } else {
-      settings.lock_length = Serial.parseInt();
+      ::Focus.read(settings.lock_length);
     }
     break;
   case LEFT_MAX:
-    if (Serial.peek() == '\n') {
-      Serial.println(settings.left_hand_max_keys);
+    if (::Focus.isEOL()) {
+      ::Focus.send(settings.left_hand_max_keys);
     } else {
-      settings.left_hand_max_keys = Serial.parseInt();
+      ::Focus.read(settings.left_hand_max_keys);
     }
     break;
   case RIGHT_MAX:
-    if (Serial.peek() == '\n') {
-      Serial.println(settings.right_hand_max_keys);
+    if (::Focus.isEOL()) {
+      ::Focus.send(settings.right_hand_max_keys);
     } else {
-      settings.right_hand_max_keys = Serial.parseInt();
+      ::Focus.read(settings.right_hand_max_keys);
     }
     break;
   }


### PR DESCRIPTION
Introduce a couple of helper methods that make it easier to work with Focus. These abstract away the dependency on Serial as a side-effect. The intent is that all traffic will go through Focus.

Fixes #476.