### PR TITLE
Add rules and scripts for building on FreeBSD.

### DIFF
--- a/bin/find-device-port-freebsd
+++ b/bin/find-device-port-freebsd
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+
+use warnings;
+use strict;
+
+#
+# Scan all USB devices to find the Model 01's modem device number.
+#
+my @output = qx(/usr/sbin/usbconfig show_ifdrv);
+my $serial_port_number;
+
+foreach my $line (@output) {
+  chomp $line;
+
+  next unless $line =~ m/umodem(\d+):.*Keyboardio Model 01/;
+  $serial_port_number = $1;
+}
+
+die "Can't find Model 01" unless defined($serial_port_number);
+
+my $serial_port_name = "/dev/cuaU$serial_port_number";
+die "Missing serial port at $serial_port_name" unless -e $serial_port_name;
+print "$serial_port_name\n";
+exit 0;

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -45,15 +45,24 @@ firmware_size () {
     ## This is a terrible hack, please don't hurt me. - algernon
 
     find_max_prog_size
-    output="$("$@" | grep "\\(Program\\|Data\\):" | sed -e 's,^,  - ,' && echo)"
+    set +e
+    raw_output=$("$@" 2> /dev/null)
+    rc=$?
+    set -e
 
-    PROGSIZE="$(echo "${output}" | grep "Program:" | cut -d: -f2 | awk '{print $1}')"
+    if [ $rc -eq 0 ]; then
+        output="$(echo "${raw_output}"| grep "\\(Program\\|Data\\):" | sed -e 's,^,  - ,' && echo)"
 
-    PERCENT="$(echo "${PROGSIZE}" "${MAX_PROG_SIZE}" | awk "{ printf \"%02.01f\", \$1 / \$2 * 100 }")"
+        PROGSIZE="$(echo "${output}" | grep "Program:" | cut -d: -f2 | awk '{print $1}')"
 
-    # we want the sed there, doing with shell builtins would be worse.
-    # shellcheck disable=SC2001 disable=SC1117
-    echo "${output}" | sed -e "s/\(Program:.*\)(\([0-9\.]*%\) Full)/\1(${PERCENT}% Full)/"
+        PERCENT="$(echo "${PROGSIZE}" "${MAX_PROG_SIZE}" | awk "{ printf \"%02.01f\", \$1 / \$2 * 100 }")"
+
+        # we want the sed there, doing with shell builtins would be worse.
+        # shellcheck disable=SC2001 disable=SC1117
+        echo "${output}" | sed -e "s/\(Program:.*\)(\([0-9\.]*%\) Full)/\1(${PERCENT}% Full)/"
+    else
+        echo "Unable to determine image size."
+    fi
 }
 
 
@@ -102,7 +111,7 @@ flash () {
     ${preFlash_HOOKS}
 
     reset_device
-    sleep 3s
+    sleep 3
     find_bootloader_ports
     check_bootloader_port_and_flash
 
@@ -121,7 +130,7 @@ check_bootloader_port_and_flash () {
 }
 
 flash_over_usb () {
-    sleep 1s
+    sleep 1
     ${AVRDUDE} -q -q -C "${AVRDUDE_CONF}" -p"${MCU}" -cavr109 -D -P "${DEVICE_PORT_BOOTLOADER}" -b57600 "-Uflash:w:${HEX_FILE_PATH}:i"
 }
 
@@ -283,7 +292,7 @@ size () {
     fi
 
     echo "- Size: firmware/${LIBRARY}/${OUTPUT_FILE_PREFIX}.elf"
-    firmware_size "${AVR_SIZE}" -C --mcu="${MCU}" "${ELF_FILE_PATH}"
+    firmware_size "${AVR_SIZE}" "${AVR_SIZE_FLAGS}" "${ELF_FILE_PATH}"
     echo
 }
 

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -98,6 +98,31 @@ if [ "${uname_S}" = "Darwin" ]; then
 	DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER})"
     }
 
+elif [ "${uname_S}" = "FreeBSD" ]; then
+
+    find_device_port() {
+	DIR=$(dirname "$0")
+	DEVICE_PORT_PROBER="${DIR}/find-device-port-freebsd"
+	DEVICE_PORT="$(perl ${DEVICE_PORT_PROBER})"
+    }
+
+    reset_device_cmd() {
+	/bin/stty -f ${DEVICE_PORT} 1200
+    }
+
+    MD5="md5"
+    AVR_SIZE="${AVR_SIZE:-/usr/local/bin/avr-size}"
+    AVR_NM="${AVR_NM:-/usr/local/bin/avr-nm}"
+    AVR_OBJDUMP="${AVR_OBJDUMP:-/usr/local/bin/avr-objdump}"
+    AVRDUDE="${AVRDUDE:-/usr/local/bin/avrdude}"
+    AVRDUDE_CONF="${AVRDUDE_CONF:-/usr/local/etc/avrdude.conf}"
+
+    find_bootloader_ports() {
+	DIR=$(dirname "$0")
+	DEVICE_PORT_PROBER="${DIR}/find-device-port-freebsd"
+	DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER})"
+    }
+
 fi
 
 ######
@@ -117,6 +142,7 @@ ARDUINO_IDE_VERSION="10607"
 ######
 
 AVR_SIZE="${AVR_SIZE:-${ARDUINO_TOOLS_PATH}/avr/bin/avr-size}"
+AVR_SIZE_FLAGS="${AVR_SIZE_FLAGS:--C --mcu=${MCU}}"
 AVR_NM="${AVR_NM:-${ARDUINO_TOOLS_PATH}/avr/bin/avr-nm}"
 AVR_OBJDUMP="${AVR_OBJDUMP:-${ARDUINO_TOOLS_PATH}/avr/bin/avr-objdump}"
 AVRDUDE="${AVRDUDE:-${ARDUINO_TOOLS_PATH}/avr/bin/avrdude}"


### PR DESCRIPTION
  * Uses usbconfig to determine the Model 01's USB modem port.

  * Works around incompatibe avrsize flags.

You need to be able to run usbconfig to flash the firmware from the
buildtools. This can be accomplished with appropriate groups and devfs
rules.

Requires gmake, perl, avrdude, and (probably) arduino18 from ports.

The version of avrdude in ports uses an avr-size command that doesn't
understand the -C or --mcu flags. From what I can tell, these flags
are uneccessary, as the size computed with them is the same as what
you get from adding up the appropriate segments from the standard
output of avr-size without any flags. However, since the size is only
informative, I've opted to simply check to see if the command
succeeded, and if not, output a string saying it could not be.

It would probably be better to:

  * Determine appropriate flags based on build tools, or,

  * Just not use the flags at all, and grab the .text, etc., segment
    sizes from the standard output and add them up via `dc` for
    display.

I've been using this toolchain to build successfully on FreeBSD 12 for
the Model 01 without issue. It should work with earlier versions of
FreeBSD as well.