### PR TITLE
doc: Update the ErgoDox & Atreus docs to mention teensy_loader_cli

### DIFF
--- a/doc/plugin/Hardware-EZ-ErgoDox.md
+++ b/doc/plugin/Hardware-EZ-ErgoDox.md
@@ -1,6 +1,8 @@
 # Kaleidoscope-Hardware-ErgoDox
 
-This is a plugin for [Kaleidoscope][fw], that adds hardware support for
-the ErgoDox.
+This is a plugin for [Kaleidoscope][fw], that adds hardware support for the
+ErgoDox. To be able to flash the firmware, one will need the [Teensy Loader
+CLI][teensy_cli] tool in addition to Arduino.
 
+ [teensy_cli]: https://www.pjrc.com/teensy/loader_cli.html
  [fw]: https://github.com/keyboardio/Kaleidoscope

--- a/doc/plugin/Hardware-Technomancy-Atreus.md
+++ b/doc/plugin/Hardware-Technomancy-Atreus.md
@@ -6,6 +6,11 @@ MCU, and the hand-wired variant from [FalbaTech][falba] with a Teensy2.
 
 PCBs prior to 2016, and the legacy teensy2 variants are not supported.
 
+To be able to flash the firmware, one will need the [Teensy Loader
+CLI][teensy_cli] tool in addition to Arduino, if using a Teensy. If using an A*
+MCU, the additional tool is not required.
+
+ [teensy_cli]: https://www.pjrc.com/teensy/loader_cli.html
  [fw]: https://github.com/keyboardio/Kaleidoscope
  [atreus]: https://atreus.technomancy.us/
  [falba]: https://falba.tech/


### PR DESCRIPTION
The ErgoDox typically uses a Teensy, and the Atreus has the option to as well. In both cases, the flashing procedure (whether through the IDE or CLI) will require the `teensy_loader_cli` tool installed.

Fixes #479.