### PR TITLE
New plugin: WinKeyToggle

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -101,6 +101,10 @@ To make it easier to port Kaleidoscope, we introduced the [ATMegaKeyboard](doc/p
 
 The [IdleLEDs](doc/plugin/IdleLEDs.md) plugin is a simple, yet, useful one: it will turn the keyboard LEDs off after a period of inactivity, and back on upon the next key event.
 
+### WinKeyToggle
+
+The [WinKeyToggle](doc/plugin/WinKeyToggle.md) plugin assists with toggling the Windows key on and off - a little something for those of us who game under Windows and are tired of accidentally popping up the start menu.
+
 ## Breaking changes
 
 ### The `RxCy` macros and peeking into the keyswitch state

--- a/doc/plugin/WinKeyToggle.md
+++ b/doc/plugin/WinKeyToggle.md
@@ -1,0 +1,55 @@
+# Kaleidoscope-WinKeyToggle
+
+If you ever played games on Windows on a traditional keyboard, you likely ran
+into the issue of the Windows key: in the heat of the moment, you accidentally
+hit the windows key, and find yourself out of the game on the desktop, with the
+Start menu open. Annoying, is it? So you'd like to *temporarily* disable the key
+while gaming, and this plugin will help you achieve that.
+
+This plugin provides a method to toggle the windows keys on and off. Bind it to
+a macro, or a magic combo, and you have an easy way to toggle the key on and
+off.
+
+## Using the extension
+
+```c++
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-MagicCombo.h>
+#include <Kaleidoscope-WinKeyToggle.h>
+
+enum { WINKEY_TOGGLE };
+
+void toggleWinKey(uint8_t combo_index) {
+  WinKeyToggle.toggle();
+}
+
+USE_MAGIC_COMBOS(
+[WINKEY_TOGGLE] = {
+  .action = toggleWinKey,
+  .keys = {R3C6, R3C9} // Left Fn + Right Fn
+});
+
+KALEIDOSCOPE_INIT_PLUGINS(MagicCombo, WinKeyToggle);
+
+void setup() {
+  Kaleidoscope.setup();
+}
+```
+
+## Plugin properties
+
+The extension provides a `WinKeyToggle` singleton object, with the following
+method:
+
+### `.toggle`
+
+> Toggles the Windows keys on and off.
+>
+> Defaults to off.
+
+## Further reading
+
+Starting from the [example][plugin:example] is the recommended way of getting
+started with the plugin.
+
+ [plugin:example]: ../../examples/WinKeyToggle/WinKeyToggle.ino

--- a/examples/Keystrokes/WinKeyToggle/WinKeyToggle.ino
+++ b/examples/Keystrokes/WinKeyToggle/WinKeyToggle.ino
@@ -1,0 +1,65 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-WinKeyToggle -- Toggle the Windows (GUI) key on/off
+ * Copyright (C) 2018  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-MagicCombo.h>
+#include <Kaleidoscope-WinKeyToggle.h>
+
+enum {
+  WINKEYTOGGLE
+};
+
+void toggleWinKey(uint8_t index) {
+  WinKeyToggle.toggle();
+}
+
+USE_MAGIC_COMBOS([WINKEYTOGGLE] = {
+  .action = toggleWinKey,
+  .keys = {R3C6, R3C9}
+});
+
+// *INDENT-OFF*
+KEYMAPS(
+  [0] = KEYMAP_STACKED
+  (
+    Key_NoKey, Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
+    Key_Backtick,      Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+    Key_PageUp,        Key_A, Key_S, Key_D, Key_F, Key_G,
+    Key_PageDown,      Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+
+    Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+    Key_NoKey,
+
+    Key_skip,  Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
+    Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
+               Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
+    Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
+
+    Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
+    Key_NoKey),
+)
+// *INDENT-ON*
+
+KALEIDOSCOPE_INIT_PLUGINS(MagicCombo, WinKeyToggle);
+
+void setup() {
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/src/Kaleidoscope-WinKeyToggle.h
+++ b/src/Kaleidoscope-WinKeyToggle.h
@@ -1,0 +1,20 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-WinKeyToggle -- Heatmap LED effect for Kaleidoscope.
+ * Copyright (C) 2018  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <kaleidoscope/plugin/WinKeyToggle.h>

--- a/src/kaleidoscope/plugin/WinKeyToggle.cpp
+++ b/src/kaleidoscope/plugin/WinKeyToggle.cpp
@@ -1,0 +1,38 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-WinKeyToggle -- Toggle the Windows (GUI) key on/off
+ * Copyright (C) 2018  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-WinKeyToggle.h>
+
+namespace kaleidoscope {
+namespace plugin {
+
+bool WinKeyToggle::enabled_;
+
+EventHandlerResult WinKeyToggle::onKeyswitchEvent(Key &key, byte row, byte col, uint8_t key_state) {
+  if (!enabled_)
+    return EventHandlerResult::OK;
+
+  if (key == Key_LeftGui || key == Key_RightGui)
+    return EventHandlerResult::EVENT_CONSUMED;
+
+  return EventHandlerResult::OK;
+}
+}
+}
+
+kaleidoscope::plugin::WinKeyToggle WinKeyToggle;

--- a/src/kaleidoscope/plugin/WinKeyToggle.h
+++ b/src/kaleidoscope/plugin/WinKeyToggle.h
@@ -1,0 +1,38 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-WinKeyToggle -- Toggle the Windows (GUI) key on/off
+ * Copyright (C) 2018  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <Kaleidoscope.h>
+
+namespace kaleidoscope {
+namespace plugin {
+class WinKeyToggle: public kaleidoscope::Plugin {
+ public:
+  WinKeyToggle() {}
+
+  EventHandlerResult onKeyswitchEvent(Key &key, byte row, byte col, uint8_t key_state);
+  void toggle() {
+    enabled_ = !enabled_;
+  }
+ private:
+  static bool enabled_;
+};
+}
+}
+
+extern kaleidoscope::plugin::WinKeyToggle WinKeyToggle;


### PR DESCRIPTION
Based on a discussion on Discord, this implements a simple plugin that can temporarily disable the Windows (GUI) keys.
