### PR TITLE
Require an explicit Serial.begin() for Focus

### DIFF
--- a/src/kaleidoscope/Kaleidoscope.cpp
+++ b/src/kaleidoscope/Kaleidoscope.cpp
@@ -26,6 +26,16 @@ Kaleidoscope_::Kaleidoscope_(void) {
 
 void
 Kaleidoscope_::setup(void) {
+  // We are explicitly initializing the Serial port as early as possible to
+  // (temporarily, hopefully) work around an issue on OSX. If we initialize
+  // Serial too late, no matter what we do, we'll end up reading garbage from
+  // the serial port. For more information, see the following issue:
+  //   https://github.com/keyboardio/Kaleidoscope-Bundle-Keyboardio/pull/7
+  //
+  // TODO(anyone): Figure out a way we can get rid of this, and fix the bug
+  // properly.
+  Serial.begin(9600);
+
   kaleidoscope::Hooks::onSetup();
 
   KeyboardHardware.setup();

--- a/src/kaleidoscope/plugin/FocusSerial.h
+++ b/src/kaleidoscope/plugin/FocusSerial.h
@@ -85,10 +85,6 @@ class FocusSerial : public kaleidoscope::Plugin {
   static constexpr char SEPARATOR = ' ';
 
   /* Hooks */
-  EventHandlerResult onSetup() {
-    Serial.begin(9600);
-    return EventHandlerResult::OK;
-  }
   EventHandlerResult beforeReportingState();
   EventHandlerResult onFocusEvent(const char *command);
 


### PR DESCRIPTION
Turns out that if we do the `Serial.begin(9600)` in Focus's `onSetup()`, it is either too late, or not enough. When doing it the first thing in `setup()`, things work much better on OSX. So lets do that! Explicit is better than implicit anyway.

This removes the implicit initialization from FocusSerial, and updates all docs and examples that need an update.
