### PR TITLE
New plugin: ActiveLayerColor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -102,6 +102,10 @@ To make it easier to port Kaleidoscope, we introduced the [ATMegaKeyboard](doc/p
 
 The [IdleLEDs](doc/plugin/IdleLEDs.md) plugin is a simple, yet, useful one: it will turn the keyboard LEDs off after a period of inactivity, and back on upon the next key event.
 
+### LEDActiveLayerColor
+
+The [LEDActiveLayerColor][doc/plugin/LEDActiveLayerColor.md] plugin makes it possible to set the color of all LEDs to the same color, depending on which layer is active topmost.
+
 ### WinKeyToggle
 
 The [WinKeyToggle](doc/plugin/WinKeyToggle.md) plugin assists with toggling the Windows key on and off - a little something for those of us who game under Windows and are tired of accidentally popping up the start menu.

--- a/doc/plugin/LED-ActiveLayerColor.md
+++ b/doc/plugin/LED-ActiveLayerColor.md
@@ -1,0 +1,53 @@
+# Kaleidoscope-LED-ActiveLayerColor
+
+A simple way to light up the keyboard in uniform colors, depending on what layer
+one's on. Unlike [Colormap](Colormap.md), all keys will be the same color. But
+this plugin uses considerably less resources, and is easier to set up as well. A
+perfect solution when one wants to quickly see what layer they're on, with
+minimal resources and time investment.
+
+## Using the plugin
+
+To use the plugin, one needs to include the header, and activate the effect.
+Then, one needs to configure a color map:
+
+```c++
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-LEDControl.h>
+#include <Kaleidoscope-LED-ActiveLayerColor.h>
+
+KALEIDOSCOPE_INIT_PLUGINS(LEDControl,
+                          ActiveLayerColorEffect);
+
+void setup () {
+  static const cRGB layerColormap[] PROGMEM = {
+    CRGB(128, 0, 0),
+    CRGB(0, 128, 0)
+  };
+
+  Kaleidoscope.setup();
+  LEDActiveLayerColorEffect.setColormap(layerColormap);
+}
+```
+
+## Plugin properties
+
+The plugin provides the `LEDActiveLayerColorEffect` object, which has the following
+method:
+
+### `.setColormap(colormap)`
+
+> Sets the colormap to the supplied map. Each element of the map should be a
+> `cRGB` color, and the array must have the same amount of items as there are
+> layers. The map should reside in PROGMEM.
+
+## Dependencies
+
+* [Kaleidoscope-LEDControl](LEDControl.md)
+
+## Further reading
+
+Starting from the [example][plugin:example] is the recommended way of getting
+started with the plugin.
+
+ [plugin:example]: ../../examples/LEDs/LED-ActiveLayerColor/LED-ActiveLayerColor.ino

--- a/examples/LEDs/LED-ActiveLayerColor/LED-ActiveLayerColor.ino
+++ b/examples/LEDs/LED-ActiveLayerColor/LED-ActiveLayerColor.ino
@@ -1,0 +1,78 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-LED-ActiveLayerColor -- Light up the LEDs based on the active layers
+ * Copyright (C) 2018  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-LEDControl.h>
+#include <Kaleidoscope-LED-ActiveLayerColor.h>
+
+// *INDENT-OFF*
+KEYMAPS(
+  [0] = KEYMAP_STACKED
+  (
+    Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext,
+    Key_Backtick,      Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+    Key_PageUp,        Key_A, Key_S, Key_D, Key_F, Key_G,
+    Key_PageDown,      Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+
+    Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+    ShiftToLayer(1),
+
+    Key_skip,  Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
+    Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
+               Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
+    Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
+
+    Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
+    ShiftToLayer(1)
+  ),
+  [1] = KEYMAP_STACKED
+  (
+    Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext,
+    Key_Backtick,      Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+    Key_PageUp,        Key_A, Key_S, Key_D, Key_F, Key_G,
+    Key_PageDown,      Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+
+    Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+    ShiftToLayer(0),
+
+    Key_skip,  Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
+    Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
+               Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
+    Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
+
+    Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
+    ShiftToLayer(0)
+  )
+)
+// *INDENT-ON*
+
+KALEIDOSCOPE_INIT_PLUGINS(LEDControl,
+                          LEDActiveLayerColorEffect);
+
+void setup() {
+  static const cRGB layerColormap[] PROGMEM = {
+    CRGB(128, 0, 0),
+    CRGB(0, 128, 0)
+  };
+
+  Kaleidoscope.setup();
+  LEDActiveLayerColorEffect.setColormap(layerColormap);
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/src/Kaleidoscope-LED-ActiveLayerColor.h
+++ b/src/Kaleidoscope-LED-ActiveLayerColor.h
@@ -1,0 +1,20 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-LED-ActiveLayerColor -- Light up the LEDs based on the active layers
+ * Copyright (C) 2018  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <kaleidoscope/plugin/LED-ActiveLayerColor.h>

--- a/src/kaleidoscope/plugin/LED-ActiveLayerColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveLayerColor.cpp
@@ -1,0 +1,63 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-LED-ActiveLayerColor -- Light up the LEDs based on the active layers
+ * Copyright (C) 2018  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope-LED-ActiveLayerColor.h>
+
+namespace kaleidoscope {
+namespace plugin {
+
+cRGB LEDActiveLayerColorEffect::active_color_;
+const cRGB *LEDActiveLayerColorEffect::colormap_;
+
+void LEDActiveLayerColorEffect::setColormap(const cRGB colormap[]) {
+  colormap_ = colormap;
+}
+
+cRGB LEDActiveLayerColorEffect::getActiveColor() {
+  cRGB color;
+
+  uint8_t top_layer = ::Layer.top();
+
+  color.r = pgm_read_byte(&(colormap_[top_layer].r));
+  color.g = pgm_read_byte(&(colormap_[top_layer].g));
+  color.b = pgm_read_byte(&(colormap_[top_layer].b));
+
+  return color;
+}
+
+void LEDActiveLayerColorEffect::onActivate(void) {
+  if (!Kaleidoscope.has_leds)
+    return;
+
+  active_color_ = getActiveColor();
+  ::LEDControl.set_all_leds_to(active_color_);
+}
+
+void LEDActiveLayerColorEffect::refreshAt(byte row, byte col) {
+  ::LEDControl.setCrgbAt(row, col, active_color_);
+}
+
+EventHandlerResult LEDActiveLayerColorEffect::onLayerChange() {
+  if (::LEDControl.get_mode() == this)
+    onActivate();
+  return EventHandlerResult::OK;
+}
+
+}
+}
+
+kaleidoscope::plugin::LEDActiveLayerColorEffect LEDActiveLayerColorEffect;

--- a/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
+++ b/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
@@ -1,0 +1,44 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-LED-ActiveLayerColor -- Light up the LEDs based on the active layers
+ * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <Kaleidoscope-LEDControl.h>
+
+namespace kaleidoscope {
+namespace plugin {
+class LEDActiveLayerColorEffect : public LEDMode {
+ public:
+  LEDActiveLayerColorEffect(void) {}
+
+  EventHandlerResult onLayerChange();
+  void setColormap(const cRGB colormap[]);
+
+ protected:
+  void onActivate(void) final;
+  void refreshAt(byte row, byte col) final;
+
+ private:
+  static const cRGB *colormap_;
+  static cRGB active_color_;
+
+  static cRGB getActiveColor();
+};
+}
+}
+
+extern kaleidoscope::plugin::LEDActiveLayerColorEffect LEDActiveLayerColorEffect;


### PR DESCRIPTION
As the name implies, this makes it possible to set all leds to the same color depending on which layer is the topmost active one.

Fixes #492.

This is not a direct port, but rather a reimagining of the same idea, with a more modern API, using functionality recent Kaleidoscope provides.