### PR TITLE
doc/plugin/: Update all the example references

### DIFF
--- a/doc/plugin/Colormap.md
+++ b/doc/plugin/Colormap.md
@@ -66,4 +66,4 @@ The extension provides an `ColormapEffect` singleton object, with a single metho
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/Colormap/Colormap.ino
+ [plugin:example]: ../../examples/LEDs/Colormap/Colormap.ino

--- a/doc/plugin/Cycle.md
+++ b/doc/plugin/Cycle.md
@@ -96,4 +96,4 @@ method explained below.
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/Cycle/Cycle.ino
+ [plugin:example]: ../../examples/Keystrokes/Cycle/Cycle.ino

--- a/doc/plugin/CycleTimeReport.md
+++ b/doc/plugin/CycleTimeReport.md
@@ -50,4 +50,4 @@ property. All times are in milliseconds.
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/CycleTimeReport/CycleTimeReport.ino
+ [plugin:example]: ../../examples/Features/CycleTimeReport/CycleTimeReport.ino

--- a/doc/plugin/EEPROM-Keymap-Programmer.md
+++ b/doc/plugin/EEPROM-Keymap-Programmer.md
@@ -121,4 +121,4 @@ in turn provides the following command:
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
-  [plugin:example]: ../../examples/EEPROM-Keymap-Programmer/EEPROM-Keymap-Programmer.ino
+  [plugin:example]: ../../examples/Features/EEPROM/EEPROM-Keymap-Programmer/EEPROM-Keymap-Programmer.ino

--- a/doc/plugin/EEPROM-Keymap.md
+++ b/doc/plugin/EEPROM-Keymap.md
@@ -62,4 +62,4 @@ The plugin provides the `keymap.map` and a `keymap.roLayers` commands.
 
 Starting from the [example][plugin:example] is the recommended way of getting started with the plugin.
 
-  [plugin:example]: ../../examples/EEPROM-Keymap/EEPROM-Keymap.ino
+  [plugin:example]: ../../examples/Features/EEPROM/EEPROM-Keymap/EEPROM-Keymap.ino

--- a/doc/plugin/EEPROM-Settings.md
+++ b/doc/plugin/EEPROM-Settings.md
@@ -165,4 +165,4 @@ following commands:
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
-  [plugin:example]: ../../examples/EEPROM-Settings/EEPROM-Settings.ino
+  [plugin:example]: ../../examples/Features/EEPROM/EEPROM-Settings/EEPROM-Settings.ino

--- a/doc/plugin/Escape-OneShot.md
+++ b/doc/plugin/Escape-OneShot.md
@@ -38,4 +38,4 @@ The plugin provides the `EscapeOneShot` object, which has no public methods.
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/Escape-OneShot/Escape-OneShot.ino
+ [plugin:example]: ../../examples/Keystrokes/Escape-OneShot/Escape-OneShot.ino

--- a/doc/plugin/FingerPainter.md
+++ b/doc/plugin/FingerPainter.md
@@ -59,4 +59,4 @@ The plugin provides the `FingerPainter` object, which provides no public methods
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
-  [plugin:example]: ../../examples/FingerPainter/FingerPainter.ino
+  [plugin:example]: ../../examples/LEDs/FingerPainter/FingerPainter.ino

--- a/doc/plugin/FocusSerial.md
+++ b/doc/plugin/FocusSerial.md
@@ -123,4 +123,4 @@ the keyboard responds.
 
 Starting from the [example][plugin:example] is the recommended way of getting started with the plugin.
 
-  [plugin:example]: ../../examples/FocusSerial/FocusSerial.ino
+  [plugin:example]: ../../examples/Features/FocusSerial/FocusSerial.ino

--- a/doc/plugin/GhostInTheFirmware.md
+++ b/doc/plugin/GhostInTheFirmware.md
@@ -74,4 +74,4 @@ methods and properties:
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/GhostInTheFirmware/GhostInTheFirmware.ino
+ [plugin:example]: ../../examples/Features/GhostInTheFirmware/GhostInTheFirmware.ino

--- a/doc/plugin/Heatmap.md
+++ b/doc/plugin/Heatmap.md
@@ -86,4 +86,4 @@ and properties:
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/Heatmap/Heatmap.ino
+ [plugin:example]: ../../examples/LEDs/Heatmap/Heatmap.ino

--- a/doc/plugin/HostOS.md
+++ b/doc/plugin/HostOS.md
@@ -81,4 +81,4 @@ provides the `hostos.type` Focus command.
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the extension.
 
- [plugin:example]: ../../examples/HostOS/HostOS.ino
+ [plugin:example]: ../../examples/Features/HostOS/HostOS.ino

--- a/doc/plugin/HostPowerManagement.md
+++ b/doc/plugin/HostPowerManagement.md
@@ -44,4 +44,4 @@ The plugin provides the `HostPowerManagement` object, with no public methods.
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/HostPowerManagement/HostPowerManagement.ino
+ [plugin:example]: ../../examples/Features/HostPowerManagement/HostPowerManagement.ino

--- a/doc/plugin/IdleLEDs.md
+++ b/doc/plugin/IdleLEDs.md
@@ -55,4 +55,4 @@ properties. All times are in seconds.
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/IdleLEDs/IdleLEDs.ino
+ [plugin:example]: ../../examples/LEDs/IdleLEDs/IdleLEDs.ino

--- a/doc/plugin/LED-ActiveModColor.md
+++ b/doc/plugin/LED-ActiveModColor.md
@@ -53,4 +53,4 @@ properties:
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/LED-ActiveModColor/LED-ActiveModColor.ino
+ [plugin:example]: ../../examples/LEDs/LED-ActiveModColor/LED-ActiveModColor.ino

--- a/doc/plugin/LED-AlphaSquare.md
+++ b/doc/plugin/LED-AlphaSquare.md
@@ -99,4 +99,4 @@ been an exaggeration, there is only one as of this writing:
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/LED-AlphaSquare/LED-AlphaSquare.ino
+ [plugin:example]: ../../examples/LEDs/LED-AlphaSquare/LED-AlphaSquare.ino

--- a/doc/plugin/LED-Palette-Theme.md
+++ b/doc/plugin/LED-Palette-Theme.md
@@ -125,4 +125,4 @@ The plugin provides the `LEDPaletteTheme` object, which has the following method
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
-  [plugin:example]: ../../examples/LED-Palette-Theme/LED-Palette-Theme.ino
+  [plugin:example]: ../../examples/LEDs/LED-Palette-Theme/LED-Palette-Theme.ino

--- a/doc/plugin/LED-Stalker.md
+++ b/doc/plugin/LED-Stalker.md
@@ -87,4 +87,4 @@ The plugin provides the following effects:
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/LED-Stalker/LED-Stalker.ino
+ [plugin:example]: ../../examples/LEDs/LED-Stalker/LED-Stalker.ino

--- a/doc/plugin/LEDEffects.md
+++ b/doc/plugin/LEDEffects.md
@@ -68,4 +68,4 @@ The plugin provides a single method on each of the included effect objects:
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/LEDEffects/LEDEffects.ino
+ [plugin:example]: ../../examples/LEDs/LEDEffects/LEDEffects.ino

--- a/doc/plugin/Leader.md
+++ b/doc/plugin/Leader.md
@@ -97,4 +97,4 @@ The plugin provides the `Leader` object, with the following methods and properti
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/Leader/Leader.ino
+ [plugin:example]: ../../examples/Keystrokes/Leader/Leader.ino

--- a/doc/plugin/MagicCombo.md
+++ b/doc/plugin/MagicCombo.md
@@ -67,4 +67,4 @@ started with the plugin.
 
 ![rxcy layout](../model01_coordinates.png)
 
- [plugin:example]: ../../examples/MagicCombo/MagicCombo.ino
+ [plugin:example]: ../../examples/Keystrokes/MagicCombo/MagicCombo.ino

--- a/doc/plugin/OneShot.md
+++ b/doc/plugin/OneShot.md
@@ -203,4 +203,4 @@ properties too:
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/OneShot/OneShot.ino
+ [plugin:example]: ../../examples/Keystrokes/OneShot/OneShot.ino

--- a/doc/plugin/Qukeys.md
+++ b/doc/plugin/Qukeys.md
@@ -149,4 +149,4 @@ limit, you won't get any unintended alternate keycodes.
 
 The [example][plugin:example] can help to learn how to use this plugin.
 
- [plugin:example]: ../../examples/Qukeys/Qukeys.ino
+ [plugin:example]: ../../examples/Keystrokes/Qukeys/Qukeys.ino

--- a/doc/plugin/Redial.md
+++ b/doc/plugin/Redial.md
@@ -60,4 +60,4 @@ The `Redial` object has only one property, the key to trigger it.
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/Redial/Redial.ino
+ [plugin:example]: ../../examples/Keystrokes/Redial/Redial.ino

--- a/doc/plugin/ShapeShifter.md
+++ b/doc/plugin/ShapeShifter.md
@@ -58,4 +58,4 @@ properties:
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/ShapeShifter/ShapeShifter.ino
+ [plugin:example]: ../../examples/Keystrokes/ShapeShifter/ShapeShifter.ino

--- a/doc/plugin/SpaceCadet.md
+++ b/doc/plugin/SpaceCadet.md
@@ -154,4 +154,4 @@ properties:
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/SpaceCadet/SpaceCadet.ino
+ [plugin:example]: ../../examples/Keystrokes/SpaceCadet/SpaceCadet.ino

--- a/doc/plugin/Steno.md
+++ b/doc/plugin/Steno.md
@@ -93,4 +93,4 @@ The plugin provides a `GeminiPR` object, with no public methods or properties.
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/Steno/Steno.ino
+ [plugin:example]: ../../examples/Features/Steno/Steno.ino

--- a/doc/plugin/Syster.md
+++ b/doc/plugin/Syster.md
@@ -94,4 +94,4 @@ methods outside of the object, however, that can be overridden:
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/Syster/Syster.ino
+ [plugin:example]: ../../examples/Keystrokes/Syster/Syster.ino

--- a/doc/plugin/TapDance.md
+++ b/doc/plugin/TapDance.md
@@ -143,4 +143,4 @@ property only:
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/TapDance/TapDance.ino
+ [plugin:example]: ../../examples/Keystrokes/TapDance/TapDance.ino

--- a/doc/plugin/TopsyTurvy.md
+++ b/doc/plugin/TopsyTurvy.md
@@ -48,4 +48,4 @@ The plugin provides the `TopsyTurvy` object, without any public methods or prope
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/TopsyTurvy/TopsyTurvy.ino
+ [plugin:example]: ../../examples/Keystrokes/TopsyTurvy/TopsyTurvy.ino

--- a/doc/plugin/TypingBreaks.md
+++ b/doc/plugin/TypingBreaks.md
@@ -105,4 +105,4 @@ properties. All times are in seconds.
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/TypingBreaks/TypingBreaks.ino
+ [plugin:example]: ../../examples/Features/TypingBreaks/TypingBreaks.ino

--- a/doc/plugin/Unicode.md
+++ b/doc/plugin/Unicode.md
@@ -121,4 +121,4 @@ the `+` button, selecting it from the list, then setting it as the active input 
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/Unicode/Unicode.ino
+ [plugin:example]: ../../examples/Keystrokes/Unicode/Unicode.ino

--- a/doc/plugin/WinKeyToggle.md
+++ b/doc/plugin/WinKeyToggle.md
@@ -52,4 +52,4 @@ method:
 Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
- [plugin:example]: ../../examples/WinKeyToggle/WinKeyToggle.ino
+ [plugin:example]: ../../examples/Keystrokes/WinKeyToggle/WinKeyToggle.ino


### PR DESCRIPTION
The examples were recently reorganized, but the documentation was not updated, so some of them were pointing to dangling, obsolete places. This updates them all to point to the correct locations.
