### PR TITLE
kaleidoscope-builder: Fix the avr-size invocation

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -292,7 +292,8 @@ size () {
     fi
 
     echo "- Size: firmware/${LIBRARY}/${OUTPUT_FILE_PREFIX}.elf"
-    firmware_size "${AVR_SIZE}" "${AVR_SIZE_FLAGS}" "${ELF_FILE_PATH}"
+    # shellcheck disable=SC2086 # We want word splitting here!
+    firmware_size "${AVR_SIZE}" ${AVR_SIZE_FLAGS} "${ELF_FILE_PATH}"
     echo
 }
 


### PR DESCRIPTION
When calling avr-size, we want to expand ${AVR_SIZE_FLAGS}, not pass it as a single argument, hence, we do not need to - and do not want to! - quote it.

Without this, size computation will almost always fail, because avr-size will throw errors instead of calculating the size.