### PR TITLE
Allow plugins to modify live_composite_keymap_

### DIFF
--- a/src/kaleidoscope/key_events.cpp
+++ b/src/kaleidoscope/key_events.cpp
@@ -82,7 +82,7 @@ void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
     /* If a key had an on event, we update the live composite keymap. See
      * layers.h for an explanation about the different caches we have. */
     if (keyToggledOn(keyState)) {
-      if (mappedKey.raw == Key_NoKey.raw) {
+      if (mappedKey.raw == Key_NoKey.raw || keyState & EPHEMERAL) {
         Layer.updateLiveCompositeKeymap(row, col);
       } else {
         Layer.updateLiveCompositeKeymap(row, col, mappedKey);

--- a/src/kaleidoscope/key_events.cpp
+++ b/src/kaleidoscope/key_events.cpp
@@ -81,8 +81,13 @@ void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
 
     /* If a key had an on event, we update the live composite keymap. See
      * layers.h for an explanation about the different caches we have. */
-    if (keyToggledOn(keyState))
-      Layer.updateLiveCompositeKeymap(row, col);
+    if (keyToggledOn(keyState)) {
+      if (mappedKey.raw == Key_NoKey.raw) {
+        Layer.updateLiveCompositeKeymap(row, col);
+      } else {
+        Layer.updateLiveCompositeKeymap(row, col, mappedKey);
+      }
+    }
 
     /* If the key we are dealing with is masked, ignore it until it is released.
      * When releasing it, clear the mask, so future key events can be handled

--- a/src/kaleidoscope/keyswitch_state.h
+++ b/src/kaleidoscope/keyswitch_state.h
@@ -20,6 +20,7 @@
 #include <Arduino.h>
 
 #define INJECTED    B10000000
+#define EPHEMERAL   B01000000
 #define IS_PRESSED  B00000010
 #define WAS_PRESSED B00000001
 

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -99,6 +99,9 @@ class Layer_ {
   static Key getKeyFromPROGMEM(uint8_t layer, byte row, byte col);
 
   static void updateLiveCompositeKeymap(byte row, byte col);
+  static void updateLiveCompositeKeymap(byte row, byte col, Key mappedKey) {
+    live_composite_keymap_[row][col] = mappedKey;
+  }
   static void updateActiveLayers(void);
 
  private:

--- a/src/kaleidoscope/plugin/OneShot.cpp
+++ b/src/kaleidoscope/plugin/OneShot.cpp
@@ -70,7 +70,7 @@ void OneShot::injectNormalKey(uint8_t idx, uint8_t key_state) {
   }
 
   positionToCoords(state_[idx].position, &row, &col);
-  handleKeyswitchEvent(key, row, col, key_state | INJECTED);
+  handleKeyswitchEvent(key, UNKNOWN_KEYSWITCH_LOCATION, key_state | INJECTED);
 }
 
 void OneShot::activateOneShot(uint8_t idx) {

--- a/src/kaleidoscope/plugin/OneShot.cpp
+++ b/src/kaleidoscope/plugin/OneShot.cpp
@@ -51,11 +51,6 @@ bool OneShot::isStickable(Key key) {
   return state_[key.raw - ranges::OS_FIRST].stickable;
 }
 
-void OneShot::positionToCoords(uint8_t pos, byte *row, byte *col) {
-  *col = pos % COLS;
-  *row = (pos - *col) / COLS;
-}
-
 // ---- OneShot stuff ----
 void OneShot::injectNormalKey(uint8_t idx, uint8_t key_state) {
   Key key;
@@ -69,7 +64,6 @@ void OneShot::injectNormalKey(uint8_t idx, uint8_t key_state) {
     key.keyCode = LAYER_SHIFT_OFFSET + idx - 8;
   }
 
-  positionToCoords(state_[idx].position, &row, &col);
   handleKeyswitchEvent(key, UNKNOWN_KEYSWITCH_LOCATION, key_state | INJECTED);
 }
 

--- a/src/kaleidoscope/plugin/OneShot.h
+++ b/src/kaleidoscope/plugin/OneShot.h
@@ -95,8 +95,6 @@ class OneShot : public kaleidoscope::Plugin {
   static bool should_cancel_;
   static bool should_cancel_stickies_;
 
-  static void positionToCoords(uint8_t pos, byte *row, byte *col);
-
   static void injectNormalKey(uint8_t idx, uint8_t key_state);
   static void activateOneShot(uint8_t idx);
   static void cancelOneShot(uint8_t idx);

--- a/src/kaleidoscope/plugin/SpaceCadet.cpp
+++ b/src/kaleidoscope/plugin/SpaceCadet.cpp
@@ -130,7 +130,7 @@ EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, byte row, byte 
         //hit another key after this -- if it's a modifier, we want the modifier
         //key to be added to the report, for things like ctrl, alt, shift, etc)
         if (map[i].flagged) {
-          handleKeyswitchEvent(map[i].input, row, col, IS_PRESSED | INJECTED);
+          handleKeyswitchEvent(map[i].input, UNKNOWN_KEYSWITCH_LOCATION, IS_PRESSED | INJECTED);
         }
 
         //The keypress wasn't a match, so we need to mark it as not flagged and


### PR DESCRIPTION
This change allows plugins to call `handleKeyswitchEvent()` with a `mappedKey` value other than `Key_NoKey`, and have that value stored in `live_composite_keymap_` instead of looking up the value on the top active layer for that key. This would make it possible for a plugin to set the `Key` value of a key to something other than what's in the keymap, and not have to change it every cycle while the key is held in order for it to stay that way.

The known problem that this addresses is a bug that prevents layer-shift keys from working properly with Qukeys, which stores an alternate `Key` value, which is layer-specific, for each `Qukey` object. It calls `handleKeyswitchEvent()` so that other plugin hooks will be called, and specifies a `mappedKey` value to override what's in the keymap. The problem is that if the alternate `Key` value is `ShiftToLayer(N)`, when the next scan cycle comes around, Kaleidoscope indicates that the layer the key is mapped from is `N`, even though that's not where the still-held key's entry in `live_composite_keymap_` came from. Thus Qukeys doesn't recognize that it's a qukey (or possibly identifies it as some other qukey), and doesn't update `mappedKey` appropriately. The end result was shifted layers getting stuck on.

This isn't the only possible fix, but it is by far the simplest.

[Edit: Does not fix issue #501]