### PR TITLE
kaleidoscope-builder: Make shellcheck happy

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -292,7 +292,7 @@ size () {
     fi
 
     echo "- Size: firmware/${LIBRARY}/${OUTPUT_FILE_PREFIX}.elf"
-    # shellcheck disable=SC2086 # We want word splitting here!
+    # shellcheck disable=SC2086
     firmware_size "${AVR_SIZE}" ${AVR_SIZE_FLAGS} "${ELF_FILE_PATH}"
     echo
 }


### PR DESCRIPTION
Apparently, the shellcheck on Travis does not like comments after a disable command, while the one I used locally didn't have a problem with it. Lets make the one on Travis happy.