### PR TITLE
Fix Qukeys layer-shift bugs

### DIFF
--- a/src/kaleidoscope/key_events.cpp
+++ b/src/kaleidoscope/key_events.cpp
@@ -82,7 +82,7 @@ void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
     /* If a key had an on event, we update the live composite keymap. See
      * layers.h for an explanation about the different caches we have. */
     if (keyToggledOn(keyState)) {
-      if (mappedKey.raw == Key_NoKey.raw) {
+      if (mappedKey.raw == Key_NoKey.raw || keyState & EPHEMERAL) {
         Layer.updateLiveCompositeKeymap(row, col);
       } else {
         Layer.updateLiveCompositeKeymap(row, col, mappedKey);

--- a/src/kaleidoscope/key_events.cpp
+++ b/src/kaleidoscope/key_events.cpp
@@ -81,8 +81,13 @@ void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
 
     /* If a key had an on event, we update the live composite keymap. See
      * layers.h for an explanation about the different caches we have. */
-    if (keyToggledOn(keyState))
-      Layer.updateLiveCompositeKeymap(row, col);
+    if (keyToggledOn(keyState)) {
+      if (mappedKey.raw == Key_NoKey.raw) {
+        Layer.updateLiveCompositeKeymap(row, col);
+      } else {
+        Layer.updateLiveCompositeKeymap(row, col, mappedKey);
+      }
+    }
 
     /* If the key we are dealing with is masked, ignore it until it is released.
      * When releasing it, clear the mask, so future key events can be handled

--- a/src/kaleidoscope/keyswitch_state.h
+++ b/src/kaleidoscope/keyswitch_state.h
@@ -20,6 +20,7 @@
 #include <Arduino.h>
 
 #define INJECTED    B10000000
+#define EPHEMERAL   B01000000
 #define IS_PRESSED  B00000010
 #define WAS_PRESSED B00000001
 

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -99,6 +99,9 @@ class Layer_ {
   static Key getKeyFromPROGMEM(uint8_t layer, byte row, byte col);
 
   static void updateLiveCompositeKeymap(byte row, byte col);
+  static void updateLiveCompositeKeymap(byte row, byte col, Key mappedKey) {
+    live_composite_keymap_[row][col] = mappedKey;
+  }
   static void updateActiveLayers(void);
 
  private:

--- a/src/kaleidoscope/plugin/OneShot.cpp
+++ b/src/kaleidoscope/plugin/OneShot.cpp
@@ -70,7 +70,7 @@ void OneShot::injectNormalKey(uint8_t idx, uint8_t key_state) {
   }
 
   positionToCoords(state_[idx].position, &row, &col);
-  handleKeyswitchEvent(key, row, col, key_state | INJECTED);
+  handleKeyswitchEvent(key, UNKNOWN_KEYSWITCH_LOCATION, key_state | INJECTED);
 }
 
 void OneShot::activateOneShot(uint8_t idx) {

--- a/src/kaleidoscope/plugin/OneShot.cpp
+++ b/src/kaleidoscope/plugin/OneShot.cpp
@@ -51,11 +51,6 @@ bool OneShot::isStickable(Key key) {
   return state_[key.raw - ranges::OS_FIRST].stickable;
 }
 
-void OneShot::positionToCoords(uint8_t pos, byte *row, byte *col) {
-  *col = pos % COLS;
-  *row = (pos - *col) / COLS;
-}
-
 // ---- OneShot stuff ----
 void OneShot::injectNormalKey(uint8_t idx, uint8_t key_state) {
   Key key;
@@ -69,7 +64,6 @@ void OneShot::injectNormalKey(uint8_t idx, uint8_t key_state) {
     key.keyCode = LAYER_SHIFT_OFFSET + idx - 8;
   }
 
-  positionToCoords(state_[idx].position, &row, &col);
   handleKeyswitchEvent(key, UNKNOWN_KEYSWITCH_LOCATION, key_state | INJECTED);
 }
 

--- a/src/kaleidoscope/plugin/OneShot.h
+++ b/src/kaleidoscope/plugin/OneShot.h
@@ -95,8 +95,6 @@ class OneShot : public kaleidoscope::Plugin {
   static bool should_cancel_;
   static bool should_cancel_stickies_;
 
-  static void positionToCoords(uint8_t pos, byte *row, byte *col);
-
   static void injectNormalKey(uint8_t idx, uint8_t key_state);
   static void activateOneShot(uint8_t idx);
   static void cancelOneShot(uint8_t idx);

--- a/src/kaleidoscope/plugin/Qukeys.cpp
+++ b/src/kaleidoscope/plugin/Qukeys.cpp
@@ -154,6 +154,7 @@ bool Qukeys::flushKey(bool qukey_state, uint8_t keyswitch_state) {
       // the queue, delay this key's release event:
       if (release_delay_ > 0 && key_queue_length_ > 1) {
         key_queue_[0].start_time = millis() + QUKEYS_RELEASE_DELAY_OFFSET;
+        // Store the alternate keycode to send the toggle-off event later, if appropriate:
         if (is_dual_use) {
           delayed_qukey_keycode_ = getDualUseAlternateKey(keycode);
         } else { // is_qukey
@@ -345,6 +346,8 @@ EventHandlerResult Qukeys::beforeReportingState() {
         setQukeyState(key_queue_[0].addr, QUKEY_STATE_PRIMARY);
         flushKey(QUKEY_STATE_PRIMARY, WAS_PRESSED);
         flushQueue();
+        // If the release delay has timed out, we need to prevent the wrong toggle-off
+        // event from being sent:
         delayed_qukey_keycode_ = Key_NoKey;
       }
       return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/Qukeys.h
+++ b/src/kaleidoscope/plugin/Qukeys.h
@@ -115,8 +115,8 @@ class Qukeys : public kaleidoscope::Plugin {
   static uint8_t key_queue_length_;
   static bool flushing_queue_;
 
-  static Key delayed_qukey_keycode_;
   static uint8_t delayed_qukey_addr_;
+  static int16_t delayed_qukey_start_time_;
 
   static int8_t lookupQukey(uint8_t key_addr);
   static void enqueue(uint8_t key_addr);

--- a/src/kaleidoscope/plugin/Qukeys.h
+++ b/src/kaleidoscope/plugin/Qukeys.h
@@ -118,15 +118,6 @@ class Qukeys : public kaleidoscope::Plugin {
   static Key delayed_qukey_keycode_;
   static uint8_t delayed_qukey_addr_;
 
-  // Qukey state bitfield
-  static uint8_t qukey_state_[(TOTAL_KEYS) / 8 + ((TOTAL_KEYS) % 8 ? 1 : 0)];
-  static bool getQukeyState(uint8_t addr) {
-    return bitRead(qukey_state_[addr / 8], addr % 8);
-  }
-  static void setQukeyState(uint8_t addr, boolean qukey_state) {
-    bitWrite(qukey_state_[addr / 8], addr % 8, qukey_state);
-  }
-
   static int8_t lookupQukey(uint8_t key_addr);
   static void enqueue(uint8_t key_addr);
   static int8_t searchQueue(uint8_t key_addr);

--- a/src/kaleidoscope/plugin/Qukeys.h
+++ b/src/kaleidoscope/plugin/Qukeys.h
@@ -115,6 +115,9 @@ class Qukeys : public kaleidoscope::Plugin {
   static uint8_t key_queue_length_;
   static bool flushing_queue_;
 
+  static Key delayed_qukey_keycode_;
+  static uint8_t delayed_qukey_addr_;
+
   // Qukey state bitfield
   static uint8_t qukey_state_[(TOTAL_KEYS) / 8 + ((TOTAL_KEYS) % 8 ? 1 : 0)];
   static bool getQukeyState(uint8_t addr) {

--- a/src/kaleidoscope/plugin/SpaceCadet.cpp
+++ b/src/kaleidoscope/plugin/SpaceCadet.cpp
@@ -130,7 +130,7 @@ EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, byte row, byte 
         //hit another key after this -- if it's a modifier, we want the modifier
         //key to be added to the report, for things like ctrl, alt, shift, etc)
         if (map[i].flagged) {
-          handleKeyswitchEvent(map[i].input, row, col, IS_PRESSED | INJECTED);
+          handleKeyswitchEvent(map[i].input, UNKNOWN_KEYSWITCH_LOCATION, IS_PRESSED | INJECTED);
         }
 
         //The keypress wasn't a match, so we need to mark it as not flagged and


### PR DESCRIPTION
First, this removes code made obsolete by #502, which it is built on (which fixes a major bug in using `ShiftToLayer()` keys with Qukeys.

Second, it fixes the remaining bug with layer-shift keys in Qukeys, where a release delay, combined with rollover would result in the shifted layer getting stuck on. In order to do this, I needed to add a variable to track the `Key` value that should used to toggle off any Qukey that has a delayed release.

Fixes #501.