### PR TITLE
Add flag `immediately_send_key` to disable eating problematic keys on non-windows OSes

### DIFF
--- a/src/kaleidoscope/plugin/SpaceCadet.cpp
+++ b/src/kaleidoscope/plugin/SpaceCadet.cpp
@@ -39,6 +39,7 @@ SpaceCadet::KeyBinding::KeyBinding(Key input_, Key output_, uint16_t timeout_) {
 SpaceCadet::KeyBinding * SpaceCadet::map;
 uint16_t SpaceCadet::time_out = 1000;
 bool SpaceCadet::disabled = false;
+bool SpaceCadet::immediately_send_key = false;
 
 SpaceCadet::SpaceCadet() {
   static SpaceCadet::KeyBinding initialmap[] = {
@@ -146,7 +147,7 @@ EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, KeyAddr key_add
     //of Alt -- sending Alt by itself activates the menubar.  We don't want to send
     //anything until we know that we're either sending the alternate key or we
     //know for sure that we want to send the originally pressed key.
-    if (valid_key) {
+    if (valid_key && !immediately_send_key) {
       return EventHandlerResult::EVENT_CONSUMED;
     }
 
@@ -237,7 +238,7 @@ EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, KeyAddr key_add
   //If it's a valid key, and it's continuing to be held, return NoKey.
   //This prevents us from accidentally triggering a keypress that we didn't
   //mean to handle.
-  if (valid_key) {
+  if (valid_key && !immediately_send_key) {
     return EventHandlerResult::EVENT_CONSUMED;
   }
 

--- a/src/kaleidoscope/plugin/SpaceCadet.h
+++ b/src/kaleidoscope/plugin/SpaceCadet.h
@@ -65,6 +65,7 @@ class SpaceCadet : public kaleidoscope::Plugin {
   //Publically accessible variables
   static uint16_t time_out;  //  The global timeout in milliseconds
   static SpaceCadet::KeyBinding * map;  // The map of key bindings
+  static bool immediately_send_key;  // Sends the original key while waiting for the timeout.
 
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 


### PR DESCRIPTION
Use case:
```
  static kaleidoscope::SpaceCadet::KeyBinding spacecadetmap[] = {
    {Key_LeftShift, Key_LeftParen, 160}
    , {Key_RightShift, Key_RightParen, 160}
    , {Key_LeftGui,Key_LeftCurlyBracket, 160}
    , {Key_LeftAlt,Key_RightCurlyBracket, 160}
    , {Key_LeftControl,Key_LeftBracket, 160}
    , {Key_RightControl,Key_RightBracket, 160}
    , SPACECADET_MAP_END
  };
  SpaceCadet.map = spacecadetmap;
  SpaceCadet.immediately_send_key = true;
```

With that flag enabled, I'm able to press and hold shift and immediately use it with my mouse to select multiple things on screen.  With that flag set to `false`, I have to wait for the timeout to fire before shift is considered held.

I understand that this can cause problems on windows due to the Alt key so I've set the default for `immediately_send_key` to `false`.