### PR TITLE
LED-ActiveModColor: Use lookupOnActiveLayer() instead of lookup()

### DIFF
--- a/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -39,7 +39,7 @@ EventHandlerResult ActiveModColorEffect::onLayerChange() {
 
   for (byte r = 0; r < ROWS; r++) {
     for (byte c = 0; c < COLS; c++) {
-      Key k = Layer.lookup(r, c);
+      Key k = Layer.lookupOnActiveLayer(r, c);
 
       if (::OneShot.isOneShotKey(k) ||
           (k.raw >= Key_LeftControl.raw && k.raw <= Key_RightGui.raw) ||
@@ -59,7 +59,7 @@ EventHandlerResult ActiveModColorEffect::beforeReportingState() {
     byte c = coords % COLS;
     byte r = (coords - c) / COLS;
 
-    Key k = Layer.lookup(r, c);
+    Key k = Layer.lookupOnActiveLayer(r, c);
 
     if (::OneShot.isOneShotKey(k)) {
       if (::OneShot.isSticky(k))


### PR DESCRIPTION
When we use `lookup()`, we're looking up from the cache, not from the active layer. If the cache gets updated later than we're called, we won't notice. So do an explicit lookup.

Fixes #507.
