### PR TITLE
doc: Fix a typo in LED-ActiveLayerColor.md

### DIFF
--- a/doc/plugin/LED-ActiveLayerColor.md
+++ b/doc/plugin/LED-ActiveLayerColor.md
@@ -17,7 +17,7 @@ Then, one needs to configure a color map:
 #include <Kaleidoscope-LED-ActiveLayerColor.h>
 
 KALEIDOSCOPE_INIT_PLUGINS(LEDControl,
-                          ActiveLayerColorEffect);
+                          LEDActiveLayerColorEffect);
 
 void setup () {
   static const cRGB layerColormap[] PROGMEM = {


### PR DESCRIPTION
In the included example, `KALEIDOSCOPE_INIT_PLUGINS` included the wrong plugin name, it should have been `LEDActiveLayerColorEffect`. This corrects the mistake.

Thanks to Gheekls on Discord for noticing the problem.
