### PR TITLE
Fix plugin name for LEDActiveLayerColorEffect in docs

### DIFF
--- a/doc/plugin/LED-ActiveLayerColor.md
+++ b/doc/plugin/LED-ActiveLayerColor.md
@@ -17,7 +17,7 @@ Then, one needs to configure a color map:
 #include <Kaleidoscope-LED-ActiveLayerColor.h>
 
 KALEIDOSCOPE_INIT_PLUGINS(LEDControl,
-                          ActiveLayerColorEffect);
+                          LEDActiveLayerColorEffect);
 
 void setup () {
   static const cRGB layerColormap[] PROGMEM = {


### PR DESCRIPTION
Fix plugin name from ActiveLayerColorEffect to LEDActiveLayerColorEffect in docs

Signed-off-by: Brian Almeida <bma@thunderkeys.net>