### PR TITLE
FocusSerial: Only send a single separator when sending Keys

### DIFF
--- a/src/kaleidoscope/plugin/FocusSerial.h
+++ b/src/kaleidoscope/plugin/FocusSerial.h
@@ -34,7 +34,6 @@ class FocusSerial : public kaleidoscope::Plugin {
   }
   void send(const Key key) {
     send(key.raw);
-    Serial.print(SEPARATOR);
   }
   void send(const bool b) {
     printBool(b);


### PR DESCRIPTION
When sending `Key`s, there's no need for an extra separator, because `send(key.raw)` will send one anyway. Not sending one results in 10 bytes less PROGMEM used, and plenty of bytes less spent over the wire.
