### PR TITLE
EEPROM-Settings: Setting a new default layer should move there too

### DIFF
--- a/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -53,6 +53,8 @@ uint8_t EEPROMSettings::default_layer(uint8_t layer) {
   if (layer == 0xff)
     return settings_.default_layer;
 
+  if (settings_.default_layer != layer)
+    Layer.move(layer);
   settings_.default_layer = layer;
   update();
   return settings_.default_layer;


### PR DESCRIPTION
When selecting a new default layer via Focus, we should be moving there too, because there may be no other way to switch to the new layer, and having to reboot the keyboard for changes to take effect is not our desired behaviour.

A few users who tried Chrysalis ran into this problem, and found the current behaviour of not switching surprising. In hindsight, so do I, and would prefer the new behaviour introduced with this PR: when setting a default, make it the active layer too.