### PR TITLE
Redial: Make Key_Redial Ranges-based

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -124,6 +124,10 @@ The `RxCy` macros changed from being indexes into a per-hand bitmap to being an 
 
 Please see the [relevant upgrade notes](UPGRADING.md#the-rxcy-macros-and-peeking-into-the-keyswitch-state) for more information.
 
+### The `Redial` plugin had a breaking API change
+
+The [Redial](doc/plugn/Redial.md) plugin was simplified, one no longer needs to define `Key_Redial` on their own, the plugin defines it itself. See the [upgrade notes](UPGRADING.md#Redial) for more information about how to upgrade.
+
 ## Bugfixes
 
 We fixed way too many issues to list here, so we're going to narrow it down to the most important, most visible ones.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,6 +15,7 @@ If any of this does not make sense to you, or you have trouble updating your .in
     - [HostOS](#hostos)
     - [MagicCombo](#magiccombo)
     - [TypingBreaks](#typingbreaks)
+    - [Redial](#redial)
   + [Deprecated APIs and their replacements](#deprecated-apis-and-their-replacements)
     - [Removal of Layer.defaultLayer](#removal-of-layerdefaultlayer)
     - [More clarity in Layer method names](#more-clarity-in-layer-method-names)
@@ -433,6 +434,10 @@ Older versions of the plugin used to provide EEPROM storage for the settings onl
 Both of them are unconditionally enabled now, because they add so much to the plugin. This means that any calls to `TypingBreaks.enableEEPROM()` can be safely removed, the method is deprecated, a no-op by now. The method will be removed by **2019-01-14**.
 
 Storing the settable settings in EEPROM makes it depend on `Kaleidoscope-EEPROM-Settings`, which should be initialized before this plugin is.
+
+### Redial
+
+Older versions of the plugin required one to set up `Key_Redial` manually, and let the plugin know about it via `Redial.key`. This is no longer required, as the plugin sets up the redial key itself. As such, `Redial.key` was removed, and `Key_Redial` is defined by the plugin itself. To upgrade, simply remove your definition of `Key_Redial` and the `Redial.key` assignment from your sketch.
 
 ## Deprecated APIs and their replacements
 

--- a/doc/plugin/Redial.md
+++ b/doc/plugin/Redial.md
@@ -13,12 +13,6 @@ To use the plugin, we'll need to enable it, and configure a key to act as the
 ```c++
 #include <Kaleidoscope.h>
 #include <Kaleidoscope-Redial.h>
-#include <kaleidoscope-Ranges.h>
-
-enum {
-  REDIAL = kaleidoscope::ranges::SAFE_START,
-};
-#define Key_Redial (Key) {.raw = REDIAL}
 
 // Place Key_Redial somewhere on the keymap...
 
@@ -26,8 +20,6 @@ KALEIDOSCOPE_INIT_PLUGINS(Redial);
 
 void setup() {
   Kaleidoscope.setup();
-
-  Redial.key = Key_Redial;
 }
 ```
 
@@ -43,17 +35,9 @@ void setup() {
 >
 > By default, the plugin will remember alphanumeric keys only.
 
-## Plugin properties
+## Dependencies
 
-The `Redial` object has only one property, the key to trigger it.
-
-### `.key`
-
-> The key to trigger the redial effect. Be aware that whatever key you specify
-> here, will have its action shadowed by the redial functionality. Choose
-> something unused, see the example sketch for one way to do that.
->
-> There is no default.
+* [Kaleidoscope-Ranges](Ranges.md)
 
 ## Further reading
 

--- a/examples/Keystrokes/Redial/Redial.ino
+++ b/examples/Keystrokes/Redial/Redial.ino
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Redial -- Redial support for Kaleidoscope
- * Copyright (C) 2018  Gergely Nagy
+ * Copyright (C) 2018, 2019  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,12 +18,6 @@
 
 #include <Kaleidoscope.h>
 #include <Kaleidoscope-Redial.h>
-#include <Kaleidoscope-Ranges.h>
-
-enum {
-  REDIAL = kaleidoscope::ranges::SAFE_START,
-};
-#define Key_Redial (Key) {.raw = REDIAL}
 
 bool kaleidoscope::plugin::Redial::shouldRemember(Key mapped_key) {
   if (mapped_key >= Key_A && mapped_key <= Key_Z)
@@ -57,8 +51,6 @@ KALEIDOSCOPE_INIT_PLUGINS(Redial);
 
 void setup() {
   Kaleidoscope.setup();
-
-  Redial.key = Key_Redial;
 }
 
 void loop() {

--- a/src/Kaleidoscope-Ranges.h
+++ b/src/Kaleidoscope-Ranges.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Ranges -- Common ranges, used by a number of Kaleidoscope plugins.
- * Copyright (C) 2016, 2017  Keyboard.io, Inc
+ * Copyright (C) 2016, 2017, 2019  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -47,6 +47,7 @@ enum : uint16_t {
   STENO_LAST  = STENO_FIRST + 42,
   SC_FIRST,
   SC_LAST,
+  REDIAL,
 
   SAFE_START,
   KALEIDOSCOPE_SAFE_START = SAFE_START

--- a/src/kaleidoscope/plugin/Redial.cpp
+++ b/src/kaleidoscope/plugin/Redial.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Redial -- Redial support for Kaleidoscope
- * Copyright (C) 2018  Keyboard.io, Inc.
+ * Copyright (C) 2018, 2019  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -20,16 +20,12 @@
 namespace kaleidoscope {
 namespace plugin {
 
-Key Redial::key;
 Key Redial::key_to_redial_;
 Key Redial::last_key_;
 bool Redial::redial_held_ = false;
 
 EventHandlerResult Redial::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
-  if (key == Key_NoKey)
-    return EventHandlerResult::OK;
-
-  if (mapped_key == key) {
+  if (mapped_key == Key_Redial) {
     if (keyToggledOff(key_state))
       key_to_redial_ = last_key_;
 

--- a/src/kaleidoscope/plugin/Redial.h
+++ b/src/kaleidoscope/plugin/Redial.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Redial -- Redial support for Kaleidoscope
- * Copyright (C) 2018  Keyboard.io, Inc.
+ * Copyright (C) 2018, 2019  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -18,6 +18,9 @@
 #pragma once
 
 #include <Kaleidoscope.h>
+#include <Kaleidoscope-Ranges.h>
+
+#define Key_Redial ((Key) { .raw = kaleidoscope::ranges::REDIAL })
 
 namespace kaleidoscope {
 namespace plugin {
@@ -25,8 +28,6 @@ namespace plugin {
 class Redial : public kaleidoscope::Plugin {
  public:
   Redial(void) {}
-
-  static Key key;
 
   static bool shouldRemember(Key mappedKey);
 


### PR DESCRIPTION
Add `REDIAL` to `kaleidoscope::ranges`, so the plugin can define `Key_Redial` itself, and won't need `Redial.key` to be set in the user sketch either. This is a breaking change, but one that's easy to upgrade to, hence no effort was made to make it at least partially backwards-compatible.

Fixes #519.
