### PR TITLE
EEPROM-Settings: Fix default_layer(255)

### DIFF
--- a/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -50,12 +50,13 @@ uint16_t EEPROMSettings::crc(void) {
 }
 
 uint8_t EEPROMSettings::default_layer(uint8_t layer) {
-  if (layer == 0xff)
-    return settings_.default_layer;
-
-  if (settings_.default_layer != layer)
+  if (layer < layer_count) {
     Layer.move(layer);
-  settings_.default_layer = layer;
+    settings_.default_layer = layer;
+  }
+  if (layer == 0xff) {
+    settings_.default_layer = layer;
+  }
   update();
   return settings_.default_layer;
 }

--- a/src/kaleidoscope/plugin/EEPROM-Settings.h
+++ b/src/kaleidoscope/plugin/EEPROM-Settings.h
@@ -40,7 +40,10 @@ class EEPROMSettings : public kaleidoscope::Plugin {
   static uint16_t crc(void);
   static uint16_t used(void);
 
-  static uint8_t default_layer(uint8_t layer = 0xff);
+  static uint8_t default_layer(uint8_t layer);
+  static uint8_t default_layer() {
+    return settings_.default_layer;
+  }
 
  private:
   static uint16_t next_start_;


### PR DESCRIPTION
We should be using a different variant of the `default_layer()` method to query the default layer instead of abusing 0xff as a special valie.

Fixes #522.
