### PR TITLE
key_defs: Add Meh and Hyper keys

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -83,6 +83,10 @@ There are situations where one would like to disable sending a report after each
 
 Changing layers now triggers the `onLayerChange` event - but only if there was real change (thus, calling `Layer.on(SOME_LAYER)` multiple times in a row will only trigger one event). This event was introduced to help plugins that depend on layer state schedule their work better.
 
+### Hyper and Meh keys
+
+To make it easier to create custom shortcuts, that do not interfere with system ones, an old trick is to use many modifiers. To make this easier, `Ctrl+Shift+Alt` is commonly abbreviated as `Meh`, while `Ctrl+Shift+Alt+Gui` is often called `Hyper`. To support this, we offer the `Key_Meh` and `Key_Hyper` aliases, along with `MEH(k)` and `HYPER(k)` to go with them.
+
 ## New hardware support
 
 Kaleidoscope has been ported to the following devices:

--- a/src/kaleidoscope/key_defs_aliases.h
+++ b/src/kaleidoscope/key_defs_aliases.h
@@ -53,3 +53,15 @@
 #define Key_RightCurlyBracket LSHIFT(Key_RightBracket)
 
 #define Key_Pipe LSHIFT(Key_Backslash)
+
+// To make it easier to create custom shortcuts, that do not interfere with
+// system ones, an old trick is to use many modifiers. To make this easier,
+// Ctrl+Shift+Alt is commonly abbreviated as "Meh", while Ctrl+Shift+Alt+GUI is
+// often called "Hyper". To support this, we offer the `Key_Meh` and `Key_Hyper`
+// aliases, along with `MEH(k)` and `HYPER(k)` to go with them.
+
+#define Key_Meh   LCTRL(LSHIFT(Key_LeftAlt))
+#define Key_Hyper MEH(Key_LeftGui)
+
+#define MEH(k)   LCTRL(LSHIFT(LALT(k)))
+#define HYPER(k) LGUI(MEH(k))


### PR DESCRIPTION
To make it easier to create custom shortcuts, that do not interfere with system ones, an old trick is to use many modifiers. To make this easier, Ctrl+Shift+Alt is commonly abbreviated as "Meh", while Ctrl+Shift+Alt+GUI is often called "Hyper". To support this, we offer the `Key_Meh` and `Key_Hyper` aliases, along with `MEH(k)` and `HYPER(k)` to go with them.
