### PR TITLE
LED-Palette-Theme: Flip the component bits upon read & store

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -132,6 +132,10 @@ Please see the [relevant upgrade notes](UPGRADING.md#the-rxcy-macros-and-peeking
 
 The [Redial](doc/plugin/Redial.md) plugin was simplified, one no longer needs to define `Key_Redial` on their own, the plugin defines it itself. See the [upgrade notes](UPGRADING.md#Redial) for more information about how to upgrade.
 
+### Color palette storage has changed
+
+The [LED-Palette-Theme](doc/plugin/LED-Palette-Theme.md) had to be changed to store the palette colors in reverse. This change had to be made in order to not default to a bright white palette, that would draw so much power that most operating systems would disconnect the keyboard due to excessive power usage. With inverting the colors, we now default to a black palette instead. This sadly breaks existing palettes, and you will have to re-set the colors.
+
 ## Bugfixes
 
 We fixed way too many issues to list here, so we're going to narrow it down to the most important, most visible ones.

--- a/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-LED-Palette-Theme -- Palette-based LED theme foundation
- * Copyright (C) 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2017, 2018, 2019  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -82,6 +82,10 @@ const cRGB LEDPaletteTheme::lookupPaletteColor(uint8_t color_index) {
   cRGB color;
 
   EEPROM.get(palette_base_ + color_index * sizeof(cRGB), color);
+  color.r ^= 0xff;
+  color.g ^= 0xff;
+  color.b ^= 0xff;
+
   return color;
 }
 
@@ -115,7 +119,7 @@ EventHandlerResult LEDPaletteTheme::onFocusEvent(const char *command) {
     for (uint8_t i = 0; i < 16; i++) {
       cRGB color;
 
-      EEPROM.get(palette_base_ + i * sizeof(color), color);
+      color = lookupPaletteColor(i);
       ::Focus.send(color);
     }
     return EventHandlerResult::EVENT_CONSUMED;
@@ -126,6 +130,9 @@ EventHandlerResult LEDPaletteTheme::onFocusEvent(const char *command) {
     cRGB color;
 
     ::Focus.read(color);
+    color.r ^= 0xff;
+    color.g ^= 0xff;
+    color.b ^= 0xff;
 
     EEPROM.put(palette_base_ + i * sizeof(color), color);
     i++;


### PR DESCRIPTION
EEPROM defaults to `0xff` when uninitialized, which means we'd start off with a bright white palette. That's a problem, because it draws a lot of power, especially when all keys are lit bright. For this reason, flip the bits when reading or storing palette colors, so the default `0xff` becomes `0x00`, black.

Fixes #529.
