### PR TITLE
hardware::KBD4x: Disable clock division

### DIFF
--- a/src/kaleidoscope/hardware/kbdfans/KBD4x.h
+++ b/src/kaleidoscope/hardware/kbdfans/KBD4x.h
@@ -54,6 +54,10 @@ class KBD4x: public kaleidoscope::hardware::ATMegaKeyboard {
      */
     MCUCR |= (1 << JTD);
     MCUCR |= (1 << JTD);
+
+    // Disable Clock division
+    CLKPR = (1 << CLKPCE);
+    CLKPR = (0 << CLKPS3) | (0 << CLKPS2) | (0 << CLKPS1) | (0 << CLKPS0);
   }
 
   ATMEGA_KEYBOARD_CONFIG(


### PR DESCRIPTION
The KBD4x has a set of WS2812 LEDs, which are very picky about timing. To make them happy (even though we do not use them yet), we need to disable clock division at startup.
