### PR TITLE
CycleTimeReport: Send a newline after the default report

### DIFF
--- a/src/kaleidoscope/plugin/CycleTimeReport.cpp
+++ b/src/kaleidoscope/plugin/CycleTimeReport.cpp
@@ -56,7 +56,8 @@ EventHandlerResult CycleTimeReport::afterEachCycle() {
 }
 
 __attribute__((weak)) void cycleTimeReport(void) {
-  Focus.send(Focus.COMMENT, F("average loop time:"), CycleTimeReport.average_loop_time);
+  Focus.send(Focus.COMMENT, F("average loop time:"), CycleTimeReport.average_loop_time,
+             Focus.NEWLINE);
 }
 
 kaleidoscope::plugin::CycleTimeReport CycleTimeReport;

--- a/src/kaleidoscope/plugin/FocusSerial.h
+++ b/src/kaleidoscope/plugin/FocusSerial.h
@@ -82,6 +82,7 @@ class FocusSerial : public kaleidoscope::Plugin {
 
   static constexpr char COMMENT = '#';
   static constexpr char SEPARATOR = ' ';
+  static constexpr char NEWLINE = '\n';
 
   /* Hooks */
   EventHandlerResult beforeReportingState();


### PR DESCRIPTION
Since `Focus.send()` does not send a newline implicitly, we should do so explicitly. Introduce `Focus.NEWLINE` to help with this, and not have many copies of `'\n'` lying around.

Fixes #544.
