### PR TITLE
Assorted Chase fixes

### DIFF
--- a/doc/plugin/LEDEffect-Chase.md
+++ b/doc/plugin/LEDEffect-Chase.md
@@ -21,8 +21,23 @@ void setup() {
 
 ## Plugin methods
 
-The plugin provides the `LEDChaseEffect` object, which has no public methods or
-properties, outside of those provided by all LED modes.
+The plugin provides the `LEDChaseEffect` object, which has the following methods
+outside of those provided by all LED modes:
+
+### `.update_delay([delay])`
+
+> Accessor for the update delay, the time between each step of the animation.
+> When called without an argument, returns the current setting. When called with
+> one, sets it.
+>
+> Defaults to 150 (milliseconds).
+
+### `.distance([pixels])`
+
+> Accessor for the distance between the two pixels. When called without an
+> argument, returns the current setting. When called with one, sets it.
+>
+> Defaults to 5.
 
 ## Dependencies
 

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
@@ -37,9 +37,9 @@ void LEDChaseEffect::update(void) {
   // the first few updates, `pos2` will be out of bounds. Since it's an unsigned integer,
   // even when it would have a value below zero, it underflows and so one test is good for
   // both ends of the range.
-  ::LEDControl.setCrgbAt(pos, {0, 0, 0});
+  ::LEDControl.setCrgbAt(pos, CRGB(0, 0, 0));
   if (pos2 < LED_COUNT)
-    ::LEDControl.setCrgbAt(pos2, {0, 0, 0});
+    ::LEDControl.setCrgbAt(pos2, CRGB(0, 0, 0));
 
   // Next, we adjust the red light's position. If the direction hasn't changed (the red
   // light isn't out of bounds), we also adjust the blue light's position to match the red
@@ -58,9 +58,9 @@ void LEDChaseEffect::update(void) {
 
   // Last, we turn on the LEDs at their new positions. As before, the blue light (pos2) is
   // only set if it's in the valid LED range.
-  ::LEDControl.setCrgbAt(pos, {0, 0, 255});
+  ::LEDControl.setCrgbAt(pos, CRGB(255, 0, 0));
   if (pos2 < LED_COUNT)
-    ::LEDControl.setCrgbAt(pos2, {255, 0, 0});
+    ::LEDControl.setCrgbAt(pos2, CRGB(0, 0, 255));
 }
 
 }

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
@@ -29,16 +29,16 @@ void LEDChaseEffect::update(void) {
   }
   last_update_ = now;
 
-  // The red LED is at `pos`; the blue one follows behind. `chase_sign` is either +1 or
-  // -1; `chase_pixels` is the gap between them.
-  int8_t pos2 = pos - (chase_sign * chase_pixels);
+  // The red LED is at `pos_`; the blue one follows behind. `direction_` is
+  // either +1 or -1; `distance_` is the gap between them.
+  int8_t pos2 = pos_ - (direction_ * distance_);
 
-  // First, we turn off the LEDs that were turned on in the previous update. `pos` is
-  // always in the valid range (0 <= pos < LED_COUNT), but after it changes direction, for
-  // the first few updates, `pos2` will be out of bounds. Since it's an unsigned integer,
-  // even when it would have a value below zero, it underflows and so one test is good for
-  // both ends of the range.
-  ::LEDControl.setCrgbAt(pos, CRGB(0, 0, 0));
+  // First, we turn off the LEDs that were turned on in the previous update.
+  // `pos_` is always in the valid range (0 <= pos_ < LED_COUNT), but after it
+  // changes direction, for the first few updates, `pos2` will be out of bounds.
+  // Since it's an unsigned integer, even when it would have a value below zero,
+  // it underflows and so one test is good for both ends of the range.
+  ::LEDControl.setCrgbAt(pos_, CRGB(0, 0, 0));
   if (pos2 < LED_COUNT)
     ::LEDControl.setCrgbAt(pos2, CRGB(0, 0, 0));
 
@@ -48,18 +48,18 @@ void LEDChaseEffect::update(void) {
   // it back in bounds. When this happens, the blue light "jumps" behind the red one, and
   // will be out of bounds. The simplest way to do this is to assign it a value that is
   // known to be invalid (LED_COUNT).
-  pos += chase_sign;
-  if (pos < LED_COUNT && pos > 0) {
-    pos2 += chase_sign;
+  pos_ += direction_;
+  if (pos_ < LED_COUNT && pos_ > 0) {
+    pos2 += direction_;
   } else {
-    chase_sign = -chase_sign;
-    pos += chase_sign;
+    direction_ = -direction_;
+    pos_ += direction_;
     pos2 = LED_COUNT;
   }
 
   // Last, we turn on the LEDs at their new positions. As before, the blue light (pos2) is
   // only set if it's in the valid LED range.
-  ::LEDControl.setCrgbAt(pos, CRGB(255, 0, 0));
+  ::LEDControl.setCrgbAt(pos_, CRGB(255, 0, 0));
   if (pos2 < LED_COUNT)
     ::LEDControl.setCrgbAt(pos2, CRGB(0, 0, 255));
 }

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
@@ -18,15 +18,16 @@
 
 namespace kaleidoscope {
 namespace plugin {
+
 void LEDChaseEffect::update(void) {
   if (!Kaleidoscope.has_leds)
     return;
 
-  // Check to see if it's time to change the positions of the red and blue lights
-  if (current_chase_counter++ < chase_threshold) {
+  uint16_t now = Kaleidoscope.millisAtCycleStart();
+  if ((now - last_update_) < update_delay_) {
     return;
   }
-  current_chase_counter = 0;
+  last_update_ = now;
 
   // The red LED is at `pos`; the blue one follows behind. `chase_sign` is either +1 or
   // -1; `chase_pixels` is the gap between them.

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.h
@@ -24,6 +24,13 @@ class LEDChaseEffect : public LEDMode {
  public:
   LEDChaseEffect(void) {}
 
+  uint16_t update_delay() {
+    return update_delay_;
+  }
+  void update_delay(uint16_t delay) {
+    update_delay_ = delay;
+  }
+
  protected:
   void update(void) final;
 
@@ -31,8 +38,8 @@ class LEDChaseEffect : public LEDMode {
   int8_t pos = 0;
   int8_t chase_sign = 1; //negative values when it's going backwar
   uint8_t chase_pixels = 5;
-  uint8_t current_chase_counter = 0;
-  static const uint8_t chase_threshold = 150;
+  uint16_t update_delay_ = 150;
+  uint16_t last_update_ = 0;
 };
 }
 }

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.h
@@ -30,14 +30,20 @@ class LEDChaseEffect : public LEDMode {
   void update_delay(uint16_t delay) {
     update_delay_ = delay;
   }
+  uint8_t distance() {
+    return distance_;
+  }
+  void distance(uint8_t value) {
+    distance_ = value;
+  }
 
  protected:
   void update(void) final;
 
  private:
-  int8_t pos = 0;
-  int8_t chase_sign = 1; //negative values when it's going backwar
-  uint8_t chase_pixels = 5;
+  int8_t pos_ = 0;
+  int8_t direction_ = 1;
+  uint8_t distance_ = 5;
   uint16_t update_delay_ = 150;
   uint16_t last_update_ = 0;
 };


### PR DESCRIPTION
- Use `CRGB()` for consistent colors across different boards (#548)
- Use timers for more reliable timing (#545), and also make the delay configurable
- Make the distance configurable too (#546)