### PR TITLE
[WIP] New plugin: UnderglowControl

### DIFF
--- a/src/Kaleidoscope-Hardware-KBDFans-KBD4x.h
+++ b/src/Kaleidoscope-Hardware-KBDFans-KBD4x.h
@@ -19,5 +19,6 @@
 #pragma once
 
 #define KALEIDOSCOPE_WITH_ATMEGA_KEYBOARD 1
+#define KALEIDOSCOPE_HARDWARE_HAS_UNDERGLOW 1
 
 #include "kaleidoscope/hardware/kbdfans/KBD4x.h"

--- a/src/Kaleidoscope-UnderglowControl.h
+++ b/src/Kaleidoscope-UnderglowControl.h
@@ -1,0 +1,20 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-UnderglowControl -- RGB Underglow Control for Kaleidoscope
+ * Copyright (C) 2019  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of version 3 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <kaleidoscope/plugin/UnderglowControl.h>

--- a/src/kaleidoscope/hardware/kbdfans/KBD4x.cpp
+++ b/src/kaleidoscope/hardware/kbdfans/KBD4x.cpp
@@ -28,6 +28,7 @@ namespace kbdfans {
 
 ATMEGA_KEYBOARD_DATA(KBD4x);
 constexpr int8_t KBD4x::led_count;
+kaleidoscope::driver::led::WS2812<PIN_E2, Color, 6> KBD4x::underglow;
 
 #define BOOTLOADER_RESET_KEY 0xB007B007
 uint32_t reset_key  __attribute__((section(".noinit")));

--- a/src/kaleidoscope/hardware/kbdfans/KBD4x.h
+++ b/src/kaleidoscope/hardware/kbdfans/KBD4x.h
@@ -24,9 +24,19 @@
 #include "Kaleidoscope-HIDAdaptor-KeyboardioHID.h"
 
 #include "kaleidoscope/macro_helpers.h"
-#include "kaleidoscope/hardware/avr/pins_and_ports.h"
+
+struct cRGB {
+  uint8_t g;
+  uint8_t r;
+  uint8_t b;
+};
+
+#define CRGB(r, g, b) (cRGB){g, r, b}
 
 #include "kaleidoscope/hardware/ATMegaKeyboard.h"
+#include "kaleidoscope/driver/led/WS2812.h"
+
+using Color = kaleidoscope::driver::led::color::GRB;
 
 namespace kaleidoscope {
 namespace hardware {
@@ -66,6 +76,8 @@ class KBD4x: public kaleidoscope::hardware::ATMegaKeyboard {
   );
 
   static constexpr int8_t led_count = 0;
+
+  static kaleidoscope::driver::led::WS2812<PIN_E2, Color, 6> underglow;
 
   void resetDevice();
 };

--- a/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Idle-LEDs -- Turn off the LEDs when the keyboard's idle
- * Copyright (C) 2018  Keyboard.io, Inc
+ * Copyright (C) 2018-2019  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,6 +17,7 @@
 
 #include <Kaleidoscope-IdleLEDs.h>
 #include <Kaleidoscope-LEDControl.h>
+#include <Kaleidoscope-UnderglowControl.h>
 
 namespace kaleidoscope {
 namespace plugin {
@@ -25,12 +26,19 @@ uint16_t IdleLEDs::idle_time_limit = 600; // 10 minutes
 uint32_t IdleLEDs::end_time_;
 
 EventHandlerResult IdleLEDs::beforeEachCycle() {
-  if (!::LEDControl.paused &&
-      (Kaleidoscope.millisAtCycleStart() >= end_time_)) {
+  if (Kaleidoscope.millisAtCycleStart() < end_time_)
+    return EventHandlerResult::OK;
+
+  if (::Kaleidoscope.has_leds && !::LEDControl.paused) {
     ::LEDControl.set_all_leds_to(CRGB(0, 0, 0));
     ::LEDControl.syncLeds();
 
     ::LEDControl.paused = true;
+  }
+  if (::UnderglowControl.has_leds() && !::UnderglowControl.isPaused()) {
+    ::UnderglowControl.setColor(0, 0, 0);
+    ::UnderglowControl.sync();
+    ::UnderglowControl.pause();
   }
 
   return EventHandlerResult::OK;
@@ -38,9 +46,12 @@ EventHandlerResult IdleLEDs::beforeEachCycle() {
 
 EventHandlerResult IdleLEDs::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
 
-  if (::LEDControl.paused) {
+  if (Kaleidoscope.has_leds && ::LEDControl.paused) {
     ::LEDControl.paused = false;
     ::LEDControl.refreshAll();
+  }
+  if (::UnderglowControl.has_leds() && ::UnderglowControl.isPaused()) {
+    ::UnderglowControl.resume();
   }
 
   end_time_ = Kaleidoscope.millisAtCycleStart() + (uint32_t)idle_time_limit * 1000;

--- a/src/kaleidoscope/plugin/IdleLEDs.h
+++ b/src/kaleidoscope/plugin/IdleLEDs.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Idle-LEDs -- Turn off the LEDs when the keyboard's idle
- * Copyright (C) 2018  Keyboard.io, Inc
+ * Copyright (C) 2018-2019  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/kaleidoscope/plugin/LED-ActiveLayerColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveLayerColor.cpp
@@ -23,10 +23,6 @@ namespace plugin {
 cRGB LEDActiveLayerColorEffect::active_color_;
 const cRGB *LEDActiveLayerColorEffect::colormap_;
 
-void LEDActiveLayerColorEffect::setColormap(const cRGB colormap[]) {
-  colormap_ = colormap;
-}
-
 cRGB LEDActiveLayerColorEffect::getActiveColor() {
   cRGB color;
 
@@ -57,7 +53,43 @@ EventHandlerResult LEDActiveLayerColorEffect::onLayerChange() {
   return EventHandlerResult::OK;
 }
 
+// ---
+
+cRGB UnderglowActiveLayerColorEffect::active_color_;
+const cRGB *UnderglowActiveLayerColorEffect::colormap_;
+
+cRGB UnderglowActiveLayerColorEffect::getActiveColor() {
+  cRGB color;
+
+  uint8_t top_layer = ::Layer.top();
+
+  color.r = pgm_read_byte(&(colormap_[top_layer].r));
+  color.g = pgm_read_byte(&(colormap_[top_layer].g));
+  color.b = pgm_read_byte(&(colormap_[top_layer].b));
+
+  return color;
+}
+
+void UnderglowActiveLayerColorEffect::onActivate(void) {
+  if (!::UnderglowControl.has_leds())
+    return;
+
+  active_color_ = getActiveColor();
+  ::UnderglowControl.setColor(active_color_);
+}
+
+void UnderglowActiveLayerColorEffect::refreshAt(uint8_t index) {
+  ::UnderglowControl.setColorAt(index, active_color_);
+}
+
+EventHandlerResult UnderglowActiveLayerColorEffect::onLayerChange() {
+  if (::UnderglowControl.currentEffect() == this)
+    onActivate();
+  return EventHandlerResult::OK;
+}
+
 }
 }
 
 kaleidoscope::plugin::LEDActiveLayerColorEffect LEDActiveLayerColorEffect;
+kaleidoscope::plugin::UnderglowActiveLayerColorEffect UnderglowActiveLayerColorEffect;

--- a/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
+++ b/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-LED-ActiveLayerColor -- Light up the LEDs based on the active layers
- * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2016, 2017, 2018, 2019  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -18,15 +18,19 @@
 #pragma once
 
 #include <Kaleidoscope-LEDControl.h>
+#include <Kaleidoscope-UnderglowControl.h>
 
 namespace kaleidoscope {
 namespace plugin {
+
 class LEDActiveLayerColorEffect : public LEDMode {
  public:
   LEDActiveLayerColorEffect(void) {}
 
   EventHandlerResult onLayerChange();
-  void setColormap(const cRGB colormap[]);
+  void setColormap(const cRGB colormap[]) {
+    colormap_ = colormap;
+  }
 
  protected:
   void onActivate(void) final;
@@ -38,7 +42,29 @@ class LEDActiveLayerColorEffect : public LEDMode {
 
   static cRGB getActiveColor();
 };
+
+class UnderglowActiveLayerColorEffect : public UnderglowEffect {
+ public:
+  UnderglowActiveLayerColorEffect() {}
+
+  EventHandlerResult onLayerChange();
+  void setColormap(const cRGB colormap[]) {
+    colormap_ = colormap;
+  }
+
+ protected:
+  void onActivate() final;
+  void refreshAt(uint8_t index) final;
+
+ private:
+  static const cRGB *colormap_;
+  static cRGB active_color_;
+
+  static cRGB getActiveColor();
+};
+
 }
 }
 
 extern kaleidoscope::plugin::LEDActiveLayerColorEffect LEDActiveLayerColorEffect;
+extern kaleidoscope::plugin::UnderglowActiveLayerColorEffect UnderglowActiveLayerColorEffect;

--- a/src/kaleidoscope/plugin/LEDEffect-Breathe.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Breathe.cpp
@@ -32,7 +32,22 @@ void LEDBreatheEffect::update(void) {
   cRGB color = breath_compute(hue, saturation);
   ::LEDControl.set_all_leds_to(color);
 }
+
+void UnderglowBreatheEffect::update(void) {
+  if (!::UnderglowControl.has_leds())
+    return;
+
+  uint16_t now = Kaleidoscope.millisAtCycleStart();
+  if ((now - last_update_) < UPDATE_INTERVAL)
+    return;
+  last_update_ = now;
+
+  cRGB color = breath_compute(hue_, saturation_);
+  ::UnderglowControl.setColor(color);
+}
+
 }
 }
 
 kaleidoscope::plugin::LEDBreatheEffect LEDBreatheEffect;
+kaleidoscope::plugin::UnderglowBreatheEffect UnderglowBreatheEffect;

--- a/src/kaleidoscope/plugin/LEDEffect-Breathe.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Breathe.h
@@ -1,5 +1,5 @@
 /* Kaleidoscope-LEDEffect-Breathe - A breathing effect on the LEDs, for Kaleidoscope.
- * Copyright (C) 2017-2018  Keyboard.io, Inc.
+ * Copyright (C) 2017-2019  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "Kaleidoscope-LEDControl.h"
+#include "Kaleidoscope-UnderglowControl.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -33,7 +34,35 @@ class LEDBreatheEffect : public LEDMode {
  private:
   uint16_t last_update_ = 0;
 };
+
+class UnderglowBreatheEffect : public UnderglowEffect {
+ public:
+  UnderglowBreatheEffect() {}
+
+  uint8_t hue() {
+    return hue_;
+  }
+  void hue(uint8_t value) {
+    hue_ = value;
+  }
+  uint8_t saturation() {
+    return saturation_;
+  }
+  void saturation(uint8_t value) {
+    saturation_ = value;
+  }
+
+ protected:
+  void update() final;
+
+ private:
+  uint8_t hue_ = 170;
+  uint8_t saturation_ = 255;
+  uint16_t last_update_ = 0;
+};
+
 }
 }
 
 extern kaleidoscope::plugin::LEDBreatheEffect LEDBreatheEffect;
+extern kaleidoscope::plugin::UnderglowBreatheEffect UnderglowBreatheEffect;

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.h
@@ -1,5 +1,5 @@
 /* Kaleidoscope-LEDEffect-Chase - A Chase LED effect for Kaleidoscope.
- * Copyright (C) 2017-2018  Keyboard.io, Inc.
+ * Copyright (C) 2017-2019  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,9 +17,11 @@
 #pragma once
 
 #include "Kaleidoscope-LEDControl.h"
+#include "Kaleidoscope-UnderglowControl.h"
 
 namespace kaleidoscope {
 namespace plugin {
+
 class LEDChaseEffect : public LEDMode {
  public:
   LEDChaseEffect(void) {}
@@ -47,7 +49,37 @@ class LEDChaseEffect : public LEDMode {
   uint16_t update_delay_ = 150;
   uint16_t last_update_ = 0;
 };
+
+class UnderglowChaseEffect : public UnderglowEffect {
+ public:
+  UnderglowChaseEffect(void) {}
+
+  uint16_t update_delay() {
+    return update_delay_;
+  }
+  void update_delay(uint16_t delay) {
+    update_delay_ = delay;
+  }
+  uint8_t distance() {
+    return distance_;
+  }
+  void distance(uint8_t value) {
+    distance_ = value;
+  }
+
+ protected:
+  void update(void) final;
+
+ private:
+  int8_t pos_ = 0;
+  int8_t direction_ = 1;
+  uint8_t distance_ = 2;
+  uint16_t update_delay_ = 150;
+  uint16_t last_update_ = 0;
+};
+
 }
 }
 
 extern kaleidoscope::plugin::LEDChaseEffect LEDChaseEffect;
+extern kaleidoscope::plugin::UnderglowChaseEffect UnderglowChaseEffect;

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
@@ -1,5 +1,5 @@
 /* Kaleidoscope-LEDEffect-Rainbow - Rainbow LED effects for Kaleidoscope.
- * Copyright (C) 2017-2018  Keyboard.io, Inc.
+ * Copyright (C) 2017-2019  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,61 +17,106 @@
 #pragma once
 
 #include "Kaleidoscope-LEDControl.h"
+#include "Kaleidoscope-UnderglowControl.h"
 
 namespace kaleidoscope {
 namespace plugin {
-class LEDRainbowEffect : public LEDMode {
+
+class RainbowEffect {
+ public:
+  RainbowEffect() {}
+
+  void brightness(byte brightness) {
+    brightness_ = brightness;
+  }
+  byte brightness() {
+    return brightness_;
+  }
+  void update_delay(uint16_t delay) {
+    update_delay_ = delay;
+  }
+  uint16_t update_delay() {
+    return update_delay_;
+  }
+
+ protected:
+  bool updateColor(cRGB &rainbow);
+
+ private:
+  uint16_t hue_ = 0;   //  stores 0 to 614
+
+  uint8_t steps_ = 1;  //  number of hues we skip in a 360 range per update
+  uint16_t last_update_ = 0;
+  uint16_t update_delay_ = 40; // delay between updates (ms)
+
+  byte saturation_ = 255;
+  byte brightness_ = 50;
+};
+
+class LEDRainbowEffect : public LEDMode, public RainbowEffect {
  public:
   LEDRainbowEffect(void) {}
 
-  void brightness(byte);
-  byte brightness(void) {
-    return rainbow_value;
-  }
-  void update_delay(byte);
-  byte update_delay(void) {
-    return rainbow_update_delay;
-  }
   void update(void) final;
-
- private:
-  uint16_t rainbow_hue = 0;   //  stores 0 to 614
-
-  uint8_t rainbow_steps = 1;  //  number of hues we skip in a 360 range per update
-  uint16_t rainbow_last_update = 0;
-  uint16_t rainbow_update_delay = 40; // delay between updates (ms)
-
-  byte rainbow_saturation = 255;
-  byte rainbow_value = 50;
 };
 
+class UnderglowRainbowEffect : public UnderglowEffect, public RainbowEffect {
+ public:
+  UnderglowRainbowEffect(void) {}
 
-class LEDRainbowWaveEffect : public LEDMode {
+  void update(void) final;
+};
+
+// ---
+
+class RainbowWaveEffect {
+ public:
+  RainbowWaveEffect() {}
+
+  void brightness(byte brightness) {
+    brightness_ = brightness;
+  }
+  byte brightness() {
+    return brightness_;
+  }
+  void update_delay(uint16_t delay) {
+    update_delay_ = delay;
+  }
+  uint16_t update_delay() {
+    return update_delay_;
+  }
+
+ protected:
+  bool updateHue();
+
+  uint16_t hue_ = 0;
+  byte saturation_ = 255;
+  byte brightness_ = 50;
+
+ private:
+  uint8_t steps_ = 1;
+  uint16_t last_update_ = 0;
+  uint16_t update_delay_ = 40;
+};
+
+class LEDRainbowWaveEffect : public LEDMode, public RainbowWaveEffect {
  public:
   LEDRainbowWaveEffect(void) {}
 
-  void brightness(byte);
-  byte brightness(void) {
-    return rainbow_value;
-  }
-  void update_delay(byte);
-  byte update_delay(void) {
-    return rainbow_update_delay;
-  }
   void update(void) final;
-
- private:
-  uint16_t rainbow_hue = 0;  //  stores 0 to 614
-
-  uint8_t rainbow_wave_steps = 1;  //  number of hues we skip in a 360 range per update
-  uint16_t rainbow_last_update = 0;
-  uint16_t rainbow_update_delay = 40; // delay between updates (ms)
-
-  byte rainbow_saturation = 255;
-  byte rainbow_value = 50;
 };
+
+class UnderglowRainbowWaveEffect : public UnderglowEffect, public RainbowWaveEffect {
+ public:
+  UnderglowRainbowWaveEffect(void) {}
+
+  void update(void) final;
+};
+
 }
 }
 
 extern kaleidoscope::plugin::LEDRainbowEffect LEDRainbowEffect;
 extern kaleidoscope::plugin::LEDRainbowWaveEffect LEDRainbowWaveEffect;
+extern kaleidoscope::plugin::UnderglowRainbowEffect UnderglowRainbowEffect;
+extern kaleidoscope::plugin::UnderglowRainbowWaveEffect UnderglowRainbowWaveEffect;

--- a/src/kaleidoscope/plugin/LEDEffect-SolidColor.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-SolidColor.cpp
@@ -18,6 +18,7 @@
 
 namespace kaleidoscope {
 namespace plugin {
+
 LEDSolidColor::LEDSolidColor(uint8_t r, uint8_t g, uint8_t b) {
   this->r = r;
   this->g = g;
@@ -30,6 +31,14 @@ void LEDSolidColor::onActivate(void) {
 
 void LEDSolidColor::refreshAt(byte row, byte col) {
   ::LEDControl.setCrgbAt(row, col, CRGB(r, g, b));
+}
+
+void UnderglowSolidColor::onActivate() {
+  ::UnderglowControl.setColor(r_, g_, b_);
+}
+
+void UnderglowSolidColor::refreshAt(uint8_t index) {
+  ::UnderglowControl.setColorAt(index, r_, g_, b_);
 }
 
 }

--- a/src/kaleidoscope/plugin/LEDEffect-SolidColor.h
+++ b/src/kaleidoscope/plugin/LEDEffect-SolidColor.h
@@ -1,5 +1,5 @@
 /* Kaleidoscope-LEDEffect-SolidColor - Solid color LED effects for Kaleidoscope.
- * Copyright (C) 2017  Keyboard.io, Inc.
+ * Copyright (C) 2017-2019  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,9 +17,11 @@
 #pragma once
 
 #include "Kaleidoscope-LEDControl.h"
+#include "Kaleidoscope-UnderglowControl.h"
 
 namespace kaleidoscope {
 namespace plugin {
+
 class LEDSolidColor : public LEDMode {
  public:
   LEDSolidColor(uint8_t r, uint8_t g, uint8_t b);
@@ -31,5 +33,19 @@ class LEDSolidColor : public LEDMode {
  private:
   uint8_t r, g, b;
 };
+
+class UnderglowSolidColor : public UnderglowEffect {
+ public:
+  UnderglowSolidColor(uint8_t r, uint8_t g, uint8_t b)
+    : r_(r), g_(g), b_(b) {}
+
+ protected:
+  void onActivate(void) final;
+  void refreshAt(uint8_t index) final;
+
+ private:
+  uint8_t r_, g_, b_;
+};
+
 }
 }

--- a/src/kaleidoscope/plugin/UnderglowControl.cpp
+++ b/src/kaleidoscope/plugin/UnderglowControl.cpp
@@ -1,0 +1,98 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-UnderglowControl -- RGB Underglow Control for Kaleidoscope
+ * Copyright (C) 2019  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of version 3 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-UnderglowControl.h>
+
+namespace kaleidoscope {
+namespace plugin {
+
+#if KALEIDOSCOPE_HARDWARE_HAS_UNDERGLOW
+const int8_t UnderglowControl::led_count() {
+  return KeyboardHardware.underglow.led_count();
+}
+
+const bool UnderglowControl::has_leds() {
+  return true;
+}
+
+void UnderglowControl::sync() {
+  if (paused_)
+    return;
+
+  KeyboardHardware.underglow.sync();
+}
+
+void UnderglowControl::setColorAt(uint8_t index, cRGB color) {
+  KeyboardHardware.underglow.setColorAt(index, color.r, color.g, color.b);
+}
+
+void UnderglowControl::setColorAt(uint8_t index, uint8_t r, uint8_t g, uint8_t b) {
+  KeyboardHardware.underglow.setColorAt(index, r, g, b);
+}
+
+cRGB UnderglowControl::getColorAt(uint8_t index) {
+  cRGB ret;
+
+  auto color = KeyboardHardware.underglow.getColorAt(index);
+  ret.r = color.r;
+  ret.g = color.g;
+  ret.b = color.b;
+  return ret;
+}
+EventHandlerResult UnderglowControl::beforeReportingState()  {
+  if (paused_)
+    return kaleidoscope::EventHandlerResult::OK;
+
+  updateEffect();
+
+  uint16_t elapsed = Kaleidoscope.millisAtCycleStart() - sync_start_time_;
+  if (elapsed > sync_delay_) {
+    sync();
+    sync_start_time_ = Kaleidoscope.millisAtCycleStart() + sync_delay_;
+  }
+
+  return kaleidoscope::EventHandlerResult::OK;
+}
+
+void UnderglowControl::setColor(cRGB color) {
+  for (int8_t i = 0; i < led_count(); i++) {
+    setColorAt(i, color);
+  }
+}
+
+void UnderglowControl::setColor(uint8_t r, uint8_t g, uint8_t b) {
+  for (int8_t i = 0; i < led_count(); i++) {
+    setColorAt(i, r, g, b);
+  }
+}
+#endif
+
+void UnderglowOff::onActivate() {
+  if (!::UnderglowControl.has_leds())
+    return;
+
+  for (int8_t i = 0; i < ::UnderglowControl.led_count(); i++) {
+    ::UnderglowControl.setColorAt(i, 0, 0, 0);
+  }
+}
+
+}
+}
+
+kaleidoscope::plugin::UnderglowControl UnderglowControl;
+kaleidoscope::plugin::UnderglowOff UnderglowOff;

--- a/src/kaleidoscope/plugin/UnderglowControl.h
+++ b/src/kaleidoscope/plugin/UnderglowControl.h
@@ -1,0 +1,132 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-UnderglowControl -- RGB Underglow Control for Kaleidoscope
+ * Copyright (C) 2019  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of version 3 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <Kaleidoscope.h>
+
+namespace kaleidoscope {
+namespace plugin {
+
+class UnderglowControl;
+
+class UnderglowEffect : public kaleidoscope::Plugin {
+  friend class UnderglowControl;
+ public:
+  UnderglowEffect() {}
+
+ protected:
+  virtual void onActivate() {};
+  virtual void update() {}
+  virtual void refreshAt(uint8_t index) {}
+};
+
+class UnderglowControl : public kaleidoscope::Plugin {
+ public:
+  UnderglowControl() {}
+
+#if KALEIDOSCOPE_HARDWARE_HAS_UNDERGLOW
+  const int8_t led_count();
+  const bool has_leds();
+  void sync();
+
+  void setColorAt(uint8_t index, cRGB color);
+  void setColorAt(uint8_t index, uint8_t r, uint8_t g, uint8_t b);
+  void setColor(cRGB color);
+  void setColor(uint8_t r, uint8_t g, uint8_t b);
+  cRGB getColorAt(uint8_t index);
+
+  EventHandlerResult beforeReportingState();
+#else
+  const int8_t led_count() {
+    return -1;
+  }
+  const bool has_leds() {
+    return false;
+  }
+  void sync() {}
+  void setColorAt(uint8_t index, cRGB color) {}
+  void setColorAt(uint8_t index, uint8_t r, uint8_t g, uint8_t b) {}
+  cRGB getColorAt(uint8_t index) {
+    return CRGB(0, 0, 0);
+  }
+  void setColor(cRGB color) {}
+  void setColor(uint8_t r, uint8_t g, uint8_t b) {}
+
+  EventHandlerResult beforeReportingState() {
+    return EventHandlerResult::OK;
+  }
+#endif
+
+  void activateEffect(UnderglowEffect &effect) {
+    effect_ = &effect;
+    effect_->onActivate();
+  }
+  void updateEffect() {
+    if (!effect_)
+      return;
+    effect_->update();
+  }
+  void refreshEffectAt(uint8_t index) {
+    if (!effect_)
+      return;
+    effect_->refreshAt(index);
+  }
+  void deactivateEffect() {
+    effect_ = NULL;
+  }
+  const UnderglowEffect *currentEffect() {
+    return effect_;
+  }
+
+  bool isPaused() {
+    return paused_;
+  }
+  void pause() {
+    paused_ = true;
+  }
+  void resume() {
+    paused_ = false;
+  }
+
+  uint16_t sync_delay() {
+    return sync_delay_;
+  }
+  void sync_delay(uint16_t delay) {
+    sync_delay_ = delay;
+  }
+
+ private:
+  bool paused_ = false;
+  uint16_t sync_delay_ = 40;
+  uint16_t sync_start_time_ = 0;
+  UnderglowEffect *effect_;
+};
+
+class UnderglowOff : public UnderglowEffect {
+ public:
+  UnderglowOff() {}
+
+ protected:
+  void onActivate() final;
+};
+
+}
+}
+
+extern kaleidoscope::plugin::UnderglowControl UnderglowControl;
+extern kaleidoscope::plugin::UnderglowOff UnderglowOff;


### PR DESCRIPTION
The bulk of this is the `UnderglowControl` plugin, modeled after `LEDControl`. The `KBD4x` keyboard is the first one to support this, and I ported a few of the existing LED effects over.

Documentation is missing, but creating a PR makes it easier to review naming, the API, etc. I'll write the docs once we're happy with how things look.