### PR TITLE
EEPROMKeymap redesign

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -140,6 +140,10 @@ The [Redial](doc/plugin/Redial.md) plugin was simplified, one no longer needs to
 
 The [LED-Palette-Theme](doc/plugin/LED-Palette-Theme.md) had to be changed to store the palette colors in reverse. This change had to be made in order to not default to a bright white palette, that would draw so much power that most operating systems would disconnect the keyboard due to excessive power usage. With inverting the colors, we now default to a black palette instead. This sadly breaks existing palettes, and you will have to re-set the colors.
 
+### EEPROM-Keymap changed Focus commands
+
+The [EEPROMKeymap](doc/plugin/EEPROM-Keymap.md) plugin was changed to treat built-in (default) and EEPROM-stored (custom) layers separately, because that's less surprising, and easier to work with from Chrysalis. The old `keymap.map` and `keymap.roLayers` commands are gone, the new `keymap.default` and `keymap.custom` commands should be used instead.
+
 ## Bugfixes
 
 We fixed way too many issues to list here, so we're going to narrow it down to the most important, most visible ones.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -20,6 +20,7 @@ If any of this does not make sense to you, or you have trouble updating your .in
     - [Removal of Layer.defaultLayer](#removal-of-layerdefaultlayer)
     - [More clarity in Layer method names](#more-clarity-in-layer-method-names)
     - [Finer OneShot stickability control](#finer-oneshot-stickability-control)
+    - [EEPROMKeymap mode](#eepromkeymap-mode)
     - [Source code and namespace rearrangement](#source-code-and-namespace-rearrangement)
 * [Removed APIs](#removed-apis)
 
@@ -453,6 +454,10 @@ The goal was to have a method name that is a verb, because these are actions we 
 ### Finer OneShot stickability control
 
 The [OneShot plugin](doc/plugin/OneShot.md) has much improved stickability control. Instead of only being able to control if one-shot layers should be stickable too, or disabling the sticky feature in general, it is now possible to control stickiness on a per-key basis with the new `OneShot.enableStickability()` and `OneShot.disableStickablity()` methods.
+
+### EEPROMKeymap mode
+
+The [EEPROM-Keymap](doc/plugin/EEPROM-Keymap.md) plugin had its `setup()` method changed, the formerly optional `method` argument is now obsolete and unused. It can be safely removed. Supplying a second argument will continue to work until its scheduled removal by **2019-04-30**.
 
 ### Source code and namespace rearrangement
 

--- a/doc/plugin/EEPROM-Keymap.md
+++ b/doc/plugin/EEPROM-Keymap.md
@@ -6,6 +6,8 @@ In short, this plugin allows us to change our keymaps, without having to compile
 
  [plugin:focusSerial]: FocusSerial.md
 
+By default, the plugin extends the keymap in PROGMEM: it will only look for keys in EEPROM if looking up from a layer that's higher than the last one in PROGMEM. This behaviour can be changed either via `Focus` (see below), or by calling `EEPROMSettings.use_eeprom_layers_only` (see the [EEPROMSettings](EEPROM-Settings.md) documentation for more information).
+
 ## Using the plugin
 
 Using the plugin is reasonably simple: after including the header, enable the plugin, and configure how many layers at most we want to store in `EEPROM`. There are other settings one can tweak, but these two steps are enough to get started with.
@@ -31,27 +33,31 @@ void setup() {
 
 The plugin provides the `EEPROMKeymap` object, which has the following method:
 
-### `.setup(layers[, mode])`
+### `.setup(layers)`
 
-> Reserve space in EEPROM for up to `layers` layers, and set things up to work according to the specified `mode` (see below for a list of supported modes). To be called from the `setup` method of one's sketch.
->
-> Supported modes are:
-> - `EEPROMKeymap.Mode::EXTEND`: Extend the keymap with layers from EEPROM, treating them as extensions of the main keymap embedded in the firmware. The first layer in EEPROM will have a number one higher than the last layer in PROGMEM. In this case, the total number of layers will be the number of them in PROGMEM plus `layers`.
-> - `EEPROMKeymap.Mode::CUSTOM`: For advanced use cases where the `EXTEND` mode is not appropriate. In this case, the plugin merely reserves a slice of EEPROM for the requested amount of layers, but does no other configuration - that's entirely up to the Sketch.
+> Reserve space in EEPROM for up to `layers` layers, and set up the key lookup mechanism.
 
 ## Focus commands
 
-The plugin provides the `keymap.map` and a `keymap.roLayers` commands.
+The plugin provides three Focus commands: `keymap.default`, `keymap.custom`, and `keymap.useCustom`.
 
-### `keymap.map [codes...]`
+### `keymap.default`
 
-> Without arguments, displays the keymap currently in effect. Each key is printed as its raw, 16-bit keycode.
+> Display the default keymap from PROGMEM. Each key is printed as its raw, 16-bit keycode.
 >
-> With arguments, it stores as many keys as given. One does not need to set all keys, on all layers: the command will start from the first key on the first layer, and go on as long as it has input. It will not go past the total amount of layers (that is, `layer_count`).
+> Unlike `keymap.custom`, this does not support updating, because PROGMEM is read-only.
 
-### `keymap.roLayers`
+### `keymap.custom [codes...]`
 
-> Returns the number of read-only layers. This only makes sense for the `EEPROMKeymap.Mode::EXTEND` mode, where it returns the number of layers in PROGMEM. In any other case, it doesn't return anything, doing so is left for another event handler that understands what the correct value would be.
+> Without arguments, display the custom keymap stored in EEPROM. Each key is printed as its raw, 16-bit keycode.
+>
+> With arguments, it updates as many keys as given. One does not need to set all keys, on all layers: the command will start from the first key on the first layer (in EEPROM, which might be different than the first layer!), and go on as long as it has input. It will not go past the number of layers in EEPROM.
+
+### `keymap.onlyCustom [0|1]`
+
+> Without arguments, returns whether the firmware uses both the default and the custom layers (the default, `0`) or custom (EEPROM-stored) layers only (`1`).
+>
+> With an argument, sets whether to use custom layers only, or extend the built-in layers instead.
 
 ## Dependencies
 

--- a/doc/plugin/EEPROM-Settings.md
+++ b/doc/plugin/EEPROM-Settings.md
@@ -64,8 +64,22 @@ The plugin provides the `EEPROMSettings` object, which has the following methods
 > keyboard boots up, it will automatically switch to the configured layer - if
 > any.
 >
-> This is the Focus counterpart of the `default_layer()` method documented
-> above.
+> Setting it to `126` or anything higher disables the automatic switching.
+
+### `ignoreHardcodedLayers([true|false])`
+
+> Controls whether the hardcoded layers (in `PROGMEM`) are ignored or not.
+>
+> When not ignored, the custom layes (in `EEPROM`) extend the hardcoded ones.
+> When ignored, they replace the hardcoded set.
+>
+> Returns the setting if called without arguments, changes it to the desired
+> value if called with a boolean flag.
+>
+> This setting is exposed to Focus via the `keymap.onlyCustom` command
+> implemented by the [EEPROM-Keymap][EEPROM-Keymap.md] plugin.
+>
+> Defaults to `false`.
 
 ### `seal()`
 
@@ -129,7 +143,10 @@ following commands:
 
 > Sets or returns (if called without arguments) the ID of the default layer. If
 > set, the keyboard will automatically switch to the given layer when connected.
-> Setting it to `255` disables the automatic switching.
+> Setting it to `126` or anything higher disables the automatic switching.
+>
+> This is the Focus counterpart of the `default_layer()` method documented
+> above.
 
 ### `settings.crc`
 

--- a/src/kaleidoscope/plugin/EEPROM-Keymap.h
+++ b/src/kaleidoscope/plugin/EEPROM-Keymap.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-EEPROM-Keymap -- EEPROM-based keymap support.
- * Copyright (C) 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2017, 2018, 2019  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -20,13 +20,17 @@
 #include <Kaleidoscope.h>
 #include <Kaleidoscope-EEPROM-Settings.h>
 
+#define _DEPRECATED_MESSAGE_EEPROM_KEYMAP_SETUP_MODE                       \
+  "The `mode` argument of EEPROMKeymap.setup() is deprecated and is not\n" \
+  "used anymore. You can remove it safely."
+
 namespace kaleidoscope {
 namespace plugin {
 class EEPROMKeymap : public kaleidoscope::Plugin {
  public:
   enum class Mode {
     CUSTOM,
-    EXTEND,
+    EXTEND
   };
 
   EEPROMKeymap(void) {}
@@ -34,7 +38,10 @@ class EEPROMKeymap : public kaleidoscope::Plugin {
   EventHandlerResult onSetup();
   EventHandlerResult onFocusEvent(const char *command);
 
-  static void setup(uint8_t max, Mode mode = Mode::EXTEND);
+  static void setup(uint8_t max);
+  static void setup(uint8_t max, Mode mode) DEPRECATED(EEPROM_KEYMAP_SETUP_MODE) {
+    setup(max);
+  }
 
   static void max_layers(uint8_t max);
 
@@ -49,10 +56,10 @@ class EEPROMKeymap : public kaleidoscope::Plugin {
   static uint16_t keymap_base_;
   static uint8_t max_layers_;
   static uint8_t progmem_layers_;
-  static Mode mode_;
 
   static Key parseKey(void);
   static void printKey(Key key);
+  static void dumpKeymap(uint8_t layers, Key(*getkey)(uint8_t, byte, byte));
 };
 }
 }

--- a/src/kaleidoscope/plugin/EEPROM-Settings.h
+++ b/src/kaleidoscope/plugin/EEPROM-Settings.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-EEPROM-Settings -- Basic EEPROM settings plugin for Kaleidoscope.
- * Copyright (C) 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2017, 2018, 2019  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -44,14 +44,20 @@ class EEPROMSettings : public kaleidoscope::Plugin {
   static uint8_t default_layer() {
     return settings_.default_layer;
   }
+  static void ignoreHardcodedLayers(bool value);
+  static bool ignoreHardcodedLayers() {
+    return settings_.ignore_hardcoded_layers;
+  }
 
  private:
+  static constexpr uint8_t IGNORE_HARDCODED_LAYER_MASK = 0b1111110;
   static uint16_t next_start_;
   static bool is_valid_;
   static bool sealed_;
 
   static struct settings {
-    uint8_t default_layer;
+    uint8_t default_layer: 7;
+    bool ignore_hardcoded_layers: 1;
     uint8_t version;
     uint16_t crc;
   } settings_;


### PR DESCRIPTION
Instead of having a single `keymap.map` Focus command that tries to be smart about what layers it presents, we should have two separate commands: one to query the defaults (PROGMEM), and one to get/set the custom keymap (EEPROM). This makes `keymap.map` and `keymap.roLayers` obsolete, and they're now removed.

Furthermore, having to specify whether the EEPROM keymap extends the built-in one or not proved to be unflexible. So we re-purposed the highest bit of the first EEPROM byte, to signal whether we should use EEPROM layers only or not.
