### PR TITLE
Repurpose EEPROMSettings' version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -150,6 +150,15 @@ We also changed when we reserve space for the palette in EEPROM: we used to do i
 
 The [EEPROMKeymap](doc/plugin/EEPROM-Keymap.md) plugin was changed to treat built-in (default) and EEPROM-stored (custom) layers separately, because that's less surprising, and easier to work with from Chrysalis. The old `keymap.map` and `keymap.roLayers` commands are gone, the new `keymap.default` and `keymap.custom` commands should be used instead.
 
+### EEPROMSettings' version() setter has been deprecated
+
+We're repurposing the `version` setting: instead of it being something end-users
+can set, we'll be using it internally to track changes made to
+[EEPROMSettings](doc/plugin/EEPROM-Settings.md) itself, with the goal of
+allowing external tools to aid in migrations. The setting wasn't widely used -
+if at all -, which is why we chose to repurpose it instead of adding a new
+field.
+
 ## Bugfixes
 
 We fixed way too many issues to list here, so we're going to narrow it down to the most important, most visible ones.

--- a/doc/plugin/EEPROM-Settings.md
+++ b/doc/plugin/EEPROM-Settings.md
@@ -111,13 +111,12 @@ The plugin provides the `EEPROMSettings` object, which has the following methods
 > firmware would expect. This signals to other plugins that the contents of
 > `EEPROM` should not be trusted.
 
-### `version([newVersion])`
+### `version()`
 
-> Sets or returns the version of the `EEPROM` layout. This is purely for use by
-> the firmware, so it can attempt to upgrade the contents, if need be, or alert
-> the user in there's a mismatch. Plugins do not use this property.
+> Returns the current version of the EEPROM settings. It's the version of the
+> settings only, not that of the whole layout - the CRC covers that.
 >
-> Should only be called after calling `seal()`.
+> This is for internal use only, end-users should not need to care about it.
 
 ### `crc()`
 
@@ -159,7 +158,7 @@ following commands:
 
 ### `settings.version`
 
-> Returns the (user-set) version of the settings.
+> Returns the version of the settings.
 
 ### `eeprom.contents`
 

--- a/src/kaleidoscope/plugin/EEPROM-Settings.h
+++ b/src/kaleidoscope/plugin/EEPROM-Settings.h
@@ -20,6 +20,10 @@
 #include <Kaleidoscope.h>
 #include <EEPROM.h>
 
+#define _DEPRECATED_MESSAGE_EEPROMSETTINGS_VERSION_SET            \
+  "The EEPROMSettings.version(uint8_t version) method has been deprecated,\n" \
+  "and is a no-op now. Please see the NEWS file for more information."
+
 namespace kaleidoscope {
 namespace plugin {
 class EEPROMSettings : public kaleidoscope::Plugin {
@@ -29,11 +33,25 @@ class EEPROMSettings : public kaleidoscope::Plugin {
   EventHandlerResult onSetup();
   EventHandlerResult beforeEachCycle();
 
+  /* EEPROM is filled with 0xff when uninitialized, so a version with that value
+   * means we do not have an EEPROM version defined yet. */
+  static constexpr uint8_t VERSION_UNDEFINED = 0xff;
+  /* A version set to zero is likely some kind of corruption, we do not normally
+   * clear the byte. */
+  static constexpr uint8_t VERSION_IMPOSSIBLE_ZERO = 0x00;
+  /* Our current version. Whenever we change the layout of the settings, this
+   * needs to be increased too. If the version stored in EEPROM does not match
+   * this version, EEPROM use should be considered unsafe, and plugins should
+   * fall back to not using it. */
+  static constexpr uint8_t VERSION_CURRENT = 0x01;
+
   static void update(void);
   static bool isValid(void);
   static void invalidate(void);
-  static uint8_t version(void);
-  static void version(uint8_t ver);
+  static uint8_t version(void) {
+    return settings_.version;
+  }
+  static void version(uint8_t) DEPRECATED(EEPROMSETTINGS_VERSION_SET) {}
 
   static uint16_t requestSlice(uint16_t size);
   static void seal(void);


### PR DESCRIPTION
We want to be able to notice when the layout of the EEPROM *settings* changed (which the CRC does not cover). For this reason, we're repurposing the existing version setting, which wasn't widely used: it is now internal.

We use the version to determine whether the EEPROM has been written to yet, or if it is uninitialized. This helps us make sure we're starting up with sensible defaults.

Fixes #559, and fixes #558.
