### PR TITLE
OneShot optimizations

### DIFF
--- a/src/kaleidoscope/plugin/OneShot.cpp
+++ b/src/kaleidoscope/plugin/OneShot.cpp
@@ -163,9 +163,6 @@ EventHandlerResult OneShot::onKeyswitchEvent(Key &mapped_key, byte row, byte col
 }
 
 EventHandlerResult OneShot::beforeReportingState() {
-  if (!isActive())
-    return EventHandlerResult::OK;
-
   for (uint8_t i = 0; i < 8; i++) {
     if (state_[i].active) {
       activateOneShot(i);
@@ -176,9 +173,6 @@ EventHandlerResult OneShot::beforeReportingState() {
 }
 
 EventHandlerResult OneShot::afterEachCycle() {
-  if (!isActive())
-    return EventHandlerResult::OK;
-
   if (hasTimedOut())
     cancel();
 

--- a/src/kaleidoscope/plugin/OneShot.h
+++ b/src/kaleidoscope/plugin/OneShot.h
@@ -28,21 +28,22 @@ namespace plugin {
 
 class OneShot : public kaleidoscope::Plugin {
  public:
-  OneShot(void) {}
+  OneShot(void) {
+    for (uint8_t i = 0; i < 16; i++) {
+      state_[i].stickable = true;
+    }
+  }
 
   static bool isOneShotKey(Key key) {
     return (key.raw >= kaleidoscope::ranges::OS_FIRST && key.raw <= kaleidoscope::ranges::OS_LAST);
   }
   static bool isActive(void);
-  static bool isPressed() {
-    return !!pressed_state_.all;
-  }
-  static bool isSticky() {
-    return !!sticky_state_.all;
-  }
   static bool isActive(Key key);
+  static bool isPressed();
+  static bool isSticky();
   static bool isSticky(Key key);
   static void cancel(bool with_stickies = false);
+
   static uint16_t time_out;
   static int16_t double_tap_time_out;
   static uint16_t hold_time_out;
@@ -78,22 +79,20 @@ class OneShot : public kaleidoscope::Plugin {
   void inject(Key mapped_key, uint8_t key_state);
 
  private:
-  typedef union {
-    struct {
-      uint8_t mods;
-      uint8_t layers;
-    };
-    uint16_t all;
-  } state_t;
+  typedef struct {
+    bool active: 1;
+    bool pressed: 1;
+    bool stickable: 1;
+    bool sticky: 1;
+    uint8_t __reserved: 4;
+    uint8_t position;
+  } key_state_t;
+  static key_state_t state_[16];
+
   static uint32_t start_time_;
-  static state_t state_;
-  static state_t sticky_state_;
-  static state_t stickable_state_;
-  static state_t pressed_state_;
   static Key prev_key_;
   static bool should_cancel_;
   static bool should_cancel_stickies_;
-  static uint8_t positions_[16];
 
   static void positionToCoords(uint8_t pos, byte *row, byte *col);
 

--- a/src/kaleidoscope/plugin/OneShot.h
+++ b/src/kaleidoscope/plugin/OneShot.h
@@ -99,6 +99,13 @@ class OneShot : public kaleidoscope::Plugin {
   static void injectNormalKey(uint8_t idx, uint8_t key_state);
   static void activateOneShot(uint8_t idx);
   static void cancelOneShot(uint8_t idx);
+
+  static bool isOneShotKey_(Key key) {
+    return key.raw >= ranges::OS_FIRST && key.raw <= ranges::OS_LAST;
+  }
+  static bool hasTimedOut() {
+    return Kaleidoscope.millisAtCycleStart() - start_time_ >= time_out;
+  }
 };
 }
 }


### PR DESCRIPTION
The major change here is how the internal state is kept. Instead of using 4 16-bit bitfields, we now use a struct of mostly bools, with members having descriptive names. This allows us to remove the ugly macros that made the code readable, because it is more readable without them by now. And by not using bitfields, we save plenty of PROGMEM because 16-bit operations on a 8-bit MCU are expensive.

As far as functionality goes, there should be no change. However, as far as code and compiled size go, this saves us about 270 PROGMEM at the cost of 8 bytes of RAM - a fair trade.

Currently WIP, because I may tweak this further. Putting the PR out for the time being, because I might end up not tweaking it further this time.