### PR TITLE
Enable safer sending of mid-cycle reports

### DIFF
--- a/src/kaleidoscope/hid.h
+++ b/src/kaleidoscope/hid.h
@@ -33,6 +33,13 @@ extern void releaseRawKey(Key mappedKey);
 /** Flushes any pending regular key switch events and sends them out */
 extern void sendKeyboardReport();
 
+// Store a copy of the current report so that a mid-cycle report can be sent based on the
+// previous report instead of the incomplete current report
+extern void stashKeyboardReport();
+// Restore the saved copy of the keyboard report so that the current cycle can be resumed
+// properly after sending a mid-cycle report
+extern void restoreKeyboardReport();
+
 extern boolean isModifierKeyActive(Key mappedKey);
 extern boolean wasModifierKeyActive(Key mappedKey);
 

--- a/src/kaleidoscope/plugin/Qukeys.cpp
+++ b/src/kaleidoscope/plugin/Qukeys.cpp
@@ -173,11 +173,7 @@ bool Qukeys::flushKey(bool qukey_state, uint8_t keyswitch_state) {
   // have a full HID report, and we don't want to accidentally turn
   // off keys that the scan hasn't reached yet, so we force the
   // current report to be the same as the previous one, then proceed
-  HID_KeyboardReport_Data_t hid_report;
-  // First, save the current report
-  memcpy(hid_report.allkeys, Keyboard.keyReport.allkeys, sizeof(hid_report));
-  // Next, copy the old report
-  memcpy(Keyboard.keyReport.allkeys, Keyboard.lastKeyReport.allkeys, sizeof(Keyboard.keyReport));
+  hid::stashKeyboardReport();
   // Instead of just calling pressKey here, we start processing the
   // key again, as if it was just pressed, and mark it as injected, so
   // we can ignore it and don't start an infinite loop. It would be
@@ -188,7 +184,7 @@ bool Qukeys::flushKey(bool qukey_state, uint8_t keyswitch_state) {
   hid::sendKeyboardReport();
 
   // Next, we restore the current state of the report
-  memcpy(Keyboard.keyReport.allkeys, hid_report.allkeys, sizeof(hid_report));
+  hid::restoreKeyboardReport();
 
   // Last, if the key is still down, add its code back in
   if (keyswitch_state & IS_PRESSED)


### PR DESCRIPTION
When a plugin needs to send a keyboard report in the middle of the scan cycle, that can trigger bugs where a keyswitch processed later gets dropped from the mid-cycle report, then added again in the regular end-of-cycle report. This PR includes the other half of keyboardio/Kaleidoscope-HIDAdaptor-KeyboardioHID#16, and updates Qukeys to use it instead of directly modifying member variables in KeyboardioHID classes.

Also requires keyboardio/KeyboardioHID#49

Fixes #568