### PR TITLE
Remove numlock state management logic from NumPad plugin

### DIFF
--- a/doc/plugin/NumPad.md
+++ b/doc/plugin/NumPad.md
@@ -1,7 +1,7 @@
 # Kaleidoscope-NumPad
 
 This is a plugin for [Kaleidoscope][fw], that adds a NumPad-specific LED
-effect, along with a way to toggle to a numpad layer, and apply the effect.
+effect and applies it when the numpad layer is active.
 
 ## Using the extension
 

--- a/src/kaleidoscope/plugin/NumPad.h
+++ b/src/kaleidoscope/plugin/NumPad.h
@@ -34,15 +34,11 @@ class NumPad : public kaleidoscope::Plugin {
 
  private:
 
-  void cleanupNumlockState(void);
   void setKeyboardLEDColors(void);
-  bool getNumlockState(void);
-  void syncNumlockState(bool);
 
   static uint8_t numpadLayerToggleKeyRow;
   static uint8_t numpadLayerToggleKeyCol;
-  static bool numlockUnsynced;
-  static bool originalNumLockState;
+  static bool numpadActive;
 };
 }
 }


### PR DESCRIPTION
This PR disables the numlock state management logic in the NumPad plugin. This fixes two issues:

1. A bug in the NumPad plugin currently disables the NumLock state whenever exiting the numpad layer (instead of restoring the previous state)
2. macOS doesn't have a number lock and keeps the corresponding LED off, resulting in ⌧ being sent when enabling the numpad, destroying the contents of the current line

This PR depends on https://github.com/keyboardio/Model01-Firmware/pull/79.