### PR TITLE
TapDance: Switch from 16-bit bitfields to using a struct

### DIFF
--- a/src/kaleidoscope/plugin/TapDance.h
+++ b/src/kaleidoscope/plugin/TapDance.h
@@ -50,11 +50,16 @@ class TapDance : public kaleidoscope::Plugin {
   EventHandlerResult afterEachCycle();
 
  private:
+  static constexpr uint8_t TAPDANCE_KEY_COUNT = 16;
+  struct TapDanceState {
+    bool pressed: 1;
+    bool triggered: 1;
+    bool release_next: 1;
+    uint8_t count;
+  };
+  static TapDanceState state_[TAPDANCE_KEY_COUNT];
+
   static uint32_t end_time_;
-  static uint8_t tap_count_[16];
-  static uint16_t pressed_state_;
-  static uint16_t triggered_state_;
-  static uint16_t release_next_state_;
   static Key last_tap_dance_key_;
   static byte last_tap_dance_row_;
   static byte last_tap_dance_col_;


### PR DESCRIPTION
On AVR8, 16-bit bit-operations are expensive. Switch from using 3 16-bit bitfields to using a 16-element array of a carefully constructed struct.

This saves us almost 300 bytes of PROGMEM at the cost of 10 bytes of memory.

This is pretty much the same treatment as OneShot, except it doesn't have the bugs that were later ironed out from there.