### PR TITLE
UPGRADING.md: Add a removal date for the old stickability props

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -453,7 +453,7 @@ The goal was to have a method name that is a verb, because these are actions we 
 
 ### Finer OneShot stickability control
 
-The [OneShot plugin](doc/plugin/OneShot.md) has much improved stickability control. Instead of only being able to control if one-shot layers should be stickable too, or disabling the sticky feature in general, it is now possible to control stickiness on a per-key basis with the new `OneShot.enableStickability()` and `OneShot.disableStickablity()` methods.
+The [OneShot plugin](doc/plugin/OneShot.md) has much improved stickability control. Instead of only being able to control if one-shot layers should be stickable too, or disabling the sticky feature in general, it is now possible to control stickiness on a per-key basis with the new `OneShot.enableStickability()` and `OneShot.disableStickablity()` methods. The old properties are still available, but will be removed by **2019-04-30**.
 
 ### EEPROMKeymap mode
 


### PR DESCRIPTION
When adding the finer stickability controls and deprecating the old properties, we forgot to set a date for the old prop removal. Lets do that now.
