### PR TITLE
Remove some deprecated interfaces

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -435,22 +435,6 @@ Older versions of the plugin required one to set up `Key_Redial` manually, and l
 
 ## Deprecated APIs and their replacements
 
-### Removal of Layer.defaultLayer
-
-The `Layer.defaultLayer()` method has been deprecated, because it wasn't widely used, nor tested well, and needlessly complicated the layering logic. If one wants to set a default layer, which the keyboard switches to when booting up, `EEPROMSettings.default_layer()` may be of use.
-
-`Layer.defaultLayer` is slated for removal by **2019-02-14**.
-
-### More clarity in Layer method names
-
-A number of methods on the `Layer` object have been renamed, to make their intent clearer:
-
-- `Layer.on()` and `Layer.off()` became `Layer.activate()` and `Layer.decativate()`, repsectively.
-- `Layer.next()` and `Layer.previous()` became `Layer.activateNext()` and `Layer.deactivateTop()`.
-- `Layer.isOn` became `Layer.isActive()`.
-
-The goal was to have a method name that is a verb, because these are actions we do. The old names are still present, but emit a deprecation warning, and will be removed by **2019-02-14**.
-
 ### Finer OneShot stickability control
 
 The [OneShot plugin](doc/plugin/OneShot.md) has much improved stickability control. Instead of only being able to control if one-shot layers should be stickable too, or disabling the sticky feature in general, it is now possible to control stickiness on a per-key basis with the new `OneShot.enableStickability()` and `OneShot.disableStickablity()` methods.
@@ -481,6 +465,24 @@ The following headers and names have changed:
 - [TapDance](doc/plugin/TapDance.md) had the `kaleidoscope::TapDance::ActionType` type replaced by `kaleidoscope::plugin::TapDance::ActionType`.
 
 # Removed APIs
+
+### Removed on 2019-01-18
+
+### Removal of Layer.defaultLayer
+
+The `Layer.defaultLayer()` method has been deprecated, because it wasn't widely used, nor tested well, and needlessly complicated the layering logic. If one wants to set a default layer, which the keyboard switches to when booting up, `EEPROMSettings.default_layer()` may be of use.
+
+`Layer.defaultLayer` has since been removed.
+
+### More clarity in Layer method names
+
+A number of methods on the `Layer` object have been renamed, to make their intent clearer:
+
+- `Layer.on()` and `Layer.off()` became `Layer.activate()` and `Layer.decativate()`, repsectively.
+- `Layer.next()` and `Layer.previous()` became `Layer.activateNext()` and `Layer.deactivateTop()`.
+- `Layer.isOn` became `Layer.isActive()`.
+
+The goal was to have a method name that is a verb, because these are actions we do. The old names have since been removed.
 
 ### Removed on 2019-01-17
 

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -79,34 +79,14 @@ class Layer_ {
 
   static void activate(uint8_t layer);
   static void deactivate(uint8_t layer);
-  static void on(uint8_t layer) DEPRECATED(LAYER_ON) {
-    activate(layer);
-  }
-  static void off(uint8_t layer) DEPRECATED(LAYER_OFF) {
-    deactivate(layer);
-  }
   static void activateNext();
   static void deactivateTop();
-  static void next(void) DEPRECATED(LAYER_NEXT) {
-    activateNext();
-  }
-  static void previous(void) DEPRECATED(LAYER_PREVIOUS) {
-    deactivateTop();
-  }
   static void move(uint8_t layer);
 
   static uint8_t top(void) {
     return top_active_layer_;
   }
   static boolean isActive(uint8_t layer);
-  static boolean isOn(uint8_t layer) DEPRECATED(LAYER_ISON) {
-    return isActive(layer);
-  };
-
-  static void defaultLayer(uint8_t layer) DEPRECATED(LAYER_DEFAULT) {}
-  static uint8_t defaultLayer(void) DEPRECATED(LAYER_DEFAULT) {
-    return 0;
-  }
 
   static uint32_t getLayerState(void) {
     return layer_state_;

--- a/src/kaleidoscope_internal/deprecations.h
+++ b/src/kaleidoscope_internal/deprecations.h
@@ -26,23 +26,3 @@
   "------------------------------------------------------------------------\n" \
 
 /* Messages */
-#define _DEPRECATED_MESSAGE_LAYER_DEFAULT                                   \
-  "Layer.defaultLayer() is deprecated, and a no-op.\n"                      \
-  "\n"                                                                      \
-  "If you want to set the default layer for the keyboard, consider using\n" \
-  "EEPROMSettings.default_layer() instead."
-
-#define _DEPRECATED_MESSAGE_LAYER_ON                                        \
-  "Please use `Layer.activate()` instead of `Layer.on()`."
-
-#define _DEPRECATED_MESSAGE_LAYER_OFF                                       \
-  "Please use `Layer.deactivate()` instead of `Layer.off()`."
-
-#define _DEPRECATED_MESSAGE_LAYER_NEXT                                      \
-  "Please use `Layer.activateNext()` instead of `Layer.next()`."
-
-#define _DEPRECATED_MESSAGE_LAYER_PREVIOUS                                  \
-  "Please use `Layer.deactivateTop()` instead of `Layer.previous()`."
-
-#define _DEPRECATED_MESSAGE_LAYER_ISON                                      \
-  "Please use `Layer.isActive()` instead of `Layer.isOn().`"


### PR DESCRIPTION
Various old methods provided by `Layer` have been deprecated for a while, and were scheduled to be removed by February 14, 2019. We're past that, so lets remove them.

Fixes #577.
