### PR TITLE
Switch from compiling with C++11 to C++14

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -235,7 +235,7 @@ compile () {
 	      ${EXTRA_BUILDER_ARGS} \
 	      -build-path "${BUILD_PATH}" \
 	      -ide-version "${ARDUINO_IDE_VERSION}" \
-	      -prefs "compiler.cpp.extra_flags=-std=c++14 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
+	      -prefs "compiler.cpp.extra_flags=-std=c++14 -Wno-sized-deallocation -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
 	      -warnings all \
         ${ARDUINO_VERBOSE} \
 	      ${ARDUINO_AVR_GCC_PREFIX_PARAM} \

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -235,7 +235,7 @@ compile () {
 	      ${EXTRA_BUILDER_ARGS} \
 	      -build-path "${BUILD_PATH}" \
 	      -ide-version "${ARDUINO_IDE_VERSION}" \
-	      -prefs "compiler.cpp.extra_flags=-std=c++11 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
+	      -prefs "compiler.cpp.extra_flags=-std=c++14 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
 	      -warnings all \
         ${ARDUINO_VERBOSE} \
 	      ${ARDUINO_AVR_GCC_PREFIX_PARAM} \


### PR DESCRIPTION
I changed the compiler flags in kaleidoscope-builder to use `-std=c++-14`. This appears to work on my iMac, but I haven't tested it anywhere else yet.

I'm re-submitting this as a new PR because I want TravisCI to try building it, and when I submitted it as a draft, that wasn't done.