### PR TITLE
Suppressed a compiler warning and added warning suppression macros

### DIFF
--- a/src/kaleidoscope_internal/compiler_warnings.h
+++ b/src/kaleidoscope_internal/compiler_warnings.h
@@ -35,17 +35,17 @@
 // This enables suppress only those compiler warnings that are safe to
 // silence without using global flags as -Wno...
 //
-// Use e.g. as 
+// Use e.g. as
 //
 #if 0 // Not part of the example
 
 // Suppress Warnings for unused variables
-COMPILER_DIAG_OFF(unused-variable)
+COMPILER_DIAG_OFF(unused - variable)
 
 // Place code here that generates unavoidable unused variables
 
-COMPILER_DIAG_ON(unused-variable)
-// From this point onward, the compiler continues to warn for 
+COMPILER_DIAG_ON(unused - variable)
+// From this point onward, the compiler continues to warn for
 // unused variables.
 
 #endif // Not part of the example

--- a/src/kaleidoscope_internal/compiler_warnings.h
+++ b/src/kaleidoscope_internal/compiler_warnings.h
@@ -1,0 +1,56 @@
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2018  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// Please note that due to a bug in older gcc versions the following
+// warning suppressions mechanism does not work for gcc versions below 6.1.
+
+//******************************************************************************
+// Start for internal use only
+//******************************************************************************
+#define _GCC_DIAG_STR(s) #s
+#define _GCC_DIAG_JOINSTR(x,y) _GCC_DIAG_STR(x ## y)
+#define _GCC_DIAG_DO_PRAGMA(x) _Pragma (#x)
+#define _GCC_DIAG_PRAGMA(x) _GCC_DIAG_DO_PRAGMA(GCC diagnostic x)
+//******************************************************************************
+// End for internal use only
+//******************************************************************************
+
+//******************************************************************************
+// Use the following macros to temporarily silence compiler diagnostics (warnings).
+// This enables suppress only those compiler warnings that are safe to
+// silence without using global flags as -Wno...
+//
+// Use e.g. as 
+//
+#if 0 // Not part of the example
+
+// Suppress Warnings for unused variables
+COMPILER_DIAG_OFF(unused-variable)
+
+// Place code here that generates unavoidable unused variables
+
+COMPILER_DIAG_ON(unused-variable)
+// From this point onward, the compiler continues to warn for 
+// unused variables.
+
+#endif // Not part of the example
+
+//******************************************************************************
+#define COMPILER_DIAG_OFF(x) _GCC_DIAG_PRAGMA(push)      __NL__ \
+            _GCC_DIAG_PRAGMA(ignored _GCC_DIAG_JOINSTR(-W,x))
+#define COMPILER_DIAG_ON(x) _GCC_DIAG_PRAGMA(pop)

--- a/src/kaleidoscope_internal/eventhandler_signature_check.h
+++ b/src/kaleidoscope_internal/eventhandler_signature_check.h
@@ -19,7 +19,6 @@
 #include "kaleidoscope/macro_helpers.h"
 #include "kaleidoscope/plugin.h"
 
-
 // *************************************************************************
 // *************************************************************************
 // NOTHING IN THIS HEADER WILL RESULT IN ANY CODE COMPILED INTO KALEIDOSCOPE
@@ -135,6 +134,7 @@ template<typename Plugin__> struct
   /* type of a plugin that implements an event handler with an         */ __NL__ \
   /* incorrect signature, because it's not possible to include any     */ __NL__ \
   /* non-literal string constant in a static_assert error message.     */ __NL__ \
-  constexpr bool dummy = ___________Culprit_Plugin___________             __NL__ \
+  __attribute__((unused)) constexpr bool dummy                            __NL__ \
+                       = ___________Culprit_Plugin___________             __NL__ \
        <PLUGIN, Check::value>::value;                                     __NL__ \
 }


### PR DESCRIPTION
This commit silences a warning due to an undefined variable.

A first attemt to locally supress the warning using compiler pragmas was
unsuccessfull due to a compiler bug in all gcc versions. This bug
in all gcc versions below 6.1 makes local diagnostics suppression useless.

As future versions of Arduino will ship with later versions of gcc
from a certain point on, the supplied warning suppression macros will become useful
to avoid the necessity to set global compiler flags like -Wno... and to
enable more precise warning suppression.

The new header file comes with an example that explains how to use
the suppression mechanism.