### PR TITLE
Matrix address classes and interfaces

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -75,7 +75,7 @@ In practice, this boils down to implementing one or more of the following hook p
 
 - `onSetup()`: Called once during device bootup, at the end of the `setup()` method. It takes no arguments, and must return `kaleidoscope::EventHandlerResult::OK`.
 - `beforeEachCycle()`: Called once, at the beginning of each cycle of the main loop. This is similar to the old "loop hook" with its `post_clear` argument set to false. Takes no arguments, must return `kaleidoscope::EventHandlerResult::OK`.
-- `onKeyswitchEvent`: Called for every non-idle key event. This replaces the old "event handler hook". It takes a key reference, coordinates, and a key state. The key reference can be updated to change the key being processed, so that any plugin that processes it further, will see the updated key. Can return `kaleidoscope::EventHandlerResult::OK` to let other plugins process the event further, or `kaleidoscope::EventHandlerResult::EVENT_CONSUMED` to stop processing.
+- `onKeyswitchEvent2`: Called for every non-idle key event. This replaces the old "event handler hook". It takes a key reference, a key address, and a key state. The key reference can be updated to change the key being processed, so that any plugin that processes it further, will see the updated key. Can return `kaleidoscope::EventHandlerResult::OK` to let other plugins process the event further, or `kaleidoscope::EventHandlerResult::EVENT_CONSUMED` to stop processing.
 - `onFocusEvent`: Used to implement [bi-directional communication](#bidirectional-communication-for-plugins). This is called whenever the firmware receives a command from the host. The only argument is the command name. Can return `kaleidoscope::EventHandlerResult::OK` to let other plugins process the event further, or `kaleidoscope::EventHandlerResult::EVENT_CONSUMED` to stop processing.
 - `beforeReportingState`: Called without arguments, just before sending the keyboard and mouse reports to the host. Must return `kaleidoscope::EventHandlerResult::OK`.
 - `afterEachCycle`: Called without arguments at the very end of each cycle. This is the replacement for the "loop hook" with its `post_clear` argument set.
@@ -564,7 +564,7 @@ class Plugin {
 public:
   EventHandlerResult onSetup();
   EventHandlerResult beforeEachCycle();
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr keyAddr, uint8_t key_state);
   EventHandlerResult beforeReportingState();
   EventHandlerResult afterEachCycle();
 };

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -23,7 +23,7 @@ At the time of this writing, the following event handlers are run by hooks:
  - `onSetup`: Run once, when the plugin is initialised during
    `Kaleidoscope.setup()`.
  - `beforeEachCycle`: Run as the first thing at the start of each [cycle](#cycle).
- - `onKeyswitchEvent`: Run for every non-idle key, in each [cycle](#cycle) the
+ - `onKeyswitchEvent2`: Run for every non-idle key, in each [cycle](#cycle) the
    key isn't idle in. If a key gets pressed, released, or is held, it is not
    considered idle, and this event handler will run for it too.
  - `beforeReportingState`: Runs each [cycle](#cycle) right before sending the

--- a/doc/plugin/LED-AlphaSquare.md
+++ b/doc/plugin/LED-AlphaSquare.md
@@ -34,11 +34,11 @@ methods or properties other than those provided by all LED modes.
 
 ### `.display(key)`
 ### `.display(key, col)`
-### `.display(key, row, col)`
-### `.display(key, row, col, color)`
+### `.display(key, ledAddr)`
+### `.display(key, ledAddr, color)`
 
-> Display the symbol for `key` at the given row or column, with pixels set to
-> the specified `color`. If `row` is omitted, the first row - `0` is assumed. If
+> Display the symbol for `key` at the given led address, with pixels set to
+> the specified `color`. If only `col` is provided, the first row - `0` is assumed. If
 > the column is omitted, then the third column - `2` - is used.
 > If the `color` is omitted, the plugin will use the global `.color` property.
 >
@@ -50,8 +50,8 @@ methods or properties other than those provided by all LED modes.
 
 ### `.display(symbol)`
 ### `.display(symbol, col)`
-### `.display(symbol, row, col)`
-### `.display(symbol, row, col, color)`
+### `.display(symbol, ledAddr)`
+### `.display(symbol, ledAddr, color)`
 
 > As the previous function, but instead of a key, it expects a 4x4 bitmap in
 > the form of a 16-bit unsigned integer, where the low bit is the top-right
@@ -61,7 +61,7 @@ methods or properties other than those provided by all LED modes.
 
 ### `.clear(key)`, `.clear(symbol)`
 ### `.clear(key, col)`, `.clear(symbol, col)`
-### `.clear(key, col, row)`, `.clear(symbol, col, row)`
+### `.clear(key, ledAddr)`, `.clear(symbol, ledAddr)`
 
 > Just like the `.display()` counterparts, except these clear the symbol, by
 > turning the LED pixels it is made up from off.

--- a/doc/plugin/Qukeys.md
+++ b/doc/plugin/Qukeys.md
@@ -18,8 +18,8 @@ one keycode (i.e. symbol) when tapped, and a different keycode -- most likely a 
 KALEIDOSCOPE_INIT_PLUGINS(Qukeys);
 ```
 
-- Define some `Qukeys` of the format `Qukey(layer, row, col, alt_keycode)`
-  (layers, rows and columns are all zero-indexed, rows are top to bottom and
+- Define some `Qukeys` of the format `Qukey(layer, keyAddr, alt_keycode)`
+  (layers, and key addresses are all zero-indexed, in key addresses rows are top to bottom and
   columns are left to right):
 
 - For the Keyboardio Model 01, key coordinates refer to [this header

--- a/doc/plugin/Syster.md
+++ b/doc/plugin/Syster.md
@@ -28,9 +28,9 @@ void systerAction(kaleidoscope::plugin::Syster::action_t action, const char *sym
     Unicode.type (0x2328);
     break;
   case kaleidoscope::plugin::Syster::EndAction:
-    handleKeyswitchEvent (Key_Backspace, UNKNOWN_KEYSWITCH_LOCATION, IS_PRESSED | INJECTED);
+    handleKeyswitchEvent (Key_Backspace, UnknownKeyswitchLocation, IS_PRESSED | INJECTED);
     kaleidoscope::hid::sendKeyboardReport ();
-    handleKeyswitchEvent (Key_Backspace, UNKNOWN_KEYSWITCH_LOCATION, WAS_PRESSED | INJECTED);
+    handleKeyswitchEvent (Key_Backspace, UnknownKeyswitchLocation, WAS_PRESSED | INJECTED);
     kaleidoscope::hid::sendKeyboardReport ();
     break;
   case kaleidoscope::plugin::Syster::SymbolAction:

--- a/doc/plugin/TapDance.md
+++ b/doc/plugin/TapDance.md
@@ -123,7 +123,7 @@ property only:
 > The `tap_count` and `tap_dance_actions` parameters should be the same as the
 > similarly named parameters of the `tapDanceAction` function.
 
-### `tapDanceAction(tap_dance_index, row, col, tap_count, tap_dance_action)`
+### `tapDanceAction(tap_dance_index, keyAddr, tap_count, tap_dance_action)`
 
 > The heart of the tap-dance plugin is the handler method. This is called every
 > time any kind of tap-dance action is to be performed. See the

--- a/examples/Features/AppSwitcher/Macros.cpp
+++ b/examples/Features/AppSwitcher/Macros.cpp
@@ -58,6 +58,6 @@ void macroAppSwitchLoop() {
 
   // if appSwitchActive is true, we continue holding Alt.
   if (appSwitchActive) {
-    handleKeyswitchEvent(mod, UNKNOWN_KEYSWITCH_LOCATION, IS_PRESSED);
+    handleKeyswitchEvent(mod, UnknownKeyswitchLocation, IS_PRESSED);
   }
 }

--- a/examples/Features/GhostInTheFirmware/GhostInTheFirmware.ino
+++ b/examples/Features/GhostInTheFirmware/GhostInTheFirmware.ino
@@ -45,7 +45,7 @@ class EventDropper_ : public kaleidoscope::Plugin {
  public:
   EventDropper_() {}
 
-  kaleidoscope::EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
+  kaleidoscope::EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
     return kaleidoscope::EventHandlerResult::EVENT_CONSUMED;
   }
 };

--- a/examples/Keystrokes/Syster/Syster.ino
+++ b/examples/Keystrokes/Syster/Syster.ino
@@ -50,9 +50,9 @@ void systerAction(kaleidoscope::plugin::Syster::action_t action, const char *sym
     Unicode.type(0x2328);
     break;
   case kaleidoscope::plugin::Syster::EndAction:
-    handleKeyswitchEvent(Key_Backspace, UNKNOWN_KEYSWITCH_LOCATION, IS_PRESSED | INJECTED);
+    handleKeyswitchEvent(Key_Backspace, UnknownKeyswitchLocation, IS_PRESSED | INJECTED);
     kaleidoscope::hid::sendKeyboardReport();
-    handleKeyswitchEvent(Key_Backspace, UNKNOWN_KEYSWITCH_LOCATION, WAS_PRESSED | INJECTED);
+    handleKeyswitchEvent(Key_Backspace, UnknownKeyswitchLocation, WAS_PRESSED | INJECTED);
     kaleidoscope::hid::sendKeyboardReport();
     break;
   case kaleidoscope::plugin::Syster::SymbolAction:

--- a/examples/Keystrokes/TapDance/TapDance.ino
+++ b/examples/Keystrokes/TapDance/TapDance.ino
@@ -44,13 +44,18 @@ static void tapDanceEsc(uint8_t tap_dance_index, uint8_t tap_count, kaleidoscope
   tapDanceActionKeys(tap_count, tap_dance_action, Key_Escape, Key_Tab);
 }
 
-void tapDanceAction(uint8_t tap_dance_index, byte row, byte col, uint8_t tap_count, kaleidoscope::plugin::TapDance::ActionType tap_dance_action) {
+void tapDanceAction(uint8_t tap_dance_index, KeyAddr key_addr, uint8_t tap_count, kaleidoscope::plugin::TapDance::ActionType tap_dance_action) {
   switch (tap_dance_index) {
   case 0:
     return tapDanceActionKeys(tap_count, tap_dance_action, Key_Tab, Key_Escape);
   case 1:
     return tapDanceEsc(tap_dance_index, tap_count, tap_dance_action);
   }
+}
+
+// Only for backwards compatibility
+KS_ROW_COL_FUNC void tapDanceAction(uint8_t tap_dance_index, byte row, byte col, uint8_t tap_count, kaleidoscope::plugin::TapDance::ActionType tap_dance_action) {
+  tapDanceAction(tap_dance_index, KeyAddr(row, col), tap_count, tap_dance_action);
 }
 
 KALEIDOSCOPE_INIT_PLUGINS(TapDance);

--- a/src/kaleidoscope/Hardware.h
+++ b/src/kaleidoscope/Hardware.h
@@ -62,7 +62,7 @@ class Hardware {
   // for matrix addressing we define default key and led address classes.
   // Those typedefs are supposed to overridden by derived hardware classes.
   typedef MatrixAddr<0, 0> KeyAddr;
-  typedef MatrixAddr<0, 0> LEDAddr;
+  typedef MatrixAddr<0, 0> KeyLEDAddr;
   /**
    * @defgroup kaleidoscope_hardware_leds Kaleidoscope::Hardware/LEDs
    * @{
@@ -81,7 +81,7 @@ class Hardware {
    * @param led_addr is the matrix address of the LED.
    * @param color is the color to set the LED to.
    */
-  void setCrgbAt(LEDAddr led_addr, cRGB color) {}
+  void setCrgbAt(KeyLEDAddr led_addr, cRGB color) {}
   /**
    * Set the color of a per-key LED at a given row and column.
    *
@@ -124,7 +124,7 @@ class Hardware {
   * @returns The index of the LED at the given position, or -1 if there are no
   * LEDs there.
   */
-  int8_t getLedIndex(LEDAddr led_addr) {
+  int8_t getLedIndex(KeyLEDAddr led_addr) {
     return -1;
   }
   /**

--- a/src/kaleidoscope/Hardware.h
+++ b/src/kaleidoscope/Hardware.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "kaleidoscope/MatrixAddr.h"
+
 #ifndef CRGB
 #error cRGB and CRGB *must* be defined before including this header!
 #endif
@@ -55,6 +57,12 @@ namespace kaleidoscope {
  */
 class Hardware {
  public:
+
+  // To satisfy the interface of those methods that allow
+  // for matrix addressing we define default key and led address classes.
+  // Those typedefs are supposed to overridden by derived hardware classes.
+  typedef MatrixAddr<0, 0> KeyAddr;
+  typedef MatrixAddr<0, 0> LEDAddr;
   /**
    * @defgroup kaleidoscope_hardware_leds Kaleidoscope::Hardware/LEDs
    * @{
@@ -70,11 +78,21 @@ class Hardware {
    * Setting the color does not need to take effect immediately, it can be
    * delayed until @ref syncLeds is called.
    *
+   * @param led_addr is the matrix address of the LED.
+   * @param color is the color to set the LED to.
+   */
+  void setCrgbAt(LEDAddr led_addr, cRGB color) {}
+  /**
+   * Set the color of a per-key LED at a given row and column.
+   *
+   * Setting the color does not need to take effect immediately, it can be
+   * delayed until @ref syncLeds is called.
+   *
    * @param row is the logical row position of the key.
    * @param col is the logical column position of the key.
    * @param color is the color to set the LED to.
    */
-  void setCrgbAt(byte row, byte col, cRGB color) {}
+  KS_ROW_COL_FUNC void setCrgbAt(byte row, byte col, cRGB color) {}
   /**
    * Set the color of a per-key LED at a given LED index.
    *
@@ -99,6 +117,17 @@ class Hardware {
     return c;
   }
   /**
+  * Returns the index of the LED at a given row & column.
+  *
+  * @param led_addr is the matrix address of the LED.
+  *
+  * @returns The index of the LED at the given position, or -1 if there are no
+  * LEDs there.
+  */
+  int8_t getLedIndex(LEDAddr led_addr) {
+    return -1;
+  }
+  /**
    * Returns the index of the LED at a given row & column.
    *
    * @param row is the logical row position of the key.
@@ -107,7 +136,7 @@ class Hardware {
    * @returns The index of the LED at the given position, or -1 if there are no
    * LEDs there.
    */
-  int8_t getLedIndex(uint8_t row, byte col) {
+  KS_ROW_COL_FUNC int8_t getLedIndex(uint8_t row, byte col) {
     return -1;
   }
   /** @} */
@@ -153,10 +182,28 @@ class Hardware {
    * Masking a key out means that any other event than a release will be
    * ignored until said release.
    *
+   * @param key_addr is the matrix address of the key.
+   */
+  void maskKey(KeyAddr key_addr) {}
+  /**
+   * Mask out a key.
+   *
+   * Masking a key out means that any other event than a release will be
+   * ignored until said release.
+   *
    * @param row is the row the key is located at in the matrix.
    * @param col is the column the key is located at in the matrix.
    */
-  void maskKey(byte row, byte col) {}
+  KS_ROW_COL_FUNC void maskKey(byte row, byte col) {}
+  /**
+   * Unmask a key.
+   *
+   * Remove the mask - if any - for a given key. To be used when the mask
+   * needs to be removed without the key being released.
+   *
+   * @param key_addr is the matrix address of the key.
+   */
+  void unMaskKey(KeyAddr key_addr) {}
   /**
    * Unmask a key.
    *
@@ -170,12 +217,22 @@ class Hardware {
   /**
    * Check whether a key is masked or not.
    *
+   * @param key_addr is the matrix address of the key.
+   *
+   * @returns true if the key is masked, false otherwise.
+   */
+  bool isKeyMasked(KeyAddr key_addr) {
+    return false;
+  }
+  /**
+   * Check whether a key is masked or not.
+   *
    * @param row is the row the key is located at in the matrix.
    * @param col is the column the key is located at in the matrix.
    *
    * @returns true if the key is masked, false otherwise.
    */
-  bool isKeyMasked(byte row, byte col) {
+  KS_ROW_COL_FUNC bool isKeyMasked(byte row, byte col) {
     return false;
   }
   /** @} */
@@ -224,12 +281,22 @@ class Hardware {
   /**
    * Check if a key is pressed at a given position.
    *
+   * @param key_addr is the matrix address of the key.
+   *
+   * @returns true if the key is pressed, false otherwise.
+   */
+  bool isKeyswitchPressed(KeyAddr key_addr) {
+    return false;
+  }
+  /**
+   * Check if a key is pressed at a given position.
+   *
    * @param row is the row the key is located at in the matrix.
    * @param col is the column the key is located at in the matrix.
    *
    * @returns true if the key is pressed, false otherwise.
    */
-  bool isKeyswitchPressed(byte row, byte col) {
+  KS_ROW_COL_FUNC bool isKeyswitchPressed(byte row, byte col) {
     return false;
   }
   /**

--- a/src/kaleidoscope/Kaleidoscope.cpp
+++ b/src/kaleidoscope/Kaleidoscope.cpp
@@ -51,11 +51,9 @@ Kaleidoscope_::setup(void) {
 
   // Update the keymap cache, so we start with a non-empty state.
   Layer.updateActiveLayers();
-  for (byte row = 0; row < ROWS; row++) {
-    for (byte col = 0; col < COLS; col++) {
-      Layer.updateLiveCompositeKeymap(KeyAddr(row, col));
+  for(auto key_addr: KeyAddr{}) {
+      Layer.updateLiveCompositeKeymap(key_addr);
     }
-  }
 }
 
 void

--- a/src/kaleidoscope/Kaleidoscope.cpp
+++ b/src/kaleidoscope/Kaleidoscope.cpp
@@ -47,13 +47,13 @@ Kaleidoscope_::setup(void) {
   // A workaround, so that the compiler does not optimize handleKeyswitchEvent out...
   // This is a no-op, but tricks the compiler into not being too helpful
   // TODO(anyone): figure out how to hint the compiler in a more reasonable way
-  handleKeyswitchEvent(Key_NoKey, 255, 255, 0);
+  handleKeyswitchEvent(Key_NoKey, KeyAddr(), 0);
 
   // Update the keymap cache, so we start with a non-empty state.
   Layer.updateActiveLayers();
   for (byte row = 0; row < ROWS; row++) {
     for (byte col = 0; col < COLS; col++) {
-      Layer.updateLiveCompositeKeymap(row, col);
+      Layer.updateLiveCompositeKeymap(KeyAddr(row, col));
     }
   }
 }

--- a/src/kaleidoscope/Kaleidoscope.cpp
+++ b/src/kaleidoscope/Kaleidoscope.cpp
@@ -51,9 +51,9 @@ Kaleidoscope_::setup(void) {
 
   // Update the keymap cache, so we start with a non-empty state.
   Layer.updateActiveLayers();
-  for(auto key_addr: KeyAddr{}) {
-      Layer.updateLiveCompositeKeymap(key_addr);
-    }
+  for (auto key_addr : KeyAddr{}) {
+    Layer.updateLiveCompositeKeymap(key_addr);
+  }
 }
 
 void

--- a/src/kaleidoscope/Kaleidoscope.h
+++ b/src/kaleidoscope/Kaleidoscope.h
@@ -93,6 +93,9 @@ static_assert(KALEIDOSCOPE_REQUIRED_API_VERSION == KALEIDOSCOPE_API_VERSION,
 
 namespace kaleidoscope {
 
+static constexpr uint8_t num_keys =  KeyboardHardware.matrix_rows
+                                     * KeyboardHardware.matrix_columns;
+
 class Kaleidoscope_ {
  public:
   Kaleidoscope_(void);

--- a/src/kaleidoscope/Kaleidoscope.h
+++ b/src/kaleidoscope/Kaleidoscope.h
@@ -40,6 +40,9 @@ void setup();
 
 extern HARDWARE_IMPLEMENTATION KeyboardHardware;
 
+typedef HARDWARE_IMPLEMENTATION::KeyAddr KeyAddr;
+typedef HARDWARE_IMPLEMENTATION::LEDAddr LEDAddr;
+
 #define ROWS (KeyboardHardware.matrix_rows)
 #define COLS (KeyboardHardware.matrix_columns)
 #define LED_COUNT (KeyboardHardware.led_count)

--- a/src/kaleidoscope/Kaleidoscope.h
+++ b/src/kaleidoscope/Kaleidoscope.h
@@ -41,7 +41,7 @@ void setup();
 extern HARDWARE_IMPLEMENTATION KeyboardHardware;
 
 typedef HARDWARE_IMPLEMENTATION::KeyAddr KeyAddr;
-typedef HARDWARE_IMPLEMENTATION::LEDAddr LEDAddr;
+typedef HARDWARE_IMPLEMENTATION::KeyLEDAddr KeyLEDAddr;
 
 #define ROWS (KeyboardHardware.matrix_rows)
 #define COLS (KeyboardHardware.matrix_columns)

--- a/src/kaleidoscope/MatrixAddr.h
+++ b/src/kaleidoscope/MatrixAddr.h
@@ -1,0 +1,385 @@
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// This header contains two classes that aid
+// indexed access to key and LED matrix entries.
+// There are two different implementations that feature the same
+// interface and are therefore interchangeable and also cooperate, one is
+// more memory efficient, the other prefers speed when it comes to extracting
+// row and column indices.
+//
+// You should always compare the performance of both on your hardware
+// and then select the one that is better suited for your needs.
+//
+// As both implementations are compatible, it is possible to use one type of
+// matrix address class for key addressing and another for LED addressing.
+//
+// To define the types of matrix address storage class that is used
+// throughout the firmware for key and LED accessing, provide the following
+// two typedefs in your keyboard hardware class.
+//
+// typedef MatrixAddr<4, 16> KeyAddr;
+// typedef MatrixAddrCompressed<4, 16> LEDAddr;
+//
+// Those two types are then automatically used throughout the whole
+// firmware for any type of addressing.
+
+#pragma once
+
+#include <limits.h>
+#include <stdint.h>
+
+namespace kaleidoscope {
+namespace internal {
+namespace matrix_addr {
+
+constexpr unsigned log2(unsigned n, unsigned p = 0) {
+  return (n <= 1) ? p : log2(n / 2, p + 1);
+}
+
+template<typename Int1__, typename Int2___>
+constexpr Int1__ shiftNOr(Int1__ v, Int2___ s) {
+  return v | (v >> s);
+}
+
+// The following functions are used to determine the optimal
+// storage row size for compressed storage. They compute the next greater
+// power of two for an unsigned integer value of a given size.
+
+constexpr
+uint32_t upperPowerOfTwo(uint32_t v) {
+  // From https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+
+  // The following is not possible in a c++11 constexpr function
+//     v--;
+//     v |= v >> 1;
+//     v |= v >> 2;
+//     v |= v >> 4;
+//     v |= v >> 8;
+//     v |= v >> 16;
+//     v++;
+//     return v;
+
+  // Thus, we have to reformulate it a little...
+  return shiftNOr(shiftNOr(shiftNOr(shiftNOr(shiftNOr(v - 1, 1), 2), 4), 8), 16) + 1;
+}
+
+constexpr
+uint16_t upperPowerOfTwo(uint16_t v) {
+  // From https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+
+  // The following is not possible in a c++11 constexpr function
+//     v--;
+//     v |= v >> 1;
+//     v |= v >> 2;
+//     v |= v >> 4;
+//     v |= v >> 8;
+//     v++;
+//     return v;
+
+  // Thus, we have to reformulate it a little...
+  return shiftNOr(shiftNOr(shiftNOr(shiftNOr(v - 1, 1), 2), 4), 8) + 1;
+}
+
+constexpr
+uint8_t upperPowerOfTwo(uint8_t v) {
+  // From https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+
+  // The following is not possible in a c++11 constexpr function
+//     v--;
+//     v |= v >> 1;
+//     v |= v >> 2;
+//     v |= v >> 4;
+//     v++;
+//     return v;
+
+  // Thus, we have to reformulate it a little...
+  return shiftNOr(shiftNOr(shiftNOr(v - 1, 1), 2), 4) + 1;
+}
+
+template<typename Int__> struct IntLimitsTrait {};
+template<> struct IntLimitsTrait<uint8_t> {
+  static constexpr uint8_t max = 0xFF;
+};
+template<> struct IntLimitsTrait<uint16_t> {
+  static constexpr uint16_t max = 0xFFFF;
+};
+template<> struct IntLimitsTrait<uint32_t> {
+  static constexpr uint32_t max = 0xFFFFFFFF;
+};
+
+} // end namespace internal
+} // end namespace matrix_addr
+
+// The MatrixAddr template class is meant to be used when speed is
+// more important than saving memory. It uses two bytes to store row and column
+// indices. For most keyboardsw that feature less than 256 indices keys/LEDs/...
+// the row/col information can be stored in a more memory efficient fashion.
+// In that case if saving memory is paramount, use
+// prefer template class MatrixAddrCompressed that is defined later on
+// in this file.
+//
+template<uint8_t rows__, uint8_t cols__>
+class MatrixAddr {
+ private:
+  uint8_t row_;
+  uint8_t col_;
+
+ public:
+
+  static constexpr uint8_t rows = rows__;
+  static constexpr uint8_t cols = cols__;
+
+  static constexpr uint8_t row_size = cols__;
+
+  static constexpr uint8_t matrix_size = rows__ * cols__;
+
+  static constexpr uint8_t invalid_index = 255;
+
+  constexpr MatrixAddr() : row_(invalid_index), col_(invalid_index) {}
+
+  explicit constexpr MatrixAddr(uint8_t row, uint8_t col) : row_(row), col_(col) {}
+
+  explicit constexpr MatrixAddr(uint8_t offset)
+    : MatrixAddr(offset / cols, offset % cols) {}
+
+  template<typename MatrixAddr__>
+  constexpr MatrixAddr(const MatrixAddr__ &other) : MatrixAddr(other.row(), other.col()) {}
+
+  constexpr uint8_t row() const {
+    return row_;
+  }
+  constexpr uint8_t col() const {
+    return col_;
+  }
+
+  void setRow(uint8_t r) {
+    row_ = r;
+  }
+  void setCol(uint8_t c) {
+    col_ = c;
+  }
+
+  constexpr uint8_t offset() {
+    return row_ * cols + col_;
+  }
+
+  constexpr bool isValid() const {
+    return (row_ < rows__) && (col_ < cols__);
+  }
+
+  template<typename MatrixAddr__>
+  MatrixAddr& operator=(const MatrixAddr__ &other) {
+    this->row_ = other.row();
+    this->col_ = other.col();
+    return *this;
+  }
+
+  template<typename MatrixAddr__>
+  MatrixAddr &operator+(const MatrixAddr__ &other) {
+    this->row_ += other.row();
+    this->col_ += other.col();
+    return *this;
+  }
+
+  template<typename MatrixAddr__>
+  MatrixAddr &operator-(const MatrixAddr__ &other) {
+    this->row_ -= other.row();
+    this->col_ -= other.col();
+    return *this;
+  }
+
+  template<typename MatrixAddr__>
+  MatrixAddr &operator+=(const MatrixAddr__ &other) {
+    *this = *this + other;
+    return *this;
+  }
+
+  template<typename MatrixAddr__>
+  MatrixAddr &operator-=(const MatrixAddr__ &other) {
+    *this = *this - other;
+    return *this;
+  }
+};
+
+// This is a copressed storage version of MatrixAddr.
+// It uses a common integer to store row and column indices.
+// To enable fast row/col access, bitshifts are used instead of
+// integer divisions to compute row indices. This is only possible
+// by padding rows with unused entries to gain a row size that
+// is a power of two.
+//
+template<uint8_t rows__, uint8_t cols__, typename StorageType__ = uint8_t>
+class MatrixAddrCompressed {
+ private:
+
+  StorageType__ raw_;
+
+ public:
+
+  typedef MatrixAddrCompressed<rows__, cols__, StorageType__> ThisType;
+
+  // Row size must be a power of two to enable fast index extraction.
+  static constexpr uint8_t row_size
+    = internal::matrix_addr::upperPowerOfTwo(cols__);
+
+  static constexpr StorageType__ max_raw_value
+    = internal::matrix_addr::IntLimitsTrait<StorageType__>::max;
+  static constexpr StorageType__ invalid_state = max_raw_value;
+  static constexpr uint8_t shift = internal::matrix_addr::log2(row_size);
+
+  static constexpr uint8_t rows = rows__;
+  static constexpr uint8_t cols = cols__;
+
+  static constexpr uint8_t matrix_size = rows__ * cols__;
+
+  static constexpr StorageType__ rowMask = StorageType__(max_raw_value << shift);
+  static constexpr StorageType__ colMask = StorageType__(~rowMask);
+
+  static_assert(rows * row_size < max_raw_value, "Please use a StorageType__ with a higher capacity");
+
+  constexpr MatrixAddrCompressed() : raw_(invalid_state) {}
+
+  explicit constexpr MatrixAddrCompressed(uint8_t row, uint8_t col) : raw_(row * row_size + col) {}
+
+  explicit constexpr MatrixAddrCompressed(uint8_t offset)
+    : MatrixAddrCompressed(offset / cols, offset % cols) {}
+
+  constexpr MatrixAddrCompressed(const ThisType &other) : raw_(other.raw_) {}
+
+  template<typename MatrixAddr__>
+  constexpr MatrixAddrCompressed(const MatrixAddr__ &other)
+    : MatrixAddrCompressed(other.row(), other.col()) {}
+
+  constexpr uint8_t row() const {
+    return raw_ >> shift;
+  }
+  constexpr uint8_t col() const {
+    return raw_ & colMask;
+  }
+
+  void setRow(uint8_t r) {
+    raw_ = (r << shift) | (raw_ & colMask);
+  }
+  void setCol(uint8_t c) {
+    raw_ = (raw_ & rowMask) | c;
+  }
+
+  constexpr uint8_t offset() {
+    return row() * cols + col();
+  }
+
+  constexpr bool isValid() const {
+    return (row() < rows__) && (col() < cols__);
+  }
+
+  ThisType &operator=(const ThisType &other) {
+    raw_ = other.raw_;
+    return *this;
+  }
+
+  template<typename MatrixAddr__>
+  ThisType& operator=(const MatrixAddr__ &other) {
+    raw_ = other.row() * row_size + other.col();
+    return *this;
+  }
+
+  template<typename MatrixAddr__>
+  ThisType &operator+(const MatrixAddr__ &other) {
+    *this = ThisType(this->row_ + other.row(),
+                     this->col_ + other.col());
+    return *this;
+  }
+
+  template<typename MatrixAddr__>
+  ThisType &operator-(const MatrixAddr__ &other) {
+    *this = ThisType(this->row_ - other.row(),
+                     this->col_ - other.col());
+    return *this;
+  }
+
+  template<typename MatrixAddr__>
+  ThisType &operator+=(const MatrixAddr__ &other) {
+    *this = *this + other;
+    return *this;
+  }
+
+  template<typename MatrixAddr__>
+  ThisType &operator-=(const MatrixAddr__ &other) {
+    *this = *this - other;
+    return *this;
+  }
+};
+
+// Comparison operators only used for module testing. This is because they
+// cause ambiguous symbol lookup when used in the regular firmware.
+//
+// To use them also for the regular firmware they would need to be
+// disambiguated by moving them to the Kaleidoscope.h header and replacing
+// them with non-template versions that operate on the actual typedefed
+// KeyAddr and LEDAddr.
+
+#ifdef MATRIX_ADDR_TESTING
+
+template<typename MatrixAddr1__, typename MatrixAddr2__>
+bool operator==(const MatrixAddr1__&a1, const MatrixAddr2__ &a2) {
+  return (a1.row() == a2.row()) && (a1.col() == a2.col());
+}
+template<typename MatrixAddr1__, typename MatrixAddr2__>
+bool operator!=(const MatrixAddr1__&a1, const MatrixAddr2__ &a2) {
+  return !operator==(a1, a2);
+}
+
+template<typename MatrixAddr1__, typename MatrixAddr2__>
+bool operator>(const MatrixAddr1__&a1, const MatrixAddr2__ &a2) {
+  return (a1.row() > a2.row())
+         || ((a1.row() == a2.row()) && (a1.col() > a2.col()));
+}
+
+template<typename MatrixAddr1__, typename MatrixAddr2__>
+bool operator<(const MatrixAddr1__&a1, const MatrixAddr2__ &a2) {
+  // This could be optimized if necessary
+  return !operator>(a1, a2) && !operator==(a1, a2);
+}
+
+template<typename MatrixAddr1__, typename MatrixAddr2__>
+bool operator>=(const MatrixAddr1__&a1, const MatrixAddr2__ &a2) {
+  // This could be optimized if necessary
+  return operator>(a1, a2) || operator==(a1, a2);
+}
+
+template<typename MatrixAddr1__, typename MatrixAddr2__>
+bool operator<=(const MatrixAddr1__&a1, const MatrixAddr2__ &a2) {
+  return !operator>(a1, a2);
+}
+
+#endif
+
+} // end namespace kaleidoscope
+
+// Row/col based access functions have been superseded by matrix address
+// base access. To deprecate any row/col based access functions, toggle
+// the definitions of macro KS_ROW_COL_FUNC below
+// and uncomment _DEPRECATED_MESSAGE_ROW_COL_FUNC.
+//
+#define KS_ROW_COL_FUNC
+
+#if 0
+#define _DEPRECATED_MESSAGE_ROW_COL_FUNC \
+   "Row/col based access functions have been deprecated. Please use " \
+   "the KeyAddr/LEDAddr based versions instead."
+#define KS_ROW_COL_FUNC DEPRECATED(ROW_COL_FUNC)
+#endif

--- a/src/kaleidoscope/MatrixAddr.h
+++ b/src/kaleidoscope/MatrixAddr.h
@@ -280,7 +280,7 @@ class MatrixAddr {
 // To use them also for the regular firmware they would need to be
 // disambiguated by moving them to the Kaleidoscope.h header and replacing
 // them with non-template versions that operate on the actual typedefed
-// KeyAddr and LEDAddr.
+// KeyAddr and KeyLEDAddr.
 
 #ifdef MATRIX_ADDR_TESTING
 
@@ -330,6 +330,6 @@ bool operator<=(const MatrixAddr1__ & a1, const MatrixAddr2__ & a2) {
 #if 0
 #define _DEPRECATED_MESSAGE_ROW_COL_FUNC \
    "Row/col based access functions have been deprecated. Please use " \
-   "the KeyAddr/LEDAddr based versions instead."
+   "the KeyAddr/KeyLEDAddr based versions instead."
 #define KS_ROW_COL_FUNC DEPRECATED(ROW_COL_FUNC)
 #endif

--- a/src/kaleidoscope/MatrixAddr.h
+++ b/src/kaleidoscope/MatrixAddr.h
@@ -14,272 +14,69 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-// This header contains two classes that aid
-// indexed access to key and LED matrix entries.
-// There are two different implementations that feature the same
-// interface and are therefore interchangeable and also cooperate, one is
-// more memory efficient, the other prefers speed when it comes to extracting
-// row and column indices.
-//
-// You should always compare the performance of both on your hardware
-// and then select the one that is better suited for your needs.
-//
-// As both implementations are compatible, it is possible to use one type of
-// matrix address class for key addressing and another for LED addressing.
-//
-// To define the types of matrix address storage class that is used
-// throughout the firmware for key and LED accessing, provide the following
-// two typedefs in your keyboard hardware class.
-//
-// typedef MatrixAddr<4, 16> KeyAddr;
-// typedef MatrixAddrCompressed<4, 16> LEDAddr;
-//
-// Those two types are then automatically used throughout the whole
-// firmware for any type of addressing.
-
 #pragma once
 
 #include <limits.h>
 #include <stdint.h>
 
 namespace kaleidoscope {
-namespace internal {
-namespace matrix_addr {
 
-constexpr unsigned log2(unsigned n, unsigned p = 0) {
-  return (n <= 1) ? p : log2(n / 2, p + 1);
-}
-
-template<typename Int1__, typename Int2___>
-constexpr Int1__ shiftNOr(Int1__ v, Int2___ s) {
-  return v | (v >> s);
-}
-
-// The following functions are used to determine the optimal
-// storage row size for compressed storage. They compute the next greater
-// power of two for an unsigned integer value of a given size.
-
-constexpr
-uint32_t upperPowerOfTwo(uint32_t v) {
-  // From https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
-
-  // The following is not possible in a c++11 constexpr function
-//     v--;
-//     v |= v >> 1;
-//     v |= v >> 2;
-//     v |= v >> 4;
-//     v |= v >> 8;
-//     v |= v >> 16;
-//     v++;
-//     return v;
-
-  // Thus, we have to reformulate it a little...
-  return shiftNOr(shiftNOr(shiftNOr(shiftNOr(shiftNOr(v - 1, 1), 2), 4), 8), 16) + 1;
-}
-
-constexpr
-uint16_t upperPowerOfTwo(uint16_t v) {
-  // From https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
-
-  // The following is not possible in a c++11 constexpr function
-//     v--;
-//     v |= v >> 1;
-//     v |= v >> 2;
-//     v |= v >> 4;
-//     v |= v >> 8;
-//     v++;
-//     return v;
-
-  // Thus, we have to reformulate it a little...
-  return shiftNOr(shiftNOr(shiftNOr(shiftNOr(v - 1, 1), 2), 4), 8) + 1;
-}
-
-constexpr
-uint8_t upperPowerOfTwo(uint8_t v) {
-  // From https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
-
-  // The following is not possible in a c++11 constexpr function
-//     v--;
-//     v |= v >> 1;
-//     v |= v >> 2;
-//     v |= v >> 4;
-//     v++;
-//     return v;
-
-  // Thus, we have to reformulate it a little...
-  return shiftNOr(shiftNOr(shiftNOr(v - 1, 1), 2), 4) + 1;
-}
-
-template<typename Int__> struct IntLimitsTrait {};
-template<> struct IntLimitsTrait<uint8_t> {
-  static constexpr uint8_t max = 0xFF;
-};
-template<> struct IntLimitsTrait<uint16_t> {
-  static constexpr uint16_t max = 0xFFFF;
-};
-template<> struct IntLimitsTrait<uint32_t> {
-  static constexpr uint32_t max = 0xFFFFFFFF;
-};
-
-} // end namespace internal
-} // end namespace matrix_addr
-
-// The MatrixAddr template class is meant to be used when speed is
-// more important than saving memory. It uses two bytes to store row and column
-// indices. For most keyboardsw that feature less than 256 indices keys/LEDs/...
-// the row/col information can be stored in a more memory efficient fashion.
-// In that case if saving memory is paramount, use
-// prefer template class MatrixAddrCompressed that is defined later on
-// in this file.
-//
 template<uint8_t rows__, uint8_t cols__>
 class MatrixAddr {
  private:
-  uint8_t row_;
-  uint8_t col_;
+
+  uint8_t offset_;
 
  public:
 
+  typedef MatrixAddr<rows__, cols__> ThisType;
+
   static constexpr uint8_t rows = rows__;
   static constexpr uint8_t cols = cols__;
-
-  static constexpr uint8_t row_size = cols__;
-
   static constexpr uint8_t matrix_size = rows__ * cols__;
 
-  static constexpr uint8_t invalid_index = 255;
+  static constexpr uint8_t invalid_state = 255;
 
-  constexpr MatrixAddr() : row_(invalid_index), col_(invalid_index) {}
+  static_assert(rows * cols < 255,
+                "The number of rows and columns provided to instanciate \n"
+                "MatrixAddr<rows, cols> exceeds the supported total number of 255 keys");
 
-  explicit constexpr MatrixAddr(uint8_t row, uint8_t col) : row_(row), col_(col) {}
+  constexpr MatrixAddr() : offset_(invalid_state) {}
+
+  explicit constexpr MatrixAddr(uint8_t row, uint8_t col)
+    : offset_(row * cols + col) {}
 
   explicit constexpr MatrixAddr(uint8_t offset)
-    : MatrixAddr(offset / cols, offset % cols) {}
+    : offset_(offset) {}
+
+  constexpr MatrixAddr(const ThisType &other) : offset_(other.offset_) {}
 
   template<typename MatrixAddr__>
-  constexpr MatrixAddr(const MatrixAddr__ &other) : MatrixAddr(other.row(), other.col()) {}
+  constexpr MatrixAddr(const MatrixAddr__ &other)
+    : MatrixAddr(other.row(), other.col()) {}
 
   constexpr uint8_t row() const {
-    return row_;
+    return offset_ / cols;
   }
   constexpr uint8_t col() const {
-    return col_;
+    return offset_ % cols;
   }
 
   void setRow(uint8_t r) {
-    row_ = r;
+    //assert(r < rows);
+    offset_ = this->col() + r * cols;
   }
   void setCol(uint8_t c) {
-    col_ = c;
+    //assert(c < cols);
+    offset_ = this->row() * cols + c;
   }
 
   constexpr uint8_t offset() {
-    return row_ * cols + col_;
+    return offset_;
   }
 
-  constexpr bool isValid() const {
-    return (row_ < rows__) && (col_ < cols__);
-  }
-
-  template<typename MatrixAddr__>
-  MatrixAddr& operator=(const MatrixAddr__ &other) {
-    this->row_ = other.row();
-    this->col_ = other.col();
-    return *this;
-  }
-
-  template<typename MatrixAddr__>
-  MatrixAddr &operator+(const MatrixAddr__ &other) {
-    this->row_ += other.row();
-    this->col_ += other.col();
-    return *this;
-  }
-
-  template<typename MatrixAddr__>
-  MatrixAddr &operator-(const MatrixAddr__ &other) {
-    this->row_ -= other.row();
-    this->col_ -= other.col();
-    return *this;
-  }
-
-  template<typename MatrixAddr__>
-  MatrixAddr &operator+=(const MatrixAddr__ &other) {
-    *this = *this + other;
-    return *this;
-  }
-
-  template<typename MatrixAddr__>
-  MatrixAddr &operator-=(const MatrixAddr__ &other) {
-    *this = *this - other;
-    return *this;
-  }
-};
-
-// This is a copressed storage version of MatrixAddr.
-// It uses a common integer to store row and column indices.
-// To enable fast row/col access, bitshifts are used instead of
-// integer divisions to compute row indices. This is only possible
-// by padding rows with unused entries to gain a row size that
-// is a power of two.
-//
-template<uint8_t rows__, uint8_t cols__, typename StorageType__ = uint8_t>
-class MatrixAddrCompressed {
- private:
-
-  StorageType__ raw_;
-
- public:
-
-  typedef MatrixAddrCompressed<rows__, cols__, StorageType__> ThisType;
-
-  // Row size must be a power of two to enable fast index extraction.
-  static constexpr uint8_t row_size
-    = internal::matrix_addr::upperPowerOfTwo(cols__);
-
-  static constexpr StorageType__ max_raw_value
-    = internal::matrix_addr::IntLimitsTrait<StorageType__>::max;
-  static constexpr StorageType__ invalid_state = max_raw_value;
-  static constexpr uint8_t shift = internal::matrix_addr::log2(row_size);
-
-  static constexpr uint8_t rows = rows__;
-  static constexpr uint8_t cols = cols__;
-
-  static constexpr uint8_t matrix_size = rows__ * cols__;
-
-  static constexpr StorageType__ rowMask = StorageType__(max_raw_value << shift);
-  static constexpr StorageType__ colMask = StorageType__(~rowMask);
-
-  static_assert(rows * row_size < max_raw_value, "Please use a StorageType__ with a higher capacity");
-
-  constexpr MatrixAddrCompressed() : raw_(invalid_state) {}
-
-  explicit constexpr MatrixAddrCompressed(uint8_t row, uint8_t col) : raw_(row * row_size + col) {}
-
-  explicit constexpr MatrixAddrCompressed(uint8_t offset)
-    : MatrixAddrCompressed(offset / cols, offset % cols) {}
-
-  constexpr MatrixAddrCompressed(const ThisType &other) : raw_(other.raw_) {}
-
-  template<typename MatrixAddr__>
-  constexpr MatrixAddrCompressed(const MatrixAddr__ &other)
-    : MatrixAddrCompressed(other.row(), other.col()) {}
-
-  constexpr uint8_t row() const {
-    return raw_ >> shift;
-  }
-  constexpr uint8_t col() const {
-    return raw_ & colMask;
-  }
-
-  void setRow(uint8_t r) {
-    raw_ = (r << shift) | (raw_ & colMask);
-  }
-  void setCol(uint8_t c) {
-    raw_ = (raw_ & rowMask) | c;
-  }
-
-  constexpr uint8_t offset() {
-    return row() * cols + col();
+  constexpr operator uint8_t() {
+    return offset_;
   }
 
   constexpr bool isValid() const {
@@ -287,27 +84,27 @@ class MatrixAddrCompressed {
   }
 
   ThisType &operator=(const ThisType &other) {
-    raw_ = other.raw_;
+    offset_ = other.offset_;
     return *this;
   }
 
   template<typename MatrixAddr__>
   ThisType& operator=(const MatrixAddr__ &other) {
-    raw_ = other.row() * row_size + other.col();
+    offset_ = other.row() * cols + other.col();
     return *this;
   }
 
   template<typename MatrixAddr__>
   ThisType &operator+(const MatrixAddr__ &other) {
-    *this = ThisType(this->row_ + other.row(),
-                     this->col_ + other.col());
+    *this = ThisType(this->row() + other.row(),
+                     this->col() + other.col());
     return *this;
   }
 
   template<typename MatrixAddr__>
   ThisType &operator-(const MatrixAddr__ &other) {
-    *this = ThisType(this->row_ - other.row(),
-                     this->col_ - other.col());
+    *this = ThisType(this->row() - other.row(),
+                     this->col() - other.col());
     return *this;
   }
 

--- a/src/kaleidoscope/addr.h
+++ b/src/kaleidoscope/addr.h
@@ -25,19 +25,19 @@
 // as the keyboard has fewer than 256 keys.
 namespace kaleidoscope {
 namespace addr {
-inline uint8_t row(uint8_t key_addr) {
+KS_ROW_COL_FUNC inline uint8_t row(uint8_t key_addr) {
   return (key_addr / COLS);
 }
-inline uint8_t col(uint8_t key_addr) {
+KS_ROW_COL_FUNC inline uint8_t col(uint8_t key_addr) {
   return (key_addr % COLS);
 }
-inline uint8_t addr(uint8_t row, uint8_t col) {
+KS_ROW_COL_FUNC inline uint8_t addr(uint8_t row, uint8_t col) {
   return ((row * COLS) + col);
 }
-inline void mask(uint8_t key_addr) {
+KS_ROW_COL_FUNC inline void mask(uint8_t key_addr) {
   KeyboardHardware.maskKey(row(key_addr), col(key_addr));
 }
-inline void unmask(uint8_t key_addr) {
+KS_ROW_COL_FUNC inline void unmask(uint8_t key_addr) {
   KeyboardHardware.unMaskKey(row(key_addr), col(key_addr));
 }
 } // namespace addr {

--- a/src/kaleidoscope/event_handlers.h
+++ b/src/kaleidoscope/event_handlers.h
@@ -47,6 +47,7 @@
                _NOT_ABORTABLE,                                            __NL__ \
                (), (), ##__VA_ARGS__)                                     __NL__ \
                                                                           __NL__ \
+   /* DEPRECATED                                                       */ __NL__ \
    /* Function called for every non-idle key, every cycle, so it       */ __NL__ \
    /* can decide what to do with it. It can modify the key (which is   */ __NL__ \
    /* passed by reference for this reason), and decide whether         */ __NL__ \
@@ -54,10 +55,22 @@
    /* EventHandlerResult::OK, other handlers will also get a chance    */ __NL__ \
    /* to react to the event. If it returns anything else, Kaleidoscope */ __NL__ \
    /* will stop processing there.                                      */ __NL__ \
-  OPERATION(onKeyswitchEvent,                                             __NL__ \
+   OPERATION(onKeyswitchEvent,                                            __NL__ \
                _ABORTABLE,                                                __NL__ \
                (Key &mappedKey, byte row, byte col, uint8_t keyState),    __NL__ \
                (mappedKey, row, col, keyState), ##__VA_ARGS__)            __NL__ \
+                                                                          __NL__ \
+   /* Function called for every non-idle key, every cycle, so it       */ __NL__ \
+   /* can decide what to do with it. It can modify the key (which is   */ __NL__ \
+   /* passed by reference for this reason), and decide whether         */ __NL__ \
+   /* further handles should be tried. If it returns                   */ __NL__ \
+   /* EventHandlerResult::OK, other handlers will also get a chance    */ __NL__ \
+   /* to react to the event. If it returns anything else, Kaleidoscope */ __NL__ \
+   /* will stop processing there.                                      */ __NL__ \
+   OPERATION(onKeyswitchEvent2,                                           __NL__ \
+               _ABORTABLE,                                                __NL__ \
+               (Key &mappedKey, KeyAddr key_addr, uint8_t keyState),       __NL__ \
+               (mappedKey, key_addr, keyState), ##__VA_ARGS__)             __NL__ \
                                                                           __NL__ \
    /* Called by an external plugin (such as Kaleidoscope-FocusSerial)  */ __NL__ \
    /* via Kaleidoscope::onFocusEvent. This is where Focus events can   */ __NL__ \

--- a/src/kaleidoscope/hardware/ATMegaKeyboard.cpp
+++ b/src/kaleidoscope/hardware/ATMegaKeyboard.cpp
@@ -74,9 +74,8 @@ uint8_t ATMegaKeyboard::pressedKeyswitchCount() {
   return count;
 }
 
-bool ATMegaKeyboard::isKeyswitchPressed(uint8_t row, byte col) {
-  return (bitRead(KeyboardHardware.keyState_[row], col) != 0);
-
+bool ATMegaKeyboard::isKeyswitchPressed(KeyAddr key_addr) {
+  return (bitRead(KeyboardHardware.keyState_[key_addr.row()], key_addr.col()) != 0);
 }
 
 bool ATMegaKeyboard::isKeyswitchPressed(uint8_t keyIndex) {
@@ -95,8 +94,8 @@ uint8_t ATMegaKeyboard::previousPressedKeyswitchCount() {
   return count;
 }
 
-bool ATMegaKeyboard::wasKeyswitchPressed(uint8_t row, byte col) {
-  return (bitRead(KeyboardHardware.previousKeyState_[row], col) != 0);
+bool ATMegaKeyboard::wasKeyswitchPressed(KeyAddr keyAddr) {
+  return (bitRead(KeyboardHardware.previousKeyState_[keyAddr.row()], keyAddr.col()) != 0);
 
 }
 
@@ -113,7 +112,7 @@ void __attribute__((optimize(3))) ATMegaKeyboard::actOnMatrixScan() {
       uint8_t keyState = (bitRead(KeyboardHardware.previousKeyState_[row], col) << 0) |
                          (bitRead(KeyboardHardware.keyState_[row], col) << 1);
       if (keyState) {
-        handleKeyswitchEvent(Key_NoKey, row, col, keyState);
+        handleKeyswitchEvent(Key_NoKey, KeyAddr(row, col), keyState);
       }
     }
     KeyboardHardware.previousKeyState_[row] = KeyboardHardware.keyState_[row];
@@ -130,25 +129,25 @@ void ATMegaKeyboard::scanMatrix() {
   KeyboardHardware.actOnMatrixScan();
 }
 
-void ATMegaKeyboard::maskKey(byte row, byte col) {
-  if (row >= KeyboardHardware.matrix_rows || col >= KeyboardHardware.matrix_columns)
+void ATMegaKeyboard::maskKey(KeyAddr key_addr) {
+  if (!key_addr.isValid())
     return;
 
-  bitWrite(KeyboardHardware.masks_[row], col, 1);
+  bitWrite(KeyboardHardware.masks_[key_addr.row()], key_addr.col(), 1);
 }
 
-void ATMegaKeyboard::unMaskKey(byte row, byte col) {
-  if (row >= KeyboardHardware.matrix_rows || col >= KeyboardHardware.matrix_columns)
+void ATMegaKeyboard::unMaskKey(KeyAddr key_addr) {
+  if (!key_addr.isValid())
     return;
 
-  bitWrite(KeyboardHardware.masks_[row], col, 0);
+  bitWrite(KeyboardHardware.masks_[key_addr.row()], key_addr.col(), 0);
 }
 
-bool ATMegaKeyboard::isKeyMasked(byte row, byte col) {
-  if (row >= KeyboardHardware.matrix_rows || col >= KeyboardHardware.matrix_columns)
+bool ATMegaKeyboard::isKeyMasked(KeyAddr key_addr) {
+  if (!key_addr.isValid())
     return false;
 
-  return bitRead(KeyboardHardware.masks_[row], col);
+  return bitRead(KeyboardHardware.masks_[key_addr.row()], key_addr.col());
 }
 
 /*

--- a/src/kaleidoscope/hardware/ATMegaKeyboard.h
+++ b/src/kaleidoscope/hardware/ATMegaKeyboard.h
@@ -22,9 +22,10 @@
 #include <Arduino.h>
 #include <KeyboardioHID.h>
 #include "Kaleidoscope-HIDAdaptor-KeyboardioHID.h"
+#include "kaleidoscope/MatrixAddr.h"
 
 #include "kaleidoscope/macro_helpers.h"
-#include "kaleidoscope/key_events.h"
+// #include "kaleidoscope/key_events.h"
 #include "kaleidoscope/hardware/avr/pins_and_ports.h"
 
 #include <avr/wdt.h>
@@ -84,16 +85,31 @@ class ATMegaKeyboard : public kaleidoscope::Hardware {
   void scanMatrix();
 
   uint8_t pressedKeyswitchCount();
-  bool isKeyswitchPressed(uint8_t row, byte col);
+  bool isKeyswitchPressed(KeyAddr key_addr);
+  KS_ROW_COL_FUNC bool isKeyswitchPressed(uint8_t row, byte col) {
+    return isKeyswitchPressed(KeyAddr(row, col));
+  }
   bool isKeyswitchPressed(uint8_t keyIndex);
 
   uint8_t previousPressedKeyswitchCount();
-  bool wasKeyswitchPressed(uint8_t row, byte col);
+  bool wasKeyswitchPressed(KeyAddr keyAddr);
+  KS_ROW_COL_FUNC bool wasKeyswitchPressed(uint8_t row, byte col) {
+    return wasKeyswitchPressed(KeyAddr(row, col));
+  }
   bool wasKeyswitchPressed(uint8_t keyIndex);
 
-  void maskKey(byte row, byte col);
-  void unMaskKey(byte row, byte col);
-  bool isKeyMasked(byte row, byte col);
+  void maskKey(KeyAddr keyAddr);
+  KS_ROW_COL_FUNC void maskKey(byte row, byte col) {
+    maskKey(KeyAddr(row, col));
+  }
+  void unMaskKey(KeyAddr key_addr);
+  KS_ROW_COL_FUNC void unMaskKey(byte row, byte col) {
+    unMaskKey(KeyAddr(row, col));
+  }
+  bool isKeyMasked(KeyAddr key_addr);
+  KS_ROW_COL_FUNC bool isKeyMasked(byte row, byte col) {
+    return isKeyMasked(KeyAddr(row, col));
+  }
 
   static bool do_scan_;
 

--- a/src/kaleidoscope/hardware/ez/ErgoDox.cpp
+++ b/src/kaleidoscope/hardware/ez/ErgoDox.cpp
@@ -113,7 +113,7 @@ void __attribute__((optimize(3))) ErgoDox::actOnMatrixScan() {
       uint8_t keyState = (bitRead(previousKeyState_[row], col) << 0) |
                          (bitRead(keyState_[row], col) << 1);
       if (keyState)
-        handleKeyswitchEvent(Key_NoKey, row, col, keyState);
+        handleKeyswitchEvent(Key_NoKey, KeyAddr(row, col), keyState);
     }
     previousKeyState_[row] = keyState_[row];
   }
@@ -130,25 +130,25 @@ void ErgoDox::scanMatrix() {
   actOnMatrixScan();
 }
 
-void ErgoDox::maskKey(byte row, byte col) {
-  if (row >= ROWS || col >= COLS)
+void ErgoDox::maskKey(KeyAddr key_addr) {
+  if (!key_addr.isValid())
     return;
 
-  bitWrite(masks_[row], col, 1);
+  bitWrite(masks_[key_addr.row()], key_addr.col(), 1);
 }
 
-void ErgoDox::unMaskKey(byte row, byte col) {
-  if (row >= ROWS || col >= COLS)
+void ErgoDox::unMaskKey(KeyAddr key_addr) {
+  if (!key_addr.isValid())
     return;
 
-  bitWrite(masks_[row], col, 0);
+  bitWrite(masks_[key_addr.row()], key_addr.col(), 0);
 }
 
-bool ErgoDox::isKeyMasked(byte row, byte col) {
-  if (row >= ROWS || col >= COLS)
+bool ErgoDox::isKeyMasked(KeyAddr key_addr) {
+  if (!key_addr.isValid())
     return false;
 
-  return bitRead(masks_[row], col);
+  return bitRead(masks_[key_addr.row()], key_addr.col());
 }
 
 // ErgoDox-specific stuff
@@ -223,13 +223,13 @@ void ErgoDox::debounceRow(uint8_t change, uint8_t row) {
   }
 }
 
-bool ErgoDox::isKeyswitchPressed(byte row, byte col) {
-  return (bitRead(keyState_[row], col) != 0);
+bool ErgoDox::isKeyswitchPressed(KeyAddr key_addr) {
+  return (bitRead(keyState_[key_addr.row()], key_addr.col()) != 0);
 }
 
 bool ErgoDox::isKeyswitchPressed(uint8_t keyIndex) {
   keyIndex--;
-  return isKeyswitchPressed(keyIndex / COLS, keyIndex % COLS);
+  return isKeyswitchPressed(KeyAddr(keyIndex));
 }
 
 bool ErgoDox::wasKeyswitchPressed(byte row, byte col) {

--- a/src/kaleidoscope/hardware/ez/ErgoDox.h
+++ b/src/kaleidoscope/hardware/ez/ErgoDox.h
@@ -43,6 +43,7 @@ struct cRGB {
 #define CRGB(r,g,b) (cRGB){b, g, r}
 
 #include "kaleidoscope/Hardware.h"
+#include "kaleidoscope/MatrixAddr.h"
 
 namespace kaleidoscope {
 namespace hardware {
@@ -50,22 +51,38 @@ namespace ez {
 
 class ErgoDox : public kaleidoscope::Hardware {
  public:
-  ErgoDox(void) {}
 
   static constexpr byte matrix_columns = 6;
   static constexpr byte matrix_rows = 14;
   static constexpr int8_t led_count = 0;
+
+  typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
+  typedef MatrixAddr<1, 1> LEDAddr;
+
+  ErgoDox(void) {}
 
   void scanMatrix(void);
   void readMatrix(void);
   void actOnMatrixScan(void);
   void setup();
 
-  void maskKey(byte row, byte col);
-  void unMaskKey(byte row, byte col);
-  bool isKeyMasked(byte row, byte col);
+  void maskKey(KeyAddr key_addr);
+  KS_ROW_COL_FUNC void maskKey(byte row, byte col) {
+    maskKey(KeyAddr(row, col));
+  }
+  void unMaskKey(KeyAddr key_addr);
+  KS_ROW_COL_FUNC void unMaskKey(byte row, byte col) {
+    unMaskKey(KeyAddr(row, col));
+  }
+  bool isKeyMasked(KeyAddr key_addr);
+  KS_ROW_COL_FUNC bool isKeyMasked(byte row, byte col) {
+    return isKeyMasked(KeyAddr(row, col));
+  }
 
-  bool isKeyswitchPressed(byte row, byte col);
+  bool isKeyswitchPressed(KeyAddr key_addr);
+  KS_ROW_COL_FUNC bool isKeyswitchPressed(byte row, byte col) {
+    return isKeyswitchPressed(KeyAddr(row, col));
+  }
   bool isKeyswitchPressed(uint8_t keyIndex);
   uint8_t pressedKeyswitchCount();
 

--- a/src/kaleidoscope/hardware/ez/ErgoDox.h
+++ b/src/kaleidoscope/hardware/ez/ErgoDox.h
@@ -57,7 +57,7 @@ class ErgoDox : public kaleidoscope::Hardware {
   static constexpr int8_t led_count = 0;
 
   typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
-  typedef MatrixAddr<1, 1> LEDAddr;
+  typedef MatrixAddr<1, 1> KeyLEDAddr;
 
   ErgoDox(void) {}
 

--- a/src/kaleidoscope/hardware/kbdfans/KBD4x.h
+++ b/src/kaleidoscope/hardware/kbdfans/KBD4x.h
@@ -46,7 +46,7 @@ class KBD4x: public kaleidoscope::hardware::ATMegaKeyboard {
   static constexpr int8_t led_count = 0;
 
   typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
-  typedef MatrixAddr<1, 1> LEDAddr;
+  typedef MatrixAddr<1, 1> KeyLEDAddr;
 
   void resetDevice();
 };

--- a/src/kaleidoscope/hardware/kbdfans/KBD4x.h
+++ b/src/kaleidoscope/hardware/kbdfans/KBD4x.h
@@ -45,6 +45,9 @@ class KBD4x: public kaleidoscope::hardware::ATMegaKeyboard {
 
   static constexpr int8_t led_count = 0;
 
+  typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
+  typedef MatrixAddr<1, 1> LEDAddr;
+
   void resetDevice();
 };
 

--- a/src/kaleidoscope/hardware/keyboardio/Model01.cpp
+++ b/src/kaleidoscope/hardware/keyboardio/Model01.cpp
@@ -31,11 +31,11 @@ bool Model01::isLEDChanged = true;
 keydata_t Model01::leftHandMask;
 keydata_t Model01::rightHandMask;
 
-static constexpr int8_t key_led_map[4][16] PROGMEM = {
-  {3, 4, 11, 12, 19, 20, 26, 27,     36, 37, 43, 44, 51, 52, 59, 60},
-  {2, 5, 10, 13, 18, 21, 25, 28,     35, 38, 42, 45, 50, 53, 58, 61},
-  {1, 6, 9, 14, 17, 22, 24, 29,     34, 39, 41, 46, 49, 54, 57, 62},
-  {0, 7, 8, 15, 16, 23, 31, 30,     33, 32, 40, 47, 48, 55, 56, 63},
+static constexpr int8_t key_led_map[Model01::led_count] PROGMEM = {
+  3, 4, 11, 12, 19, 20, 26, 27,     36, 37, 43, 44, 51, 52, 59, 60,
+  2, 5, 10, 13, 18, 21, 25, 28,     35, 38, 42, 45, 50, 53, 58, 61,
+  1, 6, 9, 14, 17, 22, 24, 29,     34, 39, 41, 46, 49, 54, 57, 62,
+  0, 7, 8, 15, 16, 23, 31, 30,     33, 32, 40, 47, 48, 55, 56, 63,
 };
 
 Model01::Model01(void) {
@@ -123,7 +123,7 @@ void Model01::setCrgbAt(LEDAddr led_addr, cRGB color) {
 }
 
 int8_t Model01::getLedIndex(LEDAddr led_addr) {
-  return pgm_read_byte(&(key_led_map[led_addr.row()][led_addr.col()]));
+  return pgm_read_byte(&(key_led_map[led_addr.toInt()]));
 }
 
 cRGB Model01::getCrgbAt(int8_t i) {

--- a/src/kaleidoscope/hardware/keyboardio/Model01.cpp
+++ b/src/kaleidoscope/hardware/keyboardio/Model01.cpp
@@ -118,11 +118,11 @@ void Model01::setCrgbAt(int8_t i, cRGB crgb) {
   }
 }
 
-void Model01::setCrgbAt(LEDAddr led_addr, cRGB color) {
+void Model01::setCrgbAt(KeyLEDAddr led_addr, cRGB color) {
   setCrgbAt(getLedIndex(led_addr), color);
 }
 
-int8_t Model01::getLedIndex(LEDAddr led_addr) {
+int8_t Model01::getLedIndex(KeyLEDAddr led_addr) {
   return pgm_read_byte(&(key_led_map[led_addr.toInt()]));
 }
 

--- a/src/kaleidoscope/hardware/keyboardio/Model01.h
+++ b/src/kaleidoscope/hardware/keyboardio/Model01.h
@@ -30,6 +30,7 @@
 #define CRGB(r,g,b) (cRGB){b, g, r}
 
 #include "kaleidoscope/Hardware.h"
+#include "kaleidoscope/MatrixAddr.h"
 
 namespace kaleidoscope {
 namespace hardware {
@@ -43,11 +44,20 @@ class Model01 : public kaleidoscope::Hardware {
   static constexpr byte matrix_columns = 16;
   static constexpr int8_t led_count = 64;
 
+  typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
+  typedef MatrixAddr<matrix_rows, matrix_columns> LEDAddr;
+
   void syncLeds(void);
-  void setCrgbAt(byte row, byte col, cRGB color);
+  void setCrgbAt(LEDAddr led_addr, cRGB color);
+  KS_ROW_COL_FUNC void setCrgbAt(byte row, byte col, cRGB color) {
+    setCrgbAt(LEDAddr(row, col), color);
+  }
   void setCrgbAt(int8_t i, cRGB crgb);
   cRGB getCrgbAt(int8_t i);
-  int8_t getLedIndex(byte row, byte col);
+  int8_t getLedIndex(LEDAddr led_addr);
+  KS_ROW_COL_FUNC int8_t getLedIndex(byte row, byte col) {
+    return getLedIndex(LEDAddr(row, col));
+  }
 
   void scanMatrix(void);
   void readMatrix(void);
@@ -63,12 +73,24 @@ class Model01 : public kaleidoscope::Hardware {
   void setKeyscanInterval(uint8_t interval);
   boolean ledPowerFault(void);
 
-  void maskKey(byte row, byte col);
-  void unMaskKey(byte row, byte col);
-  bool isKeyMasked(byte row, byte col);
+  void maskKey(KeyAddr key_addr);
+  KS_ROW_COL_FUNC void maskKey(byte row, byte col) {
+    maskKey(KeyAddr(row, col));
+  }
+  void unMaskKey(KeyAddr key_addr);
+  KS_ROW_COL_FUNC void unMaskKey(byte row, byte col) {
+    unMaskKey(KeyAddr(row, col));
+  }
+  bool isKeyMasked(KeyAddr key_addr);
+  KS_ROW_COL_FUNC bool isKeyMasked(byte row, byte col) {
+    return isKeyMasked(KeyAddr(row, col));
+  }
   void maskHeldKeys(void);
 
-  bool isKeyswitchPressed(byte row, byte col);
+  bool isKeyswitchPressed(KeyAddr key_addr);
+  KS_ROW_COL_FUNC bool isKeyswitchPressed(byte row, byte col) {
+    return isKeyswitchPressed(KeyAddr(row, col));
+  }
   bool isKeyswitchPressed(uint8_t keyIndex);
   uint8_t pressedKeyswitchCount();
 

--- a/src/kaleidoscope/hardware/keyboardio/Model01.h
+++ b/src/kaleidoscope/hardware/keyboardio/Model01.h
@@ -45,18 +45,18 @@ class Model01 : public kaleidoscope::Hardware {
   static constexpr int8_t led_count = 64;
 
   typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
-  typedef MatrixAddr<matrix_rows, matrix_columns> LEDAddr;
+  typedef MatrixAddr<matrix_rows, matrix_columns> KeyLEDAddr;
 
   void syncLeds(void);
-  void setCrgbAt(LEDAddr led_addr, cRGB color);
+  void setCrgbAt(KeyLEDAddr led_addr, cRGB color);
   KS_ROW_COL_FUNC void setCrgbAt(byte row, byte col, cRGB color) {
-    setCrgbAt(LEDAddr(row, col), color);
+    setCrgbAt(KeyLEDAddr(row, col), color);
   }
   void setCrgbAt(int8_t i, cRGB crgb);
   cRGB getCrgbAt(int8_t i);
-  int8_t getLedIndex(LEDAddr led_addr);
+  int8_t getLedIndex(KeyLEDAddr led_addr);
   KS_ROW_COL_FUNC int8_t getLedIndex(byte row, byte col) {
-    return getLedIndex(LEDAddr(row, col));
+    return getLedIndex(KeyLEDAddr(row, col));
   }
 
   void scanMatrix(void);

--- a/src/kaleidoscope/hardware/olkb/Planck.h
+++ b/src/kaleidoscope/hardware/olkb/Planck.h
@@ -41,6 +41,9 @@ class Planck: public kaleidoscope::hardware::ATMegaKeyboard {
   );
 
   static constexpr int8_t led_count = 0;
+
+  typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
+  typedef MatrixAddr<1, 1> LEDAddr;
 };
 
 #define KEYMAP(                                                                    \

--- a/src/kaleidoscope/hardware/olkb/Planck.h
+++ b/src/kaleidoscope/hardware/olkb/Planck.h
@@ -43,7 +43,7 @@ class Planck: public kaleidoscope::hardware::ATMegaKeyboard {
   static constexpr int8_t led_count = 0;
 
   typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
-  typedef MatrixAddr<1, 1> LEDAddr;
+  typedef MatrixAddr<1, 1> KeyLEDAddr;
 };
 
 #define KEYMAP(                                                                    \

--- a/src/kaleidoscope/hardware/softhruf/Splitography.h
+++ b/src/kaleidoscope/hardware/softhruf/Splitography.h
@@ -52,7 +52,7 @@ class Splitography: public kaleidoscope::hardware::ATMegaKeyboard {
   static constexpr int8_t led_count = 0;
 
   typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
-  typedef MatrixAddr<1, 1> LEDAddr;
+  typedef MatrixAddr<1, 1> KeyLEDAddr;
 };
 
 #define KEYMAP(                                                                    \

--- a/src/kaleidoscope/hardware/softhruf/Splitography.h
+++ b/src/kaleidoscope/hardware/softhruf/Splitography.h
@@ -50,6 +50,9 @@ class Splitography: public kaleidoscope::hardware::ATMegaKeyboard {
   );
 
   static constexpr int8_t led_count = 0;
+
+  typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
+  typedef MatrixAddr<1, 1> LEDAddr;
 };
 
 #define KEYMAP(                                                                    \

--- a/src/kaleidoscope/hardware/technomancy/Atreus.h
+++ b/src/kaleidoscope/hardware/technomancy/Atreus.h
@@ -66,7 +66,7 @@ class Atreus: public kaleidoscope::hardware::ATMegaKeyboard {
   static constexpr int8_t led_count = 0;
 
   typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
-  typedef MatrixAddr<1, 1> LEDAddr;
+  typedef MatrixAddr<1, 1> KeyLEDAddr;
 
   void resetDevice();
 

--- a/src/kaleidoscope/hardware/technomancy/Atreus.h
+++ b/src/kaleidoscope/hardware/technomancy/Atreus.h
@@ -65,6 +65,9 @@ class Atreus: public kaleidoscope::hardware::ATMegaKeyboard {
 
   static constexpr int8_t led_count = 0;
 
+  typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
+  typedef MatrixAddr<1, 1> LEDAddr;
+
   void resetDevice();
 
  protected:

--- a/src/kaleidoscope/hooks.cpp
+++ b/src/kaleidoscope/hooks.cpp
@@ -14,6 +14,7 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Kaleidoscope.h"
 #include "kaleidoscope/hooks.h"
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/hooks.h
+++ b/src/kaleidoscope/hooks.h
@@ -28,7 +28,8 @@ union Key;
 // Forward declaration required to enable friend declarations
 // in class Hooks.
 class kaleidoscope_;
-extern void handleKeyswitchEvent(kaleidoscope::Key mappedKey, byte row, byte col, uint8_t keyState);
+extern void handleKeyswitchEvent(kaleidoscope::Key mappedKey, KeyAddr key_addr, uint8_t keyState);
+KS_ROW_COL_FUNC extern void handleKeyswitchEvent(kaleidoscope::Key mappedKey, byte row, byte col, uint8_t keyState);
 
 namespace kaleidoscope {
 
@@ -54,9 +55,9 @@ class Hooks {
   friend class Kaleidoscope_;
   friend class ::kaleidoscope::Layer_;
 
-  // ::handleKeyswitchEvent(...) calls Hooks::onKeyswitchEvent.
+  // ::handleKeyswitchEvent(...) calls Hooks::onKeyswitchEvent2.
   friend void ::handleKeyswitchEvent(kaleidoscope::Key mappedKey,
-                                     byte row, byte col, uint8_t keyState);
+                                     KeyAddr key_addr, uint8_t keyState);
 
  private:
 

--- a/src/kaleidoscope/key_events.cpp
+++ b/src/kaleidoscope/key_events.cpp
@@ -43,7 +43,7 @@ static bool handleSyntheticKeyswitchEvent(Key mappedKey, uint8_t keyState) {
   return true;
 }
 
-static bool handleKeyswitchEventDefault(Key mappedKey, byte row, byte col, uint8_t keyState) {
+static bool handleKeyswitchEventDefault(Key mappedKey, KeyAddr key_addr, uint8_t keyState) {
   //for every newly pressed button, figure out what logical key it is and send a key down event
   // for every newly released button, figure out what logical key it is and send a key up event
 
@@ -59,33 +59,33 @@ static bool handleKeyswitchEventDefault(Key mappedKey, byte row, byte col, uint8
   return true;
 }
 
-void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
-  /* These first steps are only done for keypresses that have a real (row,col).
-   * In particular, doing them for keypresses with out-of-bounds (row,col)
+void handleKeyswitchEvent(Key mappedKey, KeyAddr key_addr, uint8_t keyState) {
+  /* These first steps are only done for keypresses that have a valid key_addr.
+   * In particular, doing them for keypresses with out-of-bounds key_addr
    *   would cause out-of-bounds array accesses in Layer.lookup(),
    *   Layer.updateLiveCompositeKeymap(), etc.
-   * Note that many INJECTED keypresses use the UNKNOWN_KEYSWITCH_LOCATION macro
-   *   which gives us row==255, col==255 here.  Therefore, it's legitimate that
-   *   we may have keypresses with out-of-bounds (row, col).
-   * However, some INJECTED keypresses do have valid (row, col) if they are
+   * Note that many INJECTED keypresses use UnknownKeyswitchLocation
+   *   which gives us an invalid key_addr here.  Therefore, it's legitimate that
+   *   we may have keypresses with out-of-bounds key_addr.
+   * However, some INJECTED keypresses do have valid key_addr if they are
    *   injecting an event tied to a physical keyswitch - and we want them to go
    *   through this lookup.
-   * So we can't just test for INJECTED here, we need to test the row and col
+   * So we can't just test for INJECTED here, we need to test the key_addr
    *   directly.
-   * Note also that this (row, col) test avoids out-of-bounds accesses in *core*,
+   * Note also that this key_addr test avoids out-of-bounds accesses in *core*,
    *   but doesn't guarantee anything about event handlers - event handlers may
-   *   still receive out-of-bounds (row, col), and handling that properly is on
+   *   still receive out-of-bounds key_addr, and handling that properly is on
    *   them.
    */
-  if (row < ROWS && col < COLS) {
+  if (key_addr.isValid()) {
 
     /* If a key had an on event, we update the live composite keymap. See
      * layers.h for an explanation about the different caches we have. */
     if (keyToggledOn(keyState)) {
       if (mappedKey.raw == Key_NoKey.raw || keyState & EPHEMERAL) {
-        Layer.updateLiveCompositeKeymap(row, col);
+        Layer.updateLiveCompositeKeymap(key_addr);
       } else {
-        Layer.updateLiveCompositeKeymap(row, col, mappedKey);
+        Layer.updateLiveCompositeKeymap(key_addr, mappedKey);
       }
     }
 
@@ -96,32 +96,44 @@ void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
      * See layers.cpp for an example that masks keys, and the reason why it does
      * so.
      */
-    if (KeyboardHardware.isKeyMasked(row, col)) {
+    if (KeyboardHardware.isKeyMasked(key_addr)) {
       if (keyToggledOff(keyState)) {
-        KeyboardHardware.unMaskKey(row, col);
+        KeyboardHardware.unMaskKey(key_addr);
       } else {
         return;
       }
     }
 
-    /* Convert (row, col) to the correct mappedKey
-     * The condition here means that if mappedKey and (row, col) are both valid,
+    /* Convert key_addr to the correct mappedKey
+     * The condition here means that if mappedKey and key_addr are both valid,
      *   the mappedKey wins - we don't re-look-up the mappedKey
      */
     if (mappedKey.raw == Key_NoKey.raw) {
-      mappedKey = Layer.lookup(row, col);
+      mappedKey = Layer.lookup(key_addr);
     }
 
-  }  // row < ROWS && col < COLS
+  }  // key_addr valid
 
-  // Keypresses with out-of-bounds (row,col) start here in the processing chain
+  // Keypresses with out-of-bounds key_addr start here in the processing chain
 
-  // New event handler interface
-  if (kaleidoscope::Hooks::onKeyswitchEvent(mappedKey, row, col, keyState) != kaleidoscope::EventHandlerResult::OK)
+  // We call both versions of onKeyswitchEvent. This assumes that a plugin
+  // implements either the old or the new version of the hook.
+  // The call to that version that is not implemented is optimized out
+  // by the caller. This is possible as the call would fall back to
+  // the version of the hook that is implemented in the base class of the
+  // plugin. This fallback version is an empty inline noop method that
+  // is simple for the compiler to optimize out.
+
+  // New event handler interface version 2 (key address version)
+  if (kaleidoscope::Hooks::onKeyswitchEvent2(mappedKey, key_addr, keyState) != kaleidoscope::EventHandlerResult::OK)
     return;
 
-  mappedKey = Layer.eventHandler(mappedKey, row, col, keyState);
+  // New event handler interface (deprecated version)
+  if (kaleidoscope::Hooks::onKeyswitchEvent(mappedKey, key_addr.row(), key_addr.col(), keyState) != kaleidoscope::EventHandlerResult::OK)
+    return;
+
+  mappedKey = Layer.eventHandler(mappedKey, key_addr, keyState);
   if (mappedKey.raw == Key_NoKey.raw)
     return;
-  handleKeyswitchEventDefault(mappedKey, row, col, keyState);
+  handleKeyswitchEventDefault(mappedKey, key_addr, keyState);
 }

--- a/src/kaleidoscope/key_events.h
+++ b/src/kaleidoscope/key_events.h
@@ -24,10 +24,18 @@
 
 // Code can use this macro on injected key events to signal that
 // the event isn't tied to a specific physical keyswitch
+//
+// TODO: Once row/col based key/LED access is deprecated,
+//       deprecate UNKNOWN_KEYSWITCH_LOCATION as well.
 #define UNKNOWN_KEYSWITCH_LOCATION 255,255
+
+// UnknownKeyswitchLocation represents an invalid (as default constructed)
+// key address.
+static constexpr KeyAddr UnknownKeyswitchLocation;
+
 // Conversely, if an injected event *is* tied to a physical keyswitch and should
 // be resolved by the current keymap, code can use Key_NoKey on the injected event
-// with a real (row, col) location
+// with a real key address
 
 // sending events to the computer
 /* The event handling starts with the Scanner calling handleKeyswitchEvent() for
@@ -54,10 +62,13 @@
  * too.
  *
  * For this reason, the handleKeyswitchEvent receives four arguments: the mapped key
- * (or Key_NoKey if we do not want to override what is in the keymap), the row
- * and column of the key, so we can look up the code for it, and the current and
+ * (or Key_NoKey if we do not want to override what is in the keymap), the matrix
+ * address of the key, so we can look up the code for it, and the current and
  * previous state of the key, so we can determine what the event is. The
  * currentState may be flagged INJECTED, which signals that the event was
  * injected, and is not a direct result of a keypress, coming from the scanner.
  */
-void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState);
+void handleKeyswitchEvent(Key mappedKey, KeyAddr key_addr, uint8_t keyState);
+KS_ROW_COL_FUNC inline void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
+  handleKeyswitchEvent(mappedKey, KeyAddr(row, col), keyState);
+}

--- a/src/kaleidoscope/key_events.h
+++ b/src/kaleidoscope/key_events.h
@@ -30,8 +30,11 @@
 #define UNKNOWN_KEYSWITCH_LOCATION 255,255
 
 // UnknownKeyswitchLocation represents an invalid (as default constructed)
-// key address.
-static constexpr KeyAddr UnknownKeyswitchLocation;
+// key address. Note: This is not a constexpr as it turned out
+// that the compiler would instanciate it and store it in RAM if
+// not made a temporary.
+//
+#define UnknownKeyswitchLocation (KeyAddr{})
 
 // Conversely, if an injected event *is* tied to a physical keyswitch and should
 // be resolved by the current keymap, code can use Key_NoKey on the injected event

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -66,14 +66,24 @@ class Layer_ {
    * are curious what the active layer state describes the key as, use
    * `lookupOnActiveLayer`.
    */
-  static Key lookup(byte row, byte col) {
+  static Key lookup(KeyAddr key_addr) {
+    return live_composite_keymap_[key_addr.row()][key_addr.col()];
+  }
+  KS_ROW_COL_FUNC static Key lookup(byte row, byte col) {
     return live_composite_keymap_[row][col];
   }
-  static Key lookupOnActiveLayer(byte row, byte col) {
-    uint8_t layer = active_layers_[row][col];
-    return (*getKey)(layer, row, col);
+  static Key lookupOnActiveLayer(KeyAddr key_addr) {
+    uint8_t layer = active_layers_[key_addr.row()][key_addr.col()];
+    return (*getKey)(layer, key_addr);
   }
-  static uint8_t lookupActiveLayer(byte row, byte col) {
+  KS_ROW_COL_FUNC static Key lookupOnActiveLayer(byte row, byte col) {
+    uint8_t layer = active_layers_[row][col];
+    return (*getKey)(layer, KeyAddr(row, col));
+  }
+  static uint8_t lookupActiveLayer(KeyAddr key_addr) {
+    return active_layers_[key_addr.row()][key_addr.col()];
+  }
+  KS_ROW_COL_FUNC static uint8_t lookupActiveLayer(byte row, byte col) {
     return active_layers_[row][col];
   }
 
@@ -92,15 +102,27 @@ class Layer_ {
     return layer_state_;
   }
 
-  static Key eventHandler(Key mappedKey, byte row, byte col, uint8_t keyState);
+  static Key eventHandler(Key mappedKey, KeyAddr key_addr, uint8_t keyState);
+  KS_ROW_COL_FUNC static Key eventHandler(Key mappedKey, byte row, byte col, uint8_t keyState) {
+    return eventHandler(mappedKey, KeyAddr(row, col), keyState);
+  }
 
-  static Key(*getKey)(uint8_t layer, byte row, byte col);
+  static Key(*getKey)(uint8_t layer, KeyAddr key_addr);
 
-  static Key getKeyFromPROGMEM(uint8_t layer, byte row, byte col);
+  static Key getKeyFromPROGMEM(uint8_t layer, KeyAddr key_addr);
+  KS_ROW_COL_FUNC static Key getKeyFromPROGMEM(uint8_t layer, byte row, byte col) {
+    return getKeyFromPROGMEM(layer, KeyAddr(row, col));
+  }
 
-  static void updateLiveCompositeKeymap(byte row, byte col);
-  static void updateLiveCompositeKeymap(byte row, byte col, Key mappedKey) {
-    live_composite_keymap_[row][col] = mappedKey;
+  static void updateLiveCompositeKeymap(KeyAddr keyAddr, Key mappedKey) {
+    live_composite_keymap_[keyAddr.row()][keyAddr.col()] = mappedKey;
+  }
+  KS_ROW_COL_FUNC static void updateLiveCompositeKeymap(byte row, byte col, Key mappedKey) {
+    updateLiveCompositeKeymap(KeyAddr(row, col), mappedKey);
+  }
+  static void updateLiveCompositeKeymap(KeyAddr keyAddr);
+  KS_ROW_COL_FUNC static void updateLiveCompositeKeymap(byte row, byte col) {
+    updateLiveCompositeKeymap(KeyAddr(row, col));
   }
   static void updateActiveLayers(void);
 

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -67,24 +67,25 @@ class Layer_ {
    * `lookupOnActiveLayer`.
    */
   static Key lookup(KeyAddr key_addr) {
-    return live_composite_keymap_[key_addr.row()][key_addr.col()];
+    return live_composite_keymap_[key_addr.toInt()];
   }
   KS_ROW_COL_FUNC static Key lookup(byte row, byte col) {
-    return live_composite_keymap_[row][col];
+    return live_composite_keymap_[KeyAddr(row, col).toInt()];
   }
   static Key lookupOnActiveLayer(KeyAddr key_addr) {
-    uint8_t layer = active_layers_[key_addr.row()][key_addr.col()];
+    uint8_t layer = active_layers_[key_addr.toInt()];
     return (*getKey)(layer, key_addr);
   }
   KS_ROW_COL_FUNC static Key lookupOnActiveLayer(byte row, byte col) {
-    uint8_t layer = active_layers_[row][col];
-    return (*getKey)(layer, KeyAddr(row, col));
+    KeyAddr key_addr(row, col);
+    uint8_t layer = active_layers_[key_addr.toInt()];
+    return (*getKey)(layer, key_addr);
   }
   static uint8_t lookupActiveLayer(KeyAddr key_addr) {
-    return active_layers_[key_addr.row()][key_addr.col()];
+    return active_layers_[key_addr.toInt()];
   }
   KS_ROW_COL_FUNC static uint8_t lookupActiveLayer(byte row, byte col) {
-    return active_layers_[row][col];
+    return active_layers_[KeyAddr(row, col).toInt()];
   }
 
   static void activate(uint8_t layer);
@@ -115,7 +116,7 @@ class Layer_ {
   }
 
   static void updateLiveCompositeKeymap(KeyAddr keyAddr, Key mappedKey) {
-    live_composite_keymap_[keyAddr.row()][keyAddr.col()] = mappedKey;
+    live_composite_keymap_[keyAddr.toInt()] = mappedKey;
   }
   KS_ROW_COL_FUNC static void updateLiveCompositeKeymap(byte row, byte col, Key mappedKey) {
     updateLiveCompositeKeymap(KeyAddr(row, col), mappedKey);
@@ -129,8 +130,8 @@ class Layer_ {
  private:
   static uint32_t layer_state_;
   static uint8_t top_active_layer_;
-  static Key live_composite_keymap_[ROWS][COLS];
-  static uint8_t active_layers_[ROWS][COLS];
+  static Key live_composite_keymap_[KeyAddr::upper_limit];
+  static uint8_t active_layers_[KeyAddr::upper_limit];
 
   static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState);
   static void updateTopActiveLayer(void);

--- a/src/kaleidoscope/plugin/Colormap.cpp
+++ b/src/kaleidoscope/plugin/Colormap.cpp
@@ -47,9 +47,9 @@ void ColormapEffect::onActivate(void) {
     ::LEDPaletteTheme.updateHandler(map_base_, top_layer_);
 }
 
-void ColormapEffect::refreshAt(byte row, byte col) {
+void ColormapEffect::refreshAt(LEDAddr led_addr) {
   if (top_layer_ <= max_layers_)
-    ::LEDPaletteTheme.refreshAt(map_base_, top_layer_, row, col);
+    ::LEDPaletteTheme.refreshAt(map_base_, top_layer_, led_addr);
 }
 
 EventHandlerResult ColormapEffect::onLayerChange() {

--- a/src/kaleidoscope/plugin/Colormap.cpp
+++ b/src/kaleidoscope/plugin/Colormap.cpp
@@ -47,7 +47,7 @@ void ColormapEffect::onActivate(void) {
     ::LEDPaletteTheme.updateHandler(map_base_, top_layer_);
 }
 
-void ColormapEffect::refreshAt(LEDAddr led_addr) {
+void ColormapEffect::refreshAt(KeyLEDAddr led_addr) {
   if (top_layer_ <= max_layers_)
     ::LEDPaletteTheme.refreshAt(map_base_, top_layer_, led_addr);
 }

--- a/src/kaleidoscope/plugin/Colormap.h
+++ b/src/kaleidoscope/plugin/Colormap.h
@@ -33,7 +33,10 @@ class ColormapEffect : public LEDMode {
 
  protected:
   void onActivate(void) final;
-  void refreshAt(byte row, byte col) final;
+  void refreshAt(LEDAddr led_addr) final;
+  KS_ROW_COL_FUNC void refreshAt(byte row, byte col) final {
+    refreshAt(LEDAddr(row, col));
+  }
 
  private:
   static uint8_t top_layer_;

--- a/src/kaleidoscope/plugin/Colormap.h
+++ b/src/kaleidoscope/plugin/Colormap.h
@@ -33,9 +33,9 @@ class ColormapEffect : public LEDMode {
 
  protected:
   void onActivate(void) final;
-  void refreshAt(LEDAddr led_addr) final;
+  void refreshAt(KeyLEDAddr led_addr) final;
   KS_ROW_COL_FUNC void refreshAt(byte row, byte col) final {
-    refreshAt(LEDAddr(row, col));
+    refreshAt(KeyLEDAddr(row, col));
   }
 
  private:

--- a/src/kaleidoscope/plugin/Cycle.cpp
+++ b/src/kaleidoscope/plugin/Cycle.cpp
@@ -33,14 +33,14 @@ uint8_t Cycle::cycle_count_;
 // --- api ---
 
 void Cycle::replace(Key key) {
-  handleKeyswitchEvent(Key_Backspace, UNKNOWN_KEYSWITCH_LOCATION, IS_PRESSED | INJECTED);
+  handleKeyswitchEvent(Key_Backspace, UnknownKeyswitchLocation, IS_PRESSED | INJECTED);
   hid::sendKeyboardReport();
-  handleKeyswitchEvent(Key_Backspace, UNKNOWN_KEYSWITCH_LOCATION, WAS_PRESSED | INJECTED);
+  handleKeyswitchEvent(Key_Backspace, UnknownKeyswitchLocation, WAS_PRESSED | INJECTED);
   hid::sendKeyboardReport();
 
-  handleKeyswitchEvent(key, UNKNOWN_KEYSWITCH_LOCATION, IS_PRESSED | INJECTED);
+  handleKeyswitchEvent(key, UnknownKeyswitchLocation, IS_PRESSED | INJECTED);
   hid::sendKeyboardReport();
-  handleKeyswitchEvent(key, UNKNOWN_KEYSWITCH_LOCATION, WAS_PRESSED | INJECTED);
+  handleKeyswitchEvent(key, UnknownKeyswitchLocation, WAS_PRESSED | INJECTED);
   hid::sendKeyboardReport();
 }
 
@@ -54,7 +54,7 @@ void Cycle::replace(uint8_t cycle_size, const Key cycle_steps[]) {
 
 // --- hooks ---
 
-EventHandlerResult Cycle::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
+EventHandlerResult Cycle::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
   if (key_state & INJECTED)
     return EventHandlerResult::OK;
 

--- a/src/kaleidoscope/plugin/Cycle.h
+++ b/src/kaleidoscope/plugin/Cycle.h
@@ -36,7 +36,7 @@ class Cycle : public kaleidoscope::Plugin {
   static void replace(Key key);
   static void replace(uint8_t cycle_size, const Key cycle_steps[]);
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 
  private:
   static uint8_t toModFlag(uint8_t keyCode);

--- a/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
+++ b/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
@@ -50,16 +50,16 @@ void EEPROMKeymapProgrammer::cancel(void) {
   state_ = INACTIVE;
 }
 
-EventHandlerResult EEPROMKeymapProgrammer::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
+EventHandlerResult EEPROMKeymapProgrammer::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
   if (state_ == INACTIVE)
     return EventHandlerResult::OK;
 
   if (state_ == WAIT_FOR_KEY) {
     if (keyToggledOn(key_state)) {
-      update_position_ = Layer.top() * ROWS * COLS + row * COLS + col;
+      update_position_ = Layer.top() * ROWS * COLS + key_addr.offset();
     }
     if (keyToggledOff(key_state)) {
-      if ((uint16_t)(Layer.top() * ROWS * COLS + row * COLS + col) == update_position_)
+      if ((uint16_t)(Layer.top() * ROWS * COLS + key_addr.offset()) == update_position_)
         nextState();
     }
     return EventHandlerResult::EVENT_CONSUMED;
@@ -67,10 +67,10 @@ EventHandlerResult EEPROMKeymapProgrammer::onKeyswitchEvent(Key &mapped_key, byt
 
   if (state_ == WAIT_FOR_SOURCE_KEY) {
     if (keyToggledOn(key_state)) {
-      new_key_ = Layer.getKeyFromPROGMEM(Layer.top(), row, col);
+      new_key_ = Layer.getKeyFromPROGMEM(Layer.top(), key_addr);
     }
     if (keyToggledOff(key_state)) {
-      if (new_key_ == Layer.getKeyFromPROGMEM(Layer.top(), row, col))
+      if (new_key_ == Layer.getKeyFromPROGMEM(Layer.top(), key_addr))
         nextState();
     }
     return EventHandlerResult::EVENT_CONSUMED;

--- a/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
+++ b/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
@@ -56,10 +56,10 @@ EventHandlerResult EEPROMKeymapProgrammer::onKeyswitchEvent2(Key &mapped_key, Ke
 
   if (state_ == WAIT_FOR_KEY) {
     if (keyToggledOn(key_state)) {
-      update_position_ = Layer.top() * ROWS * COLS + key_addr.offset();
+      update_position_ = Layer.top() * ROWS * COLS + key_addr.toInt();
     }
     if (keyToggledOff(key_state)) {
-      if ((uint16_t)(Layer.top() * ROWS * COLS + key_addr.offset()) == update_position_)
+      if ((uint16_t)(Layer.top() * ROWS * COLS + key_addr.toInt()) == update_position_)
         nextState();
     }
     return EventHandlerResult::EVENT_CONSUMED;

--- a/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.h
+++ b/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.h
@@ -38,7 +38,7 @@ class EEPROMKeymapProgrammer : public kaleidoscope::Plugin {
   static void nextState(void);
   static void cancel(void);
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
   EventHandlerResult onFocusEvent(const char *command);
 
  private:

--- a/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -62,7 +62,6 @@ Key EEPROMKeymap::getKey(uint8_t layer, KeyAddr key_addr) {
 }
 
 Key EEPROMKeymap::getKeyExtended(uint8_t layer, KeyAddr key_addr) {
-  Key key;
 
   // If the layer is within PROGMEM bounds, look it up from there
   if (layer < progmem_layers_) {
@@ -84,21 +83,21 @@ void EEPROMKeymap::updateKey(uint16_t base_pos, Key key) {
 
 void EEPROMKeymap::dumpKeymap(uint8_t layers, Key(*getkey)(uint8_t, KeyAddr)) {
   for (uint8_t layer = 0; layer < layers; layer++) {
-     for(auto key_addr: KeyAddr{}) {
-        Key k = (*getkey)(layer, key_addr);
+    for (auto key_addr : KeyAddr{}) {
+      Key k = (*getkey)(layer, key_addr);
 
-        ::Focus.send(k);
-      }
+      ::Focus.send(k);
     }
+  }
 }
 
 void EEPROMKeymap::dumpKeymap(uint8_t layers, Key(*getkey)(uint8_t, byte, byte)) {
   for (uint8_t layer = 0; layer < layers; layer++) {
-    for(auto key_addr: KeyAddr{}) {
-        Key k = (*getkey)(layer, key_addr.row(), key_addr.col());
+    for (auto key_addr : KeyAddr{}) {
+      Key k = (*getkey)(layer, key_addr.row(), key_addr.col());
 
-        ::Focus.send(k);
-      }
+      ::Focus.send(k);
+    }
   }
 }
 

--- a/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -84,25 +84,21 @@ void EEPROMKeymap::updateKey(uint16_t base_pos, Key key) {
 
 void EEPROMKeymap::dumpKeymap(uint8_t layers, Key(*getkey)(uint8_t, KeyAddr)) {
   for (uint8_t layer = 0; layer < layers; layer++) {
-    for (uint8_t row = 0; row < ROWS; row++) {
-      for (uint8_t col = 0; col < COLS; col++) {
-        Key k = (*getkey)(layer, KeyAddr(row, col));
+     for(auto key_addr: KeyAddr{}) {
+        Key k = (*getkey)(layer, key_addr);
 
         ::Focus.send(k);
       }
     }
-  }
 }
 
 void EEPROMKeymap::dumpKeymap(uint8_t layers, Key(*getkey)(uint8_t, byte, byte)) {
   for (uint8_t layer = 0; layer < layers; layer++) {
-    for (uint8_t row = 0; row < ROWS; row++) {
-      for (uint8_t col = 0; col < COLS; col++) {
-        Key k = (*getkey)(layer, row, col);
+    for(auto key_addr: KeyAddr{}) {
+        Key k = (*getkey)(layer, key_addr.row(), key_addr.col());
 
         ::Focus.send(k);
       }
-    }
   }
 }
 

--- a/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -53,7 +53,7 @@ Key EEPROMKeymap::getKey(uint8_t layer, KeyAddr key_addr) {
   if (layer >= max_layers_)
     return Key_NoKey;
 
-  uint16_t pos = ((layer * ROWS * COLS) + key_addr.offset()) * 2;
+  uint16_t pos = ((layer * ROWS * COLS) + key_addr.toInt()) * 2;
 
   key.flags = EEPROM.read(keymap_base_ + pos);
   key.keyCode = EEPROM.read(keymap_base_ + pos + 1);

--- a/src/kaleidoscope/plugin/EEPROM-Keymap.h
+++ b/src/kaleidoscope/plugin/EEPROM-Keymap.h
@@ -47,8 +47,14 @@ class EEPROMKeymap : public kaleidoscope::Plugin {
 
   static uint16_t keymap_base(void);
 
-  static Key getKey(uint8_t layer, byte row, byte col);
-  static Key getKeyExtended(uint8_t layer, byte row, byte col);
+  static Key getKey(uint8_t layer, KeyAddr key_addr);
+  KS_ROW_COL_FUNC static Key getKey(uint8_t layer, byte row, byte col) {
+    return getKey(layer, KeyAddr(row, col));
+  }
+  static Key getKeyExtended(uint8_t layer, KeyAddr key_addr);
+  KS_ROW_COL_FUNC static Key getKeyExtended(uint8_t layer, byte row, byte col) {
+    return getKeyExtended(layer, KeyAddr(row, col));
+  }
 
   static void updateKey(uint16_t base_pos, Key key);
 
@@ -59,7 +65,8 @@ class EEPROMKeymap : public kaleidoscope::Plugin {
 
   static Key parseKey(void);
   static void printKey(Key key);
-  static void dumpKeymap(uint8_t layers, Key(*getkey)(uint8_t, byte, byte));
+  static void dumpKeymap(uint8_t layers, Key(*getkey)(uint8_t, KeyAddr));
+  KS_ROW_COL_FUNC static void dumpKeymap(uint8_t layers, Key(*getkey)(uint8_t, byte, byte));
 };
 }
 }

--- a/src/kaleidoscope/plugin/Escape-OneShot.cpp
+++ b/src/kaleidoscope/plugin/Escape-OneShot.cpp
@@ -22,7 +22,7 @@
 namespace kaleidoscope {
 namespace plugin {
 
-EventHandlerResult EscapeOneShot::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState) {
+EventHandlerResult EscapeOneShot::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
   if (mapped_key.raw != Key_Escape.raw ||
       (keyState & INJECTED) ||
       !keyToggledOn(keyState))
@@ -32,7 +32,7 @@ EventHandlerResult EscapeOneShot::onKeyswitchEvent(Key &mapped_key, byte row, by
     return EventHandlerResult::OK;
   }
 
-  KeyboardHardware.maskKey(row, col);
+  KeyboardHardware.maskKey(key_addr);
 
   ::OneShot.cancel(true);
   return EventHandlerResult::EVENT_CONSUMED;

--- a/src/kaleidoscope/plugin/Escape-OneShot.h
+++ b/src/kaleidoscope/plugin/Escape-OneShot.h
@@ -25,7 +25,7 @@ class EscapeOneShot : public kaleidoscope::Plugin {
  public:
   EscapeOneShot(void) {}
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);
 };
 }
 }

--- a/src/kaleidoscope/plugin/FingerPainter.cpp
+++ b/src/kaleidoscope/plugin/FingerPainter.cpp
@@ -38,7 +38,7 @@ void FingerPainter::update(void) {
   ::LEDPaletteTheme.updateHandler(color_base_, 0);
 }
 
-void FingerPainter::refreshAt(LEDAddr led_addr) {
+void FingerPainter::refreshAt(KeyLEDAddr led_addr) {
   ::LEDPaletteTheme.refreshAt(color_base_, 0, led_addr);
 }
 

--- a/src/kaleidoscope/plugin/FingerPainter.cpp
+++ b/src/kaleidoscope/plugin/FingerPainter.cpp
@@ -38,15 +38,15 @@ void FingerPainter::update(void) {
   ::LEDPaletteTheme.updateHandler(color_base_, 0);
 }
 
-void FingerPainter::refreshAt(byte row, byte col) {
-  ::LEDPaletteTheme.refreshAt(color_base_, 0, row, col);
+void FingerPainter::refreshAt(LEDAddr led_addr) {
+  ::LEDPaletteTheme.refreshAt(color_base_, 0, led_addr);
 }
 
 void FingerPainter::toggle(void) {
   edit_mode_ = !edit_mode_;
 }
 
-EventHandlerResult FingerPainter::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
+EventHandlerResult FingerPainter::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
   if (!Kaleidoscope.has_leds || !edit_mode_)
     return EventHandlerResult::OK;
 
@@ -54,10 +54,12 @@ EventHandlerResult FingerPainter::onKeyswitchEvent(Key &mapped_key, byte row, by
     return EventHandlerResult::EVENT_CONSUMED;
   }
 
-  if (row >= ROWS || col >= COLS)
+  if (!key_addr.isValid())
     return EventHandlerResult::EVENT_CONSUMED;
 
-  uint8_t color_index = ::LEDPaletteTheme.lookupColorIndexAtPosition(color_base_, KeyboardHardware.getLedIndex(row, col));
+  // TODO: The following works only for keyboards with LEDs for each key.
+
+  uint8_t color_index = ::LEDPaletteTheme.lookupColorIndexAtPosition(color_base_, KeyboardHardware.getLedIndex(key_addr));
 
   // Find the next color in the palette that is different.
   // But do not loop forever!
@@ -74,7 +76,7 @@ EventHandlerResult FingerPainter::onKeyswitchEvent(Key &mapped_key, byte row, by
     new_color = ::LEDPaletteTheme.lookupPaletteColor(color_index);
   }
 
-  ::LEDPaletteTheme.updateColorIndexAtPosition(color_base_, KeyboardHardware.getLedIndex(row, col), color_index);
+  ::LEDPaletteTheme.updateColorIndexAtPosition(color_base_, KeyboardHardware.getLedIndex(key_addr), color_index);
 
   return EventHandlerResult::EVENT_CONSUMED;
 }

--- a/src/kaleidoscope/plugin/FingerPainter.h
+++ b/src/kaleidoscope/plugin/FingerPainter.h
@@ -33,9 +33,9 @@ class FingerPainter : public LEDMode {
 
  protected:
   void update(void) final;
-  void refreshAt(LEDAddr led_addr) final;
+  void refreshAt(KeyLEDAddr led_addr) final;
   KS_ROW_COL_FUNC void refreshAt(byte row, byte col) final {
-    refreshAt(LEDAddr(row, col));
+    refreshAt(KeyLEDAddr(row, col));
   }
 
  private:

--- a/src/kaleidoscope/plugin/FingerPainter.h
+++ b/src/kaleidoscope/plugin/FingerPainter.h
@@ -27,13 +27,16 @@ class FingerPainter : public LEDMode {
 
   static void toggle(void);
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
   EventHandlerResult onFocusEvent(const char *command);
   EventHandlerResult onSetup();
 
  protected:
   void update(void) final;
-  void refreshAt(byte row, byte col) final;
+  void refreshAt(LEDAddr led_addr) final;
+  KS_ROW_COL_FUNC void refreshAt(byte row, byte col) final {
+    refreshAt(LEDAddr(row, col));
+  }
 
  private:
   static uint16_t color_base_;

--- a/src/kaleidoscope/plugin/GeminiPR.cpp
+++ b/src/kaleidoscope/plugin/GeminiPR.cpp
@@ -24,7 +24,7 @@ namespace steno {
 uint8_t GeminiPR::keys_held_;
 uint8_t GeminiPR::state_[6];
 
-EventHandlerResult GeminiPR::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState) {
+EventHandlerResult GeminiPR::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
   if (mapped_key < geminipr::START ||
       mapped_key > geminipr::END)
     return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/GeminiPR.h
+++ b/src/kaleidoscope/plugin/GeminiPR.h
@@ -29,8 +29,7 @@ class GeminiPR : public kaleidoscope::Plugin {
  public:
   GeminiPR(void) {}
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState);
-
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);
  private:
   static uint8_t keys_held_;
   static uint8_t state_[6];

--- a/src/kaleidoscope/plugin/GhostInTheFirmware.cpp
+++ b/src/kaleidoscope/plugin/GhostInTheFirmware.cpp
@@ -55,12 +55,12 @@ EventHandlerResult GhostInTheFirmware::beforeReportingState() {
       byte row = pgm_read_byte(&(ghost_keys[current_pos_].row));
       byte col = pgm_read_byte(&(ghost_keys[current_pos_].col));
 
-      handleKeyswitchEvent(Key_NoKey, row, col, WAS_PRESSED);
+      handleKeyswitchEvent(Key_NoKey, KeyAddr(row, col), WAS_PRESSED);
     } else if (is_pressed_) {
       byte row = pgm_read_byte(&(ghost_keys[current_pos_].row));
       byte col = pgm_read_byte(&(ghost_keys[current_pos_].col));
 
-      handleKeyswitchEvent(Key_NoKey, row, col, IS_PRESSED);
+      handleKeyswitchEvent(Key_NoKey, KeyAddr(row, col), IS_PRESSED);
     } else if ((millis() - start_time_) > delay_timeout_) {
       current_pos_++;
       press_timeout_ = 0;

--- a/src/kaleidoscope/plugin/Heatmap.cpp
+++ b/src/kaleidoscope/plugin/Heatmap.cpp
@@ -197,7 +197,7 @@ void Heatmap::update(void) {
     // https://forum.arduino.cc/index.php?topic=92684.msg2733723#msg2733723
 
     // set the LED color accordingly
-    ::LEDControl.setCrgbAt(LEDAddr(key_addr), computeColor(v));
+    ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr), computeColor(v));
   }
 }
 

--- a/src/kaleidoscope/plugin/Heatmap.cpp
+++ b/src/kaleidoscope/plugin/Heatmap.cpp
@@ -123,7 +123,7 @@ void Heatmap::resetMap(void) {
   highest_ = 1;
 }
 
-EventHandlerResult Heatmap::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
+EventHandlerResult Heatmap::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
   if (!Kaleidoscope.has_leds)
     return EventHandlerResult::OK;
 
@@ -137,6 +137,9 @@ EventHandlerResult Heatmap::onKeyswitchEvent(Key &mapped_key, byte row, byte col
   // if the key is not toggled on, skip it
   if (!keyToggledOn(key_state))
     return EventHandlerResult::OK;
+
+  auto row = key_addr.row();
+  auto col = key_addr.col();
 
   // increment the heatmap_ value related to the key
   heatmap_[row][col]++;
@@ -202,7 +205,7 @@ void Heatmap::update(void) {
       // https://forum.arduino.cc/index.php?topic=92684.msg2733723#msg2733723
 
       // set the LED color accordingly
-      ::LEDControl.setCrgbAt(r, c, computeColor(v));
+      ::LEDControl.setCrgbAt(LEDAddr(r, c), computeColor(v));
     }
   }
 }

--- a/src/kaleidoscope/plugin/Heatmap.h
+++ b/src/kaleidoscope/plugin/Heatmap.h
@@ -38,7 +38,7 @@ class Heatmap : public LEDMode {
   void update(void) final;
 
  private:
-  static uint16_t heatmap_[ROWS][COLS];
+  static uint16_t heatmap_[ROWS * COLS];
   static uint16_t highest_;
   static uint32_t next_heatmap_comp_time_;
 

--- a/src/kaleidoscope/plugin/Heatmap.h
+++ b/src/kaleidoscope/plugin/Heatmap.h
@@ -31,7 +31,7 @@ class Heatmap : public LEDMode {
   static uint8_t heat_colors_length;
   void resetMap(void);
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
   EventHandlerResult beforeEachCycle();
 
  protected:

--- a/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -36,7 +36,7 @@ EventHandlerResult IdleLEDs::beforeEachCycle() {
   return EventHandlerResult::OK;
 }
 
-EventHandlerResult IdleLEDs::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
+EventHandlerResult IdleLEDs::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
 
   if (::LEDControl.paused) {
     ::LEDControl.paused = false;

--- a/src/kaleidoscope/plugin/IdleLEDs.h
+++ b/src/kaleidoscope/plugin/IdleLEDs.h
@@ -33,7 +33,7 @@ class IdleLEDs: public kaleidoscope::Plugin {
     return EventHandlerResult::OK;
   }
   EventHandlerResult beforeEachCycle();
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 
  private:
   static uint32_t end_time_;

--- a/src/kaleidoscope/plugin/LED-ActiveLayerColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveLayerColor.cpp
@@ -47,7 +47,7 @@ void LEDActiveLayerColorEffect::onActivate(void) {
   ::LEDControl.set_all_leds_to(active_color_);
 }
 
-void LEDActiveLayerColorEffect::refreshAt(LEDAddr led_addr) {
+void LEDActiveLayerColorEffect::refreshAt(KeyLEDAddr led_addr) {
   ::LEDControl.setCrgbAt(led_addr, active_color_);
 }
 

--- a/src/kaleidoscope/plugin/LED-ActiveLayerColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveLayerColor.cpp
@@ -47,8 +47,8 @@ void LEDActiveLayerColorEffect::onActivate(void) {
   ::LEDControl.set_all_leds_to(active_color_);
 }
 
-void LEDActiveLayerColorEffect::refreshAt(byte row, byte col) {
-  ::LEDControl.setCrgbAt(row, col, active_color_);
+void LEDActiveLayerColorEffect::refreshAt(LEDAddr led_addr) {
+  ::LEDControl.setCrgbAt(led_addr, active_color_);
 }
 
 EventHandlerResult LEDActiveLayerColorEffect::onLayerChange() {

--- a/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
+++ b/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
@@ -30,7 +30,10 @@ class LEDActiveLayerColorEffect : public LEDMode {
 
  protected:
   void onActivate(void) final;
-  void refreshAt(byte row, byte col) final;
+  void refreshAt(LEDAddr led_addr) final;
+  KS_ROW_COL_FUNC void refreshAt(byte row, byte col) final {
+    refreshAt(LEDAddr(row, col));
+  }
 
  private:
   static const cRGB *colormap_;

--- a/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
+++ b/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
@@ -30,9 +30,9 @@ class LEDActiveLayerColorEffect : public LEDMode {
 
  protected:
   void onActivate(void) final;
-  void refreshAt(LEDAddr led_addr) final;
+  void refreshAt(KeyLEDAddr led_addr) final;
   KS_ROW_COL_FUNC void refreshAt(byte row, byte col) final {
-    refreshAt(LEDAddr(row, col));
+    refreshAt(KeyLEDAddr(row, col));
   }
 
  private:

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -64,25 +64,25 @@ EventHandlerResult ActiveModColorEffect::beforeReportingState() {
 
     if (::OneShot.isOneShotKey(k)) {
       if (::OneShot.isSticky(k))
-        ::LEDControl.setCrgbAt(LEDAddr(key_addr), sticky_color);
+        ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr), sticky_color);
       else if (::OneShot.isActive(k))
-        ::LEDControl.setCrgbAt(LEDAddr(key_addr), highlight_color);
+        ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr), highlight_color);
       else
-        ::LEDControl.refreshAt(LEDAddr(key_addr));
+        ::LEDControl.refreshAt(KeyLEDAddr(key_addr));
     } else if (k.raw >= Key_LeftControl.raw && k.raw <= Key_RightGui.raw) {
       if (hid::isModifierKeyActive(k))
-        ::LEDControl.setCrgbAt(LEDAddr(key_addr), highlight_color);
+        ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr), highlight_color);
       else
-        ::LEDControl.refreshAt(LEDAddr(key_addr));
+        ::LEDControl.refreshAt(KeyLEDAddr(key_addr));
     } else if (k.flags == (SYNTHETIC | SWITCH_TO_KEYMAP)) {
       uint8_t layer = k.keyCode;
       if (layer >= LAYER_SHIFT_OFFSET)
         layer -= LAYER_SHIFT_OFFSET;
 
       if (Layer.isActive(layer))
-        ::LEDControl.setCrgbAt(LEDAddr(key_addr), highlight_color);
+        ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr), highlight_color);
       else
-        ::LEDControl.refreshAt(LEDAddr(key_addr));
+        ::LEDControl.refreshAt(KeyLEDAddr(key_addr));
     }
   }
 

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -38,15 +38,15 @@ EventHandlerResult ActiveModColorEffect::onLayerChange() {
 
   mod_key_count_ = 0;
 
-  for(auto key_addr: KeyAddr{}) {
-      Key k = Layer.lookupOnActiveLayer(key_addr);
+  for (auto key_addr : KeyAddr{}) {
+    Key k = Layer.lookupOnActiveLayer(key_addr);
 
-      if (::OneShot.isOneShotKey(k) ||
-          (highlight_normal_modifiers_ && (
-             (k.raw >= Key_LeftControl.raw && k.raw <= Key_RightGui.raw) ||
-             (k.flags == (SYNTHETIC | SWITCH_TO_KEYMAP))))) {
-        mod_keys_[mod_key_count_++] = key_addr;
-      }
+    if (::OneShot.isOneShotKey(k) ||
+        (highlight_normal_modifiers_ && (
+           (k.raw >= Key_LeftControl.raw && k.raw <= Key_RightGui.raw) ||
+           (k.flags == (SYNTHETIC | SWITCH_TO_KEYMAP))))) {
+      mod_keys_[mod_key_count_++] = key_addr;
+    }
   }
 
   return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -40,7 +40,7 @@ EventHandlerResult ActiveModColorEffect::onLayerChange() {
 
   for (byte r = 0; r < ROWS; r++) {
     for (byte c = 0; c < COLS; c++) {
-      Key k = Layer.lookupOnActiveLayer(r, c);
+      Key k = Layer.lookupOnActiveLayer(KeyAddr(r, c));
 
       if (::OneShot.isOneShotKey(k) ||
           (highlight_normal_modifiers_ && (
@@ -65,29 +65,29 @@ EventHandlerResult ActiveModColorEffect::beforeReportingState() {
     byte c = coords % COLS;
     byte r = (coords - c) / COLS;
 
-    Key k = Layer.lookupOnActiveLayer(r, c);
+    Key k = Layer.lookupOnActiveLayer(KeyAddr(r, c));
 
     if (::OneShot.isOneShotKey(k)) {
       if (::OneShot.isSticky(k))
-        ::LEDControl.setCrgbAt(r, c, sticky_color);
+        ::LEDControl.setCrgbAt(LEDAddr(r, c), sticky_color);
       else if (::OneShot.isActive(k))
-        ::LEDControl.setCrgbAt(r, c, highlight_color);
+        ::LEDControl.setCrgbAt(LEDAddr(r, c), highlight_color);
       else
-        ::LEDControl.refreshAt(r, c);
+        ::LEDControl.refreshAt(LEDAddr(r, c));
     } else if (k.raw >= Key_LeftControl.raw && k.raw <= Key_RightGui.raw) {
       if (hid::isModifierKeyActive(k))
-        ::LEDControl.setCrgbAt(r, c, highlight_color);
+        ::LEDControl.setCrgbAt(LEDAddr(r, c), highlight_color);
       else
-        ::LEDControl.refreshAt(r, c);
+        ::LEDControl.refreshAt(LEDAddr(r, c));
     } else if (k.flags == (SYNTHETIC | SWITCH_TO_KEYMAP)) {
       uint8_t layer = k.keyCode;
       if (layer >= LAYER_SHIFT_OFFSET)
         layer -= LAYER_SHIFT_OFFSET;
 
       if (Layer.isActive(layer))
-        ::LEDControl.setCrgbAt(r, c, highlight_color);
+        ::LEDControl.setCrgbAt(LEDAddr(r, c), highlight_color);
       else
-        ::LEDControl.refreshAt(r, c);
+        ::LEDControl.refreshAt(LEDAddr(r, c));
     }
   }
 

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.h
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.h
@@ -40,7 +40,7 @@ class ActiveModColorEffect : public kaleidoscope::Plugin {
 
  private:
   static bool highlight_normal_modifiers_;
-  static uint8_t mod_keys_[MAX_MODS_PER_LAYER];
+  static KeyAddr mod_keys_[MAX_MODS_PER_LAYER];
   static uint8_t mod_key_count_;
 };
 }

--- a/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
@@ -90,7 +90,9 @@ void AlphaSquare::display(uint16_t symbol, KeyLEDAddr led_addr, cRGB key_color) 
       if (!pixel)
         continue;
 
-      ::LEDControl.setCrgbAt(KeyLEDAddr(led_addr.row() + r, led_addr.col() + c), key_color);
+      KeyLEDAddr shifted_addr = led_addr.shifted(r, c);
+
+      ::LEDControl.setCrgbAt(shifted_addr, key_color);
     }
   }
 
@@ -126,8 +128,8 @@ bool AlphaSquare::isSymbolPart(uint16_t symbol,
     for (uint8_t c = 0; c < 4; c++) {
       uint8_t pixel = bitRead(symbol, r * 4 + c);
 
-      if (displayLedAddr.row() + r == led_addr.row() &&
-          displayLedAddr.col() + c == led_addr.col())
+      KeyLEDAddr addr_shifted = displayLedAddr.shifted(r, c);
+      if (addr_shifted == led_addr)
         return !!pixel;
     }
   }

--- a/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
@@ -63,7 +63,7 @@ static const uint16_t alphabet[] PROGMEM = {
 
 cRGB AlphaSquare::color = {0x80, 0x80, 0x80};
 
-void AlphaSquare::display(Key key, LEDAddr led_addr, cRGB key_color) {
+void AlphaSquare::display(Key key, KeyLEDAddr led_addr, cRGB key_color) {
   if (!Kaleidoscope.has_leds)
     return;
 
@@ -76,11 +76,11 @@ void AlphaSquare::display(Key key, LEDAddr led_addr, cRGB key_color) {
   display(symbol, led_addr, key_color);
 }
 
-void AlphaSquare::display(Key key, LEDAddr led_addr) {
+void AlphaSquare::display(Key key, KeyLEDAddr led_addr) {
   display(key, led_addr, color);
 }
 
-void AlphaSquare::display(uint16_t symbol, LEDAddr led_addr, cRGB key_color) {
+void AlphaSquare::display(uint16_t symbol, KeyLEDAddr led_addr, cRGB key_color) {
   if (!Kaleidoscope.has_leds)
     return;
 
@@ -90,20 +90,20 @@ void AlphaSquare::display(uint16_t symbol, LEDAddr led_addr, cRGB key_color) {
       if (!pixel)
         continue;
 
-      ::LEDControl.setCrgbAt(LEDAddr(led_addr.row() + r, led_addr.col() + c), key_color);
+      ::LEDControl.setCrgbAt(KeyLEDAddr(led_addr.row() + r, led_addr.col() + c), key_color);
     }
   }
 
   ::LEDControl.syncLeds();
 }
 
-void AlphaSquare::display(uint16_t symbol, LEDAddr led_addr) {
+void AlphaSquare::display(uint16_t symbol, KeyLEDAddr led_addr) {
   display(symbol, led_addr, color);
 }
 
 bool AlphaSquare::isSymbolPart(Key key,
-                               LEDAddr displayLedAddr,
-                               LEDAddr led_addr) {
+                               KeyLEDAddr displayLedAddr,
+                               KeyLEDAddr led_addr) {
   if (!Kaleidoscope.has_leds)
     return false;
 
@@ -117,8 +117,8 @@ bool AlphaSquare::isSymbolPart(Key key,
 }
 
 bool AlphaSquare::isSymbolPart(uint16_t symbol,
-                               LEDAddr displayLedAddr,
-                               LEDAddr led_addr) {
+                               KeyLEDAddr displayLedAddr,
+                               KeyLEDAddr led_addr) {
   if (!Kaleidoscope.has_leds)
     return false;
 

--- a/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
@@ -63,7 +63,7 @@ static const uint16_t alphabet[] PROGMEM = {
 
 cRGB AlphaSquare::color = {0x80, 0x80, 0x80};
 
-void AlphaSquare::display(Key key, uint8_t row, uint8_t col, cRGB key_color) {
+void AlphaSquare::display(Key key, LEDAddr led_addr, cRGB key_color) {
   if (!Kaleidoscope.has_leds)
     return;
 
@@ -73,14 +73,14 @@ void AlphaSquare::display(Key key, uint8_t row, uint8_t col, cRGB key_color) {
   uint8_t index = key.keyCode - Key_A.keyCode;
   uint16_t symbol = pgm_read_word(&alphabet[index]);
 
-  display(symbol, row, col, key_color);
+  display(symbol, led_addr, key_color);
 }
 
-void AlphaSquare::display(Key key, uint8_t row, uint8_t col) {
-  display(key, row, col, color);
+void AlphaSquare::display(Key key, LEDAddr led_addr) {
+  display(key, led_addr, color);
 }
 
-void AlphaSquare::display(uint16_t symbol, uint8_t row, uint8_t col, cRGB key_color) {
+void AlphaSquare::display(uint16_t symbol, LEDAddr led_addr, cRGB key_color) {
   if (!Kaleidoscope.has_leds)
     return;
 
@@ -90,20 +90,20 @@ void AlphaSquare::display(uint16_t symbol, uint8_t row, uint8_t col, cRGB key_co
       if (!pixel)
         continue;
 
-      ::LEDControl.setCrgbAt(row + r, col + c, key_color);
+      ::LEDControl.setCrgbAt(LEDAddr(led_addr.row() + r, led_addr.col() + c), key_color);
     }
   }
 
   ::LEDControl.syncLeds();
 }
 
-void AlphaSquare::display(uint16_t symbol, uint8_t row, uint8_t col) {
-  display(symbol, row, col, color);
+void AlphaSquare::display(uint16_t symbol, LEDAddr led_addr) {
+  display(symbol, led_addr, color);
 }
 
 bool AlphaSquare::isSymbolPart(Key key,
-                               uint8_t display_row, uint8_t display_col,
-                               uint8_t row, uint8_t col) {
+                               LEDAddr displayLedAddr,
+                               LEDAddr led_addr) {
   if (!Kaleidoscope.has_leds)
     return false;
 
@@ -113,12 +113,12 @@ bool AlphaSquare::isSymbolPart(Key key,
   uint8_t index = key.keyCode - Key_A.keyCode;
   uint16_t symbol = pgm_read_word(&alphabet[index]);
 
-  return isSymbolPart(symbol, display_row, display_col, row, col);
+  return isSymbolPart(symbol, displayLedAddr, led_addr);
 }
 
 bool AlphaSquare::isSymbolPart(uint16_t symbol,
-                               uint8_t display_row, uint8_t display_col,
-                               uint8_t row, uint8_t col) {
+                               LEDAddr displayLedAddr,
+                               LEDAddr led_addr) {
   if (!Kaleidoscope.has_leds)
     return false;
 
@@ -126,8 +126,8 @@ bool AlphaSquare::isSymbolPart(uint16_t symbol,
     for (uint8_t c = 0; c < 4; c++) {
       uint8_t pixel = bitRead(symbol, r * 4 + c);
 
-      if (display_row + r == row &&
-          display_col + c == col)
+      if (displayLedAddr.row() + r == led_addr.row() &&
+          displayLedAddr.col() + c == led_addr.col())
         return !!pixel;
     }
   }

--- a/src/kaleidoscope/plugin/LED-AlphaSquare.h
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare.h
@@ -37,50 +37,78 @@ class AlphaSquare : public kaleidoscope::Plugin {
  public:
   AlphaSquare(void) {}
 
-  static void display(Key key, uint8_t row, uint8_t col, cRGB key_color);
-  static void display(Key key, uint8_t row, uint8_t col);
+  static void display(Key key, LEDAddr led_addr, cRGB key_color);
+  KS_ROW_COL_FUNC static void display(Key key, uint8_t row, uint8_t col, cRGB key_color) {
+    display(key, LEDAddr(row, col), key_color);
+  }
+  static void display(Key key, LEDAddr led_addr);
+  KS_ROW_COL_FUNC static void display(Key key, uint8_t row, uint8_t col) {
+    display(key, LEDAddr(row, col));
+  }
   static void display(Key key) {
-    display(key, 0, 2);
+    display(key, LEDAddr(0, 2));
   }
   static void display(Key key, uint8_t col) {
-    display(key, 0, col);
+    display(key, LEDAddr(0, col));
   }
 
-  static void display(uint16_t symbol, uint8_t row, uint8_t col, cRGB key_color);
-  static void display(uint16_t symbol, uint8_t row, uint8_t col);
+  static void display(uint16_t symbol, LEDAddr led_addr, cRGB key_color);
+  KS_ROW_COL_FUNC static void display(uint16_t symbol, uint8_t row, uint8_t col, cRGB key_color) {
+    display(symbol, LEDAddr(row, col), key_color);
+  }
+  static void display(uint16_t symbol, LEDAddr led_addr);
+  KS_ROW_COL_FUNC static void display(uint16_t symbol, uint8_t row, uint8_t col) {
+    display(symbol, LEDAddr(row, col));
+  }
   static void display(uint16_t symbol) {
-    display(symbol, 0, 2);
+    display(symbol, LEDAddr(0, 2));
   }
   static void display(uint16_t symbol, uint8_t col) {
-    display(symbol, 0, col);
+    display(symbol, LEDAddr(0, col));
   }
 
-  static void clear(Key key, uint8_t row, uint8_t col) {
-    display(key, row, col, {0, 0, 0});
+  static void clear(Key key, LEDAddr led_addr) {
+    display(key, led_addr, {0, 0, 0});
+  }
+  KS_ROW_COL_FUNC static void clear(Key key, uint8_t row, uint8_t col) {
+    clear(key, LEDAddr(row, col));
   }
   static void clear(Key key, uint8_t col) {
-    clear(key, 0, col);
+    clear(key, LEDAddr(0, col));
   }
   static void clear(Key key) {
-    clear(key, 0, 2);
+    clear(key, LEDAddr(0, 2));
   }
 
-  static void clear(uint16_t symbol, uint8_t row, uint8_t col) {
-    display(symbol, row, col, {0, 0, 0});
+  static void clear(uint16_t symbol, LEDAddr led_addr) {
+    display(symbol, led_addr, {0, 0, 0});
+  }
+  KS_ROW_COL_FUNC static void clear(uint16_t symbol, uint8_t row, uint8_t col) {
+    clear(symbol, LEDAddr(row, col));
   }
   static void clear(uint16_t symbol, uint8_t col) {
-    clear(symbol, 0, col);
+    clear(symbol, LEDAddr(0, col));
   }
   static void clear(uint16_t symbol) {
-    clear(symbol, 0, 2);
+    clear(symbol, LEDAddr(0, 2));
   }
 
   static bool isSymbolPart(Key key,
-                           uint8_t display_row, uint8_t display_col,
-                           uint8_t row, uint8_t col);
+                           LEDAddr displayLedAddr,
+                           LEDAddr led_addr);
+  KS_ROW_COL_FUNC static bool isSymbolPart(Key key,
+      uint8_t display_row, uint8_t display_col,
+      uint8_t row, uint8_t col) {
+    return isSymbolPart(key, LEDAddr(display_row, display_col), LEDAddr(row, col));
+  }
   static bool isSymbolPart(uint16_t symbol,
-                           uint8_t display_row, uint8_t display_col,
-                           uint8_t row, uint8_t col);
+                           LEDAddr displayLedAddr,
+                           LEDAddr led_addr);
+  KS_ROW_COL_FUNC static bool isSymbolPart(uint16_t symbol,
+      uint8_t display_row, uint8_t display_col,
+      uint8_t row, uint8_t col) {
+    return isSymbolPart(symbol, LEDAddr(display_row, display_col), LEDAddr(row, col));
+  }
 
   static cRGB color;
 };

--- a/src/kaleidoscope/plugin/LED-AlphaSquare.h
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare.h
@@ -35,9 +35,7 @@ namespace kaleidoscope {
 namespace plugin {
 class AlphaSquare : public kaleidoscope::Plugin {
  public:
-  
-  static constexpr KeyLEDAddr base_pos = KeyLEDAddr{0, 2};
-  
+
   AlphaSquare(void) {}
 
   static void display(Key key, KeyLEDAddr led_addr, cRGB key_color);
@@ -49,7 +47,7 @@ class AlphaSquare : public kaleidoscope::Plugin {
     display(key, KeyLEDAddr(row, col));
   }
   static void display(Key key) {
-    display(key, base_pos);
+    display(key, KeyLEDAddr{0, 2});
   }
   static void display(Key key, uint8_t col) {
     display(key, KeyLEDAddr(0, col));
@@ -64,7 +62,7 @@ class AlphaSquare : public kaleidoscope::Plugin {
     display(symbol, KeyLEDAddr(row, col));
   }
   static void display(uint16_t symbol) {
-    display(symbol, base_pos);
+    display(symbol, KeyLEDAddr{0, 2});
   }
   static void display(uint16_t symbol, uint8_t col) {
     display(symbol, KeyLEDAddr(0, col));
@@ -80,7 +78,7 @@ class AlphaSquare : public kaleidoscope::Plugin {
     clear(key, KeyLEDAddr(0, col));
   }
   static void clear(Key key) {
-    clear(key, base_pos);
+    clear(key, KeyLEDAddr{0, 2});
   }
 
   static void clear(uint16_t symbol, KeyLEDAddr led_addr) {
@@ -93,7 +91,7 @@ class AlphaSquare : public kaleidoscope::Plugin {
     clear(symbol, KeyLEDAddr(0, col));
   }
   static void clear(uint16_t symbol) {
-    clear(symbol, base_pos);
+    clear(symbol, KeyLEDAddr{0, 2});
   }
 
   static bool isSymbolPart(Key key,

--- a/src/kaleidoscope/plugin/LED-AlphaSquare.h
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare.h
@@ -35,6 +35,9 @@ namespace kaleidoscope {
 namespace plugin {
 class AlphaSquare : public kaleidoscope::Plugin {
  public:
+  
+  static constexpr LEDAddr base_pos = LEDAddr{0, 2};
+  
   AlphaSquare(void) {}
 
   static void display(Key key, LEDAddr led_addr, cRGB key_color);
@@ -46,7 +49,7 @@ class AlphaSquare : public kaleidoscope::Plugin {
     display(key, LEDAddr(row, col));
   }
   static void display(Key key) {
-    display(key, LEDAddr(0, 2));
+    display(key, base_pos);
   }
   static void display(Key key, uint8_t col) {
     display(key, LEDAddr(0, col));
@@ -61,7 +64,7 @@ class AlphaSquare : public kaleidoscope::Plugin {
     display(symbol, LEDAddr(row, col));
   }
   static void display(uint16_t symbol) {
-    display(symbol, LEDAddr(0, 2));
+    display(symbol, base_pos);
   }
   static void display(uint16_t symbol, uint8_t col) {
     display(symbol, LEDAddr(0, col));
@@ -77,7 +80,7 @@ class AlphaSquare : public kaleidoscope::Plugin {
     clear(key, LEDAddr(0, col));
   }
   static void clear(Key key) {
-    clear(key, LEDAddr(0, 2));
+    clear(key, base_pos);
   }
 
   static void clear(uint16_t symbol, LEDAddr led_addr) {
@@ -90,7 +93,7 @@ class AlphaSquare : public kaleidoscope::Plugin {
     clear(symbol, LEDAddr(0, col));
   }
   static void clear(uint16_t symbol) {
-    clear(symbol, LEDAddr(0, 2));
+    clear(symbol, base_pos);
   }
 
   static bool isSymbolPart(Key key,

--- a/src/kaleidoscope/plugin/LED-AlphaSquare.h
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare.h
@@ -36,81 +36,81 @@ namespace plugin {
 class AlphaSquare : public kaleidoscope::Plugin {
  public:
   
-  static constexpr LEDAddr base_pos = LEDAddr{0, 2};
+  static constexpr KeyLEDAddr base_pos = KeyLEDAddr{0, 2};
   
   AlphaSquare(void) {}
 
-  static void display(Key key, LEDAddr led_addr, cRGB key_color);
+  static void display(Key key, KeyLEDAddr led_addr, cRGB key_color);
   KS_ROW_COL_FUNC static void display(Key key, uint8_t row, uint8_t col, cRGB key_color) {
-    display(key, LEDAddr(row, col), key_color);
+    display(key, KeyLEDAddr(row, col), key_color);
   }
-  static void display(Key key, LEDAddr led_addr);
+  static void display(Key key, KeyLEDAddr led_addr);
   KS_ROW_COL_FUNC static void display(Key key, uint8_t row, uint8_t col) {
-    display(key, LEDAddr(row, col));
+    display(key, KeyLEDAddr(row, col));
   }
   static void display(Key key) {
     display(key, base_pos);
   }
   static void display(Key key, uint8_t col) {
-    display(key, LEDAddr(0, col));
+    display(key, KeyLEDAddr(0, col));
   }
 
-  static void display(uint16_t symbol, LEDAddr led_addr, cRGB key_color);
+  static void display(uint16_t symbol, KeyLEDAddr led_addr, cRGB key_color);
   KS_ROW_COL_FUNC static void display(uint16_t symbol, uint8_t row, uint8_t col, cRGB key_color) {
-    display(symbol, LEDAddr(row, col), key_color);
+    display(symbol, KeyLEDAddr(row, col), key_color);
   }
-  static void display(uint16_t symbol, LEDAddr led_addr);
+  static void display(uint16_t symbol, KeyLEDAddr led_addr);
   KS_ROW_COL_FUNC static void display(uint16_t symbol, uint8_t row, uint8_t col) {
-    display(symbol, LEDAddr(row, col));
+    display(symbol, KeyLEDAddr(row, col));
   }
   static void display(uint16_t symbol) {
     display(symbol, base_pos);
   }
   static void display(uint16_t symbol, uint8_t col) {
-    display(symbol, LEDAddr(0, col));
+    display(symbol, KeyLEDAddr(0, col));
   }
 
-  static void clear(Key key, LEDAddr led_addr) {
+  static void clear(Key key, KeyLEDAddr led_addr) {
     display(key, led_addr, {0, 0, 0});
   }
   KS_ROW_COL_FUNC static void clear(Key key, uint8_t row, uint8_t col) {
-    clear(key, LEDAddr(row, col));
+    clear(key, KeyLEDAddr(row, col));
   }
   static void clear(Key key, uint8_t col) {
-    clear(key, LEDAddr(0, col));
+    clear(key, KeyLEDAddr(0, col));
   }
   static void clear(Key key) {
     clear(key, base_pos);
   }
 
-  static void clear(uint16_t symbol, LEDAddr led_addr) {
+  static void clear(uint16_t symbol, KeyLEDAddr led_addr) {
     display(symbol, led_addr, {0, 0, 0});
   }
   KS_ROW_COL_FUNC static void clear(uint16_t symbol, uint8_t row, uint8_t col) {
-    clear(symbol, LEDAddr(row, col));
+    clear(symbol, KeyLEDAddr(row, col));
   }
   static void clear(uint16_t symbol, uint8_t col) {
-    clear(symbol, LEDAddr(0, col));
+    clear(symbol, KeyLEDAddr(0, col));
   }
   static void clear(uint16_t symbol) {
     clear(symbol, base_pos);
   }
 
   static bool isSymbolPart(Key key,
-                           LEDAddr displayLedAddr,
-                           LEDAddr led_addr);
+                           KeyLEDAddr displayLedAddr,
+                           KeyLEDAddr led_addr);
   KS_ROW_COL_FUNC static bool isSymbolPart(Key key,
       uint8_t display_row, uint8_t display_col,
       uint8_t row, uint8_t col) {
-    return isSymbolPart(key, LEDAddr(display_row, display_col), LEDAddr(row, col));
+    return isSymbolPart(key, KeyLEDAddr(display_row, display_col), KeyLEDAddr(row, col));
   }
   static bool isSymbolPart(uint16_t symbol,
-                           LEDAddr displayLedAddr,
-                           LEDAddr led_addr);
+                           KeyLEDAddr displayLedAddr,
+                           KeyLEDAddr led_addr);
   KS_ROW_COL_FUNC static bool isSymbolPart(uint16_t symbol,
       uint8_t display_row, uint8_t display_col,
       uint8_t row, uint8_t col) {
-    return isSymbolPart(symbol, LEDAddr(display_row, display_col), LEDAddr(row, col));
+    return isSymbolPart(symbol, KeyLEDAddr(display_row, display_col), KeyLEDAddr(row, col));
   }
 
   static cRGB color;

--- a/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
@@ -38,7 +38,7 @@ void AlphaSquareEffect::update(void) {
   }
 }
 
-void AlphaSquareEffect::refreshAt(LEDAddr led_addr) {
+void AlphaSquareEffect::refreshAt(KeyLEDAddr led_addr) {
   bool timed_out;
   uint8_t display_col = 2;
   Key key = last_key_left_;
@@ -51,7 +51,7 @@ void AlphaSquareEffect::refreshAt(LEDAddr led_addr) {
     timed_out = !end_time_right_ || (end_time_right_ && millis() > end_time_right_);
   }
 
-  if (!::AlphaSquare.isSymbolPart(key, LEDAddr(0, display_col), led_addr) || timed_out)
+  if (!::AlphaSquare.isSymbolPart(key, KeyLEDAddr(0, display_col), led_addr) || timed_out)
     ::LEDControl.setCrgbAt(led_addr, CRGB(0, 0, 0));
 }
 

--- a/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
@@ -38,12 +38,12 @@ void AlphaSquareEffect::update(void) {
   }
 }
 
-void AlphaSquareEffect::refreshAt(byte row, byte col) {
+void AlphaSquareEffect::refreshAt(LEDAddr led_addr) {
   bool timed_out;
   uint8_t display_col = 2;
   Key key = last_key_left_;
 
-  if (col < COLS / 2) {
+  if (led_addr.col() < COLS / 2) {
     timed_out = !end_time_left_ || (end_time_left_ && millis() > end_time_left_);
   } else {
     key = last_key_right_;
@@ -51,11 +51,11 @@ void AlphaSquareEffect::refreshAt(byte row, byte col) {
     timed_out = !end_time_right_ || (end_time_right_ && millis() > end_time_right_);
   }
 
-  if (!::AlphaSquare.isSymbolPart(key, 0, display_col, row, col) || timed_out)
-    ::LEDControl.setCrgbAt(row, col, CRGB(0, 0, 0));
+  if (!::AlphaSquare.isSymbolPart(key, LEDAddr(0, display_col), led_addr) || timed_out)
+    ::LEDControl.setCrgbAt(led_addr, CRGB(0, 0, 0));
 }
 
-EventHandlerResult AlphaSquareEffect::onKeyswitchEvent(Key &mappedKey, byte row, byte col, uint8_t keyState) {
+EventHandlerResult AlphaSquareEffect::onKeyswitchEvent2(Key &mappedKey, KeyAddr key_addr, uint8_t keyState) {
   if (!Kaleidoscope.has_leds)
     return EventHandlerResult::OK;
 
@@ -74,7 +74,7 @@ EventHandlerResult AlphaSquareEffect::onKeyswitchEvent(Key &mappedKey, byte row,
   uint8_t display_col = 2;
   Key prev_key = last_key_left_;
 
-  if (col < COLS / 2) {
+  if (key_addr.col() < COLS / 2) {
     last_key_left_ = mappedKey;
     end_time_left_ = millis() + length;
   } else {

--- a/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
@@ -28,11 +28,14 @@ class AlphaSquareEffect : public LEDMode {
 
   static uint16_t length;
 
-  EventHandlerResult onKeyswitchEvent(Key &mappedKey, byte row, byte col, uint8_t keyState);
+  EventHandlerResult onKeyswitchEvent2(Key &mappedKey, KeyAddr key_addr, uint8_t keyState);
 
  protected:
   void update(void) final;
-  void refreshAt(byte row, byte col) final;
+  void refreshAt(LEDAddr led_addr) final;
+  KS_ROW_COL_FUNC void refreshAt(byte row, byte col) final {
+    refreshAt(LEDAddr(row, col));
+  }
 
  private:
   static uint32_t end_time_left_, end_time_right_;

--- a/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
@@ -32,9 +32,9 @@ class AlphaSquareEffect : public LEDMode {
 
  protected:
   void update(void) final;
-  void refreshAt(LEDAddr led_addr) final;
+  void refreshAt(KeyLEDAddr led_addr) final;
   KS_ROW_COL_FUNC void refreshAt(byte row, byte col) final {
-    refreshAt(LEDAddr(row, col));
+    refreshAt(KeyLEDAddr(row, col));
   }
 
  private:

--- a/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -38,9 +38,10 @@ void LEDPaletteTheme::updateHandler(uint16_t theme_base, uint8_t theme) {
 
   uint16_t map_base = theme_base + (theme * ROWS * COLS / 2);
 
-  for (uint16_t pos = 0; pos < ROWS * COLS; pos++) {
+  for (auto led_addr : LEDAddr{}) {
+    uint16_t pos = KeyboardHardware.getLedIndex(led_addr);
     cRGB color = lookupColorAtPosition(map_base, pos);
-    ::LEDControl.setCrgbAt(pos, color);
+    ::LEDControl.setCrgbAt(led_addr, color);
   }
 }
 
@@ -49,10 +50,10 @@ void LEDPaletteTheme::refreshAt(uint16_t theme_base, uint8_t theme, LEDAddr led_
     return;
 
   uint16_t map_base = theme_base + (theme * ROWS * COLS / 2);
-  uint16_t pos = KeyboardHardware.getLedIndex(led_addr);
+  uint8_t pos = KeyboardHardware.getLedIndex(led_addr);
 
   cRGB color = lookupColorAtPosition(map_base, pos);
-  ::LEDControl.setCrgbAt(pos, color);
+  ::LEDControl.setCrgbAt(LEDAddr(pos), color);
 }
 
 

--- a/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -44,7 +44,7 @@ void LEDPaletteTheme::updateHandler(uint16_t theme_base, uint8_t theme) {
    }
 }
 
-void LEDPaletteTheme::refreshAt(uint16_t theme_base, uint8_t theme, LEDAddr led_addr) {
+void LEDPaletteTheme::refreshAt(uint16_t theme_base, uint8_t theme, KeyLEDAddr led_addr) {
   if (!Kaleidoscope.has_leds)
     return;
 
@@ -52,7 +52,7 @@ void LEDPaletteTheme::refreshAt(uint16_t theme_base, uint8_t theme, LEDAddr led_
   uint8_t pos = KeyboardHardware.getLedIndex(led_addr);
 
   cRGB color = lookupColorAtPosition(map_base, pos);
-  ::LEDControl.setCrgbAt(LEDAddr(pos), color);
+  ::LEDControl.setCrgbAt(KeyLEDAddr(pos), color);
 }
 
 

--- a/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -37,12 +37,11 @@ void LEDPaletteTheme::updateHandler(uint16_t theme_base, uint8_t theme) {
     return;
 
   uint16_t map_base = theme_base + (theme * ROWS * COLS / 2);
-
-  for (auto led_addr : LEDAddr{}) {
-    uint16_t pos = KeyboardHardware.getLedIndex(led_addr);
-    cRGB color = lookupColorAtPosition(map_base, pos);
-    ::LEDControl.setCrgbAt(led_addr, color);
-  }
+  
+  for (uint8_t pos = 0; pos < ROWS * COLS; pos++) {
+     cRGB color = lookupColorAtPosition(map_base, pos);
+    ::LEDControl.setCrgbAt(pos, color);
+   }
 }
 
 void LEDPaletteTheme::refreshAt(uint16_t theme_base, uint8_t theme, LEDAddr led_addr) {

--- a/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -37,11 +37,11 @@ void LEDPaletteTheme::updateHandler(uint16_t theme_base, uint8_t theme) {
     return;
 
   uint16_t map_base = theme_base + (theme * ROWS * COLS / 2);
-  
+
   for (uint8_t pos = 0; pos < ROWS * COLS; pos++) {
-     cRGB color = lookupColorAtPosition(map_base, pos);
+    cRGB color = lookupColorAtPosition(map_base, pos);
     ::LEDControl.setCrgbAt(pos, color);
-   }
+  }
 }
 
 void LEDPaletteTheme::refreshAt(uint16_t theme_base, uint8_t theme, KeyLEDAddr led_addr) {

--- a/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -44,12 +44,12 @@ void LEDPaletteTheme::updateHandler(uint16_t theme_base, uint8_t theme) {
   }
 }
 
-void LEDPaletteTheme::refreshAt(uint16_t theme_base, uint8_t theme, byte row, byte col) {
+void LEDPaletteTheme::refreshAt(uint16_t theme_base, uint8_t theme, LEDAddr led_addr) {
   if (!Kaleidoscope.has_leds)
     return;
 
   uint16_t map_base = theme_base + (theme * ROWS * COLS / 2);
-  uint16_t pos = KeyboardHardware.getLedIndex(row, col);
+  uint16_t pos = KeyboardHardware.getLedIndex(led_addr);
 
   cRGB color = lookupColorAtPosition(map_base, pos);
   ::LEDControl.setCrgbAt(pos, color);

--- a/src/kaleidoscope/plugin/LED-Palette-Theme.h
+++ b/src/kaleidoscope/plugin/LED-Palette-Theme.h
@@ -29,9 +29,9 @@ class LEDPaletteTheme : public kaleidoscope::Plugin {
 
   static uint16_t reserveThemes(uint8_t max_themes);
   static void updateHandler(uint16_t theme_base, uint8_t theme);
-  static void refreshAt(uint16_t theme_base, uint8_t theme, LEDAddr led_addr);
+  static void refreshAt(uint16_t theme_base, uint8_t theme, KeyLEDAddr led_addr);
   KS_ROW_COL_FUNC static void refreshAt(uint16_t theme_base, uint8_t theme, byte row, byte col) {
-    refreshAt(theme_base, theme, LEDAddr(row, col));
+    refreshAt(theme_base, theme, KeyLEDAddr(row, col));
   }
 
   static const uint8_t lookupColorIndexAtPosition(uint16_t theme_base, uint16_t position);

--- a/src/kaleidoscope/plugin/LED-Palette-Theme.h
+++ b/src/kaleidoscope/plugin/LED-Palette-Theme.h
@@ -29,7 +29,10 @@ class LEDPaletteTheme : public kaleidoscope::Plugin {
 
   static uint16_t reserveThemes(uint8_t max_themes);
   static void updateHandler(uint16_t theme_base, uint8_t theme);
-  static void refreshAt(uint16_t theme_base, uint8_t theme, byte row, byte col);
+  static void refreshAt(uint16_t theme_base, uint8_t theme, LEDAddr led_addr);
+  KS_ROW_COL_FUNC static void refreshAt(uint16_t theme_base, uint8_t theme, byte row, byte col) {
+    refreshAt(theme_base, theme, LEDAddr(row, col));
+  }
 
   static const uint8_t lookupColorIndexAtPosition(uint16_t theme_base, uint16_t position);
   static const cRGB lookupColorAtPosition(uint16_t theme_base, uint16_t position);

--- a/src/kaleidoscope/plugin/LED-Stalker.cpp
+++ b/src/kaleidoscope/plugin/LED-Stalker.cpp
@@ -32,15 +32,15 @@ void StalkerEffect::onActivate(void) {
   memset(map_, 0, sizeof(map_));
 }
 
-EventHandlerResult StalkerEffect::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState) {
+EventHandlerResult StalkerEffect::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
   if (!Kaleidoscope.has_leds)
     return EventHandlerResult::OK;
 
-  if (row >= ROWS || col >= COLS)
+  if (!key_addr.isValid())
     return EventHandlerResult::OK;
 
   if (keyIsPressed(keyState)) {
-    map_[row][col] = 0xff;
+    map_[key_addr.row()][key_addr.col()] = 0xff;
   }
 
   return EventHandlerResult::OK;
@@ -61,13 +61,13 @@ void StalkerEffect::update(void) {
     for (byte c = 0; c < COLS; c++) {
       uint8_t step = map_[r][c];
       if (step) {
-        ::LEDControl.setCrgbAt(r, c, variant->compute(&step));
+        ::LEDControl.setCrgbAt(LEDAddr(r, c), variant->compute(&step));
       }
 
       map_[r][c] = step;
 
       if (!map_[r][c])
-        ::LEDControl.setCrgbAt(r, c, inactive_color);
+        ::LEDControl.setCrgbAt(LEDAddr(r, c), inactive_color);
     }
   }
 

--- a/src/kaleidoscope/plugin/LED-Stalker.cpp
+++ b/src/kaleidoscope/plugin/LED-Stalker.cpp
@@ -20,7 +20,7 @@
 namespace kaleidoscope {
 namespace plugin {
 
-uint8_t StalkerEffect::map_[ROWS][COLS];
+uint8_t StalkerEffect::map_[kaleidoscope::num_keys];
 StalkerEffect::ColorComputer *StalkerEffect::variant;
 uint16_t StalkerEffect::step_length = 50;
 uint16_t StalkerEffect::step_start_time_;
@@ -40,7 +40,7 @@ EventHandlerResult StalkerEffect::onKeyswitchEvent2(Key &mapped_key, KeyAddr key
     return EventHandlerResult::OK;
 
   if (keyIsPressed(keyState)) {
-    map_[key_addr.row()][key_addr.col()] = 0xff;
+    map_[key_addr.toInt()] = 0xff;
   }
 
   return EventHandlerResult::OK;
@@ -57,18 +57,16 @@ void StalkerEffect::update(void) {
   if (elapsed < step_length)
     return;
 
-  for (byte r = 0; r < ROWS; r++) {
-    for (byte c = 0; c < COLS; c++) {
-      uint8_t step = map_[r][c];
-      if (step) {
-        ::LEDControl.setCrgbAt(LEDAddr(r, c), variant->compute(&step));
-      }
-
-      map_[r][c] = step;
-
-      if (!map_[r][c])
-        ::LEDControl.setCrgbAt(LEDAddr(r, c), inactive_color);
+  for (auto key_addr : KeyAddr{}) {
+    uint8_t step = map_[key_addr.toInt()];
+    if (step) {
+      ::LEDControl.setCrgbAt(key_addr, variant->compute(&step));
     }
+
+    map_[key_addr.toInt()] = step;
+
+    if (!map_[key_addr.toInt()])
+      ::LEDControl.setCrgbAt(key_addr, inactive_color);
   }
 
   step_start_time_ = Kaleidoscope.millisAtCycleStart();

--- a/src/kaleidoscope/plugin/LED-Stalker.h
+++ b/src/kaleidoscope/plugin/LED-Stalker.h
@@ -37,7 +37,7 @@ class StalkerEffect : public LEDMode {
   static uint16_t step_length;
   static cRGB inactive_color;
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);
 
  protected:
   void onActivate(void) final;

--- a/src/kaleidoscope/plugin/LED-Stalker.h
+++ b/src/kaleidoscope/plugin/LED-Stalker.h
@@ -45,7 +45,7 @@ class StalkerEffect : public LEDMode {
 
  private:
   static uint16_t step_start_time_;
-  static uint8_t map_[ROWS][COLS];
+  static uint8_t map_[kaleidoscope::num_keys];
 };
 
 namespace stalker {

--- a/src/kaleidoscope/plugin/LED-Wavepool.cpp
+++ b/src/kaleidoscope/plugin/LED-Wavepool.cpp
@@ -41,13 +41,12 @@ PROGMEM const uint8_t WavepoolEffect::rc2pos[ROWS * COLS] = {
   42, 43, 44, 45, 46, 47,     58, 62, 63, 67,    50, 51, 52, 53, 54, 55,
 };
 
-EventHandlerResult WavepoolEffect::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
-  if (row >= ROWS || col >= COLS)
+EventHandlerResult WavepoolEffect::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
+  if (!key_addr.isValid())
     return EventHandlerResult::OK;
 
   if (keyIsPressed(key_state)) {
-    uint8_t offset = (row * COLS) + col;
-    surface[page][pgm_read_byte(rc2pos + offset)] = 0x7f;
+    surface[page][pgm_read_byte(rc2pos + key_addr.offset())] = 0x7f;
     frames_since_event = 0;
   }
 
@@ -203,7 +202,7 @@ void WavepoolEffect::update(void) {
 
       cRGB color = hsvToRgb(hue, saturation, value);
 
-      ::LEDControl.setCrgbAt(r, c, color);
+      ::LEDControl.setCrgbAt(LEDAddr(r, c), color);
     }
   }
 

--- a/src/kaleidoscope/plugin/LED-Wavepool.cpp
+++ b/src/kaleidoscope/plugin/LED-Wavepool.cpp
@@ -202,7 +202,7 @@ void WavepoolEffect::update(void) {
 
       cRGB color = hsvToRgb(hue, saturation, value);
 
-      ::LEDControl.setCrgbAt(LEDAddr(r, c), color);
+      ::LEDControl.setCrgbAt(KeyLEDAddr(r, c), color);
     }
   }
 

--- a/src/kaleidoscope/plugin/LED-Wavepool.cpp
+++ b/src/kaleidoscope/plugin/LED-Wavepool.cpp
@@ -46,7 +46,7 @@ EventHandlerResult WavepoolEffect::onKeyswitchEvent2(Key &mapped_key, KeyAddr ke
     return EventHandlerResult::OK;
 
   if (keyIsPressed(key_state)) {
-    surface[page][pgm_read_byte(rc2pos + key_addr.offset())] = 0x7f;
+    surface[page][pgm_read_byte(rc2pos + key_addr.toInt())] = 0x7f;
     frames_since_event = 0;
   }
 

--- a/src/kaleidoscope/plugin/LED-Wavepool.h
+++ b/src/kaleidoscope/plugin/LED-Wavepool.h
@@ -32,7 +32,7 @@ class WavepoolEffect : public LEDMode {
  public:
   WavepoolEffect(void) {}
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 
   // ms before idle animation starts after last keypress
   static uint16_t idle_timeout;

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -112,8 +112,8 @@ void LEDControl::set_all_leds_to(uint8_t r, uint8_t g, uint8_t b) {
 }
 
 void LEDControl::set_all_leds_to(cRGB color) {
-  for (int8_t i = 0; i < LED_COUNT; i++) {
-    setCrgbAt(i, color);
+  for (auto led_addr : LEDAddr{}) {
+    setCrgbAt(led_addr, color);
   }
 }
 
@@ -127,6 +127,9 @@ void LEDControl::setCrgbAt(LEDAddr led_addr, cRGB color) {
 
 cRGB LEDControl::getCrgbAt(int8_t i) {
   return KeyboardHardware.getCrgbAt(i);
+}
+cRGB LEDControl::getCrgbAt(LEDAddr led_addr) {
+  return KeyboardHardware.getCrgbAt(KeyboardHardware.getLedIndex(led_addr));
 }
 
 void LEDControl::syncLeds(void) {
@@ -258,22 +261,24 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
   }
   case THEME: {
     if (::Focus.isEOL()) {
-      for (int8_t idx = 0; idx < LED_COUNT; idx++) {
-        cRGB c = ::LEDControl.getCrgbAt(idx);
+      for (auto led_addr : LEDAddr{}) {
+        cRGB c = ::LEDControl.getCrgbAt(led_addr);
 
         ::Focus.send(c);
       }
       break;
     }
 
-    int8_t idx = 0;
-    while (idx < LED_COUNT && !::Focus.isEOL()) {
+    for (auto led_addr : LEDAddr{}) {
+      if (::Focus.isEOL()) {
+        break;
+      }
+
       cRGB color;
 
       ::Focus.read(color);
 
-      ::LEDControl.setCrgbAt(idx, color);
-      idx++;
+      ::LEDControl.setCrgbAt(led_addr, color);
     }
     break;
   }

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -121,8 +121,8 @@ void LEDControl::setCrgbAt(int8_t i, cRGB crgb) {
   KeyboardHardware.setCrgbAt(i, crgb);
 }
 
-void LEDControl::setCrgbAt(byte row, byte col, cRGB color) {
-  KeyboardHardware.setCrgbAt(row, col, color);
+void LEDControl::setCrgbAt(LEDAddr led_addr, cRGB color) {
+  KeyboardHardware.setCrgbAt(led_addr, color);
 }
 
 cRGB LEDControl::getCrgbAt(int8_t i) {
@@ -149,7 +149,7 @@ kaleidoscope::EventHandlerResult LEDControl::onSetup() {
   return EventHandlerResult::OK;
 }
 
-kaleidoscope::EventHandlerResult LEDControl::onKeyswitchEvent(Key &mappedKey, byte row, byte col, uint8_t keyState) {
+kaleidoscope::EventHandlerResult LEDControl::onKeyswitchEvent2(Key &mappedKey, KeyAddr key_addr, uint8_t keyState) {
   if (mappedKey.flags != (SYNTHETIC | IS_INTERNAL | LED_TOGGLE))
     return kaleidoscope::EventHandlerResult::OK;
 

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -112,7 +112,7 @@ void LEDControl::set_all_leds_to(uint8_t r, uint8_t g, uint8_t b) {
 }
 
 void LEDControl::set_all_leds_to(cRGB color) {
-   for (int8_t led_index = 0; led_index < LED_COUNT; led_index++) {
+  for (int8_t led_index = 0; led_index < LED_COUNT; led_index++) {
     setCrgbAt(led_index, color);
   }
 }

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -121,14 +121,14 @@ void LEDControl::setCrgbAt(int8_t led_index, cRGB crgb) {
   KeyboardHardware.setCrgbAt(led_index, crgb);
 }
 
-void LEDControl::setCrgbAt(LEDAddr led_addr, cRGB color) {
+void LEDControl::setCrgbAt(KeyLEDAddr led_addr, cRGB color) {
   KeyboardHardware.setCrgbAt(led_addr, color);
 }
 
 cRGB LEDControl::getCrgbAt(int8_t led_index) {
   return KeyboardHardware.getCrgbAt(led_index);
 }
-cRGB LEDControl::getCrgbAt(LEDAddr led_addr) {
+cRGB LEDControl::getCrgbAt(KeyLEDAddr led_addr) {
   return KeyboardHardware.getCrgbAt(KeyboardHardware.getLedIndex(led_addr));
 }
 
@@ -261,7 +261,7 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
   }
   case THEME: {
     if (::Focus.isEOL()) {
-      for (auto led_addr : LEDAddr{}) {
+      for (auto led_addr : KeyLEDAddr{}) {
         cRGB c = ::LEDControl.getCrgbAt(led_addr);
 
         ::Focus.send(c);
@@ -269,7 +269,7 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
       break;
     }
 
-    for (auto led_addr : LEDAddr{}) {
+    for (auto led_addr : KeyLEDAddr{}) {
       if (::Focus.isEOL()) {
         break;
       }

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -112,21 +112,21 @@ void LEDControl::set_all_leds_to(uint8_t r, uint8_t g, uint8_t b) {
 }
 
 void LEDControl::set_all_leds_to(cRGB color) {
-  for (auto led_addr : LEDAddr{}) {
-    setCrgbAt(led_addr, color);
+   for (int8_t led_index = 0; led_index < LED_COUNT; led_index++) {
+    setCrgbAt(led_index, color);
   }
 }
 
-void LEDControl::setCrgbAt(int8_t i, cRGB crgb) {
-  KeyboardHardware.setCrgbAt(i, crgb);
+void LEDControl::setCrgbAt(int8_t led_index, cRGB crgb) {
+  KeyboardHardware.setCrgbAt(led_index, crgb);
 }
 
 void LEDControl::setCrgbAt(LEDAddr led_addr, cRGB color) {
   KeyboardHardware.setCrgbAt(led_addr, color);
 }
 
-cRGB LEDControl::getCrgbAt(int8_t i) {
-  return KeyboardHardware.getCrgbAt(i);
+cRGB LEDControl::getCrgbAt(int8_t led_index) {
+  return KeyboardHardware.getCrgbAt(led_index);
 }
 cRGB LEDControl::getCrgbAt(LEDAddr led_addr) {
   return KeyboardHardware.getCrgbAt(KeyboardHardware.getLedIndex(led_addr));

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -85,7 +85,7 @@ class LEDMode : public kaleidoscope::Plugin {
    *
    * @param led_addr is the matrix coordinate of the key to refresh the color of.
    */
-  virtual void refreshAt(LEDAddr led_addr) {}
+  virtual void refreshAt(KeyLEDAddr led_addr) {}
 
   /** Refresh the color of a given key.
    *
@@ -98,7 +98,7 @@ class LEDMode : public kaleidoscope::Plugin {
    * @param col is the column coordinate of the key to refresh the color of.
    */
   KS_ROW_COL_FUNC virtual void refreshAt(byte row, byte col) {
-    refreshAt(LEDAddr(row, col));
+    refreshAt(KeyLEDAddr(row, col));
   }
 
  public:
@@ -128,7 +128,7 @@ class LEDControl : public kaleidoscope::Plugin {
     if (modes[mode])
       modes[mode]->update();
   }
-  static void refreshAt(LEDAddr led_addr) {
+  static void refreshAt(KeyLEDAddr led_addr) {
     if (!Kaleidoscope.has_leds)
       return;
 
@@ -136,7 +136,7 @@ class LEDControl : public kaleidoscope::Plugin {
       modes[mode]->refreshAt(led_addr);
   }
   KS_ROW_COL_FUNC static void refreshAt(byte row, byte col) {
-    refreshAt(LEDAddr(row, col));
+    refreshAt(KeyLEDAddr(row, col));
   }
   static void set_mode(uint8_t mode);
   static uint8_t get_mode_index();
@@ -156,14 +156,14 @@ class LEDControl : public kaleidoscope::Plugin {
   static int8_t mode_add(LEDMode *mode);
 
   static void setCrgbAt(int8_t led_index, cRGB crgb);
-  static void setCrgbAt(LEDAddr led_addr, cRGB color);
+  static void setCrgbAt(KeyLEDAddr led_addr, cRGB color);
   KS_ROW_COL_FUNC static void setCrgbAt(byte row, byte col, cRGB color) {
-    setCrgbAt(LEDAddr(row, col), color);
+    setCrgbAt(KeyLEDAddr(row, col), color);
   }
   static cRGB getCrgbAt(int8_t led_index);
-  static cRGB getCrgbAt(LEDAddr led_addr);
+  static cRGB getCrgbAt(KeyLEDAddr led_addr);
   KS_ROW_COL_FUNC static cRGB getCrgbAt(byte row, byte col) {
-    return getCrgbAt(LEDAddr(row, col));
+    return getCrgbAt(KeyLEDAddr(row, col));
   }
   static void syncLeds(void);
 

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -161,6 +161,10 @@ class LEDControl : public kaleidoscope::Plugin {
     setCrgbAt(LEDAddr(row, col), color);
   }
   static cRGB getCrgbAt(int8_t i);
+  static cRGB getCrgbAt(LEDAddr led_addr);
+  KS_ROW_COL_FUNC static cRGB getCrgbAt(byte row, byte col) {
+    return getCrgbAt(LEDAddr(row, col));
+  }
   static void syncLeds(void);
 
   static void set_all_leds_to(uint8_t r, uint8_t g, uint8_t b);

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -155,12 +155,12 @@ class LEDControl : public kaleidoscope::Plugin {
 
   static int8_t mode_add(LEDMode *mode);
 
-  static void setCrgbAt(int8_t i, cRGB crgb);
+  static void setCrgbAt(int8_t led_index, cRGB crgb);
   static void setCrgbAt(LEDAddr led_addr, cRGB color);
   KS_ROW_COL_FUNC static void setCrgbAt(byte row, byte col, cRGB color) {
     setCrgbAt(LEDAddr(row, col), color);
   }
-  static cRGB getCrgbAt(int8_t i);
+  static cRGB getCrgbAt(int8_t led_index);
   static cRGB getCrgbAt(LEDAddr led_addr);
   KS_ROW_COL_FUNC static cRGB getCrgbAt(byte row, byte col) {
     return getCrgbAt(LEDAddr(row, col));

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -83,10 +83,23 @@ class LEDMode : public kaleidoscope::Plugin {
    * restore whatever color the mode would set the key color to, this is the
    * method it will call.
    *
+   * @param led_addr is the matrix coordinate of the key to refresh the color of.
+   */
+  virtual void refreshAt(LEDAddr led_addr) {}
+
+  /** Refresh the color of a given key.
+   *
+   * If we have another plugin that overrides colors set by the active LED mode
+   * (either at @onActivate time, or via @ref update), if that plugin wants to
+   * restore whatever color the mode would set the key color to, this is the
+   * method it will call.
+   *
    * @param row is the row coordinate of the key to refresh the color of.
    * @param col is the column coordinate of the key to refresh the color of.
    */
-  virtual void refreshAt(byte row, byte col) {}
+  KS_ROW_COL_FUNC virtual void refreshAt(byte row, byte col) {
+    refreshAt(LEDAddr(row, col));
+  }
 
  public:
   /** Activate the current object as the LED mode.
@@ -115,12 +128,15 @@ class LEDControl : public kaleidoscope::Plugin {
     if (modes[mode])
       modes[mode]->update();
   }
-  static void refreshAt(byte row, byte col) {
+  static void refreshAt(LEDAddr led_addr) {
     if (!Kaleidoscope.has_leds)
       return;
 
     if (modes[mode])
-      modes[mode]->refreshAt(row, col);
+      modes[mode]->refreshAt(led_addr);
+  }
+  KS_ROW_COL_FUNC static void refreshAt(byte row, byte col) {
+    refreshAt(LEDAddr(row, col));
   }
   static void set_mode(uint8_t mode);
   static uint8_t get_mode_index();
@@ -140,7 +156,10 @@ class LEDControl : public kaleidoscope::Plugin {
   static int8_t mode_add(LEDMode *mode);
 
   static void setCrgbAt(int8_t i, cRGB crgb);
-  static void setCrgbAt(byte row, byte col, cRGB color);
+  static void setCrgbAt(LEDAddr led_addr, cRGB color);
+  KS_ROW_COL_FUNC static void setCrgbAt(byte row, byte col, cRGB color) {
+    setCrgbAt(LEDAddr(row, col), color);
+  }
   static cRGB getCrgbAt(int8_t i);
   static void syncLeds(void);
 
@@ -153,7 +172,7 @@ class LEDControl : public kaleidoscope::Plugin {
   static bool paused;
 
   kaleidoscope::EventHandlerResult onSetup();
-  kaleidoscope::EventHandlerResult onKeyswitchEvent(Key &mappedKey, byte row, byte col, uint8_t keyState);
+  kaleidoscope::EventHandlerResult onKeyswitchEvent2(Key &mappedKey, KeyAddr key_addr, uint8_t keyState);
   kaleidoscope::EventHandlerResult beforeReportingState();
 
  private:

--- a/src/kaleidoscope/plugin/LEDControl/LED-Off.cpp
+++ b/src/kaleidoscope/plugin/LEDControl/LED-Off.cpp
@@ -22,8 +22,8 @@ void LEDOff::onActivate(void) {
   ::LEDControl.set_all_leds_to({0, 0, 0});
 }
 
-void LEDOff::refreshAt(byte row, byte col) {
-  ::LEDControl.setCrgbAt(row, col, {0, 0, 0});
+void LEDOff::refreshAt(LEDAddr led_addr) {
+  ::LEDControl.setCrgbAt(led_addr, {0, 0, 0});
 }
 }
 }

--- a/src/kaleidoscope/plugin/LEDControl/LED-Off.cpp
+++ b/src/kaleidoscope/plugin/LEDControl/LED-Off.cpp
@@ -22,7 +22,7 @@ void LEDOff::onActivate(void) {
   ::LEDControl.set_all_leds_to({0, 0, 0});
 }
 
-void LEDOff::refreshAt(LEDAddr led_addr) {
+void LEDOff::refreshAt(KeyLEDAddr led_addr) {
   ::LEDControl.setCrgbAt(led_addr, {0, 0, 0});
 }
 }

--- a/src/kaleidoscope/plugin/LEDControl/LED-Off.h
+++ b/src/kaleidoscope/plugin/LEDControl/LED-Off.h
@@ -26,9 +26,9 @@ class LEDOff : public LEDMode {
 
  protected:
   void onActivate(void) final;
-  void refreshAt(LEDAddr led_addr) final;
+  void refreshAt(KeyLEDAddr led_addr) final;
   KS_ROW_COL_FUNC void refreshAt(byte row, byte col) final {
-    refreshAt(LEDAddr(row, col));
+    refreshAt(KeyLEDAddr(row, col));
   }
 };
 }

--- a/src/kaleidoscope/plugin/LEDControl/LED-Off.h
+++ b/src/kaleidoscope/plugin/LEDControl/LED-Off.h
@@ -26,7 +26,10 @@ class LEDOff : public LEDMode {
 
  protected:
   void onActivate(void) final;
-  void refreshAt(byte row, byte col) final;
+  void refreshAt(LEDAddr led_addr) final;
+  KS_ROW_COL_FUNC void refreshAt(byte row, byte col) final {
+    refreshAt(LEDAddr(row, col));
+  }
 };
 }
 }

--- a/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
@@ -57,7 +57,7 @@ EventHandlerResult BootAnimationEffect::afterEachCycle() {
 
   for (uint8_t r = 0; r < ROWS; r++) {
     for (uint8_t c = 0; c < COLS; c++) {
-      Key k = Layer.lookupOnActiveLayer(r, c);
+      Key k = Layer.lookupOnActiveLayer(KeyAddr(r, c));
       Key g;
       g.flags = 0;
       g.keyCode = pgm_read_word(&greeting_[current_index_]);
@@ -77,12 +77,12 @@ EventHandlerResult BootAnimationEffect::afterEachCycle() {
 
     start_time_ = Kaleidoscope.millisAtCycleStart();
     if (row != 255 && col != 255)
-      ::LEDControl.refreshAt(row, col);
+      ::LEDControl.refreshAt(LEDAddr(row, col));
     return EventHandlerResult::OK;
   }
 
   if (row != 255 && col != 255) {
-    ::LEDControl.setCrgbAt(row, col, color);
+    ::LEDControl.setCrgbAt(LEDAddr(row, col), color);
   }
 
   return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
@@ -74,12 +74,12 @@ EventHandlerResult BootAnimationEffect::afterEachCycle() {
 
     start_time_ = Kaleidoscope.millisAtCycleStart();
     if (key_addr_found.isValid())
-      ::LEDControl.refreshAt(LEDAddr(key_addr_found));
+      ::LEDControl.refreshAt(KeyLEDAddr(key_addr_found));
     return EventHandlerResult::OK;
   }
 
   if (key_addr_found.isValid()) {
-    ::LEDControl.setCrgbAt(LEDAddr(key_addr_found), color);
+    ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr_found), color);
   }
 
   return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
@@ -53,21 +53,18 @@ EventHandlerResult BootAnimationEffect::afterEachCycle() {
     return EventHandlerResult::OK;
   }
 
-  byte row = 255, col = 255;
+  KeyAddr key_addr_found;
 
-  for (uint8_t r = 0; r < ROWS; r++) {
-    for (uint8_t c = 0; c < COLS; c++) {
-      Key k = Layer.lookupOnActiveLayer(KeyAddr(r, c));
+  for(auto key_addr: KeyAddr{}) {
+      Key k = Layer.lookupOnActiveLayer(key_addr);
       Key g;
       g.flags = 0;
       g.keyCode = pgm_read_word(&greeting_[current_index_]);
 
       if (k.raw == g.raw) {
-        row = r;
-        col = c;
+        key_addr_found = key_addr;
         break;
       }
-    }
   }
 
   if ((Kaleidoscope.millisAtCycleStart() - start_time_) > timeout) {
@@ -76,13 +73,13 @@ EventHandlerResult BootAnimationEffect::afterEachCycle() {
       done_ = true;
 
     start_time_ = Kaleidoscope.millisAtCycleStart();
-    if (row != 255 && col != 255)
-      ::LEDControl.refreshAt(LEDAddr(row, col));
+    if (key_addr_found.isValid())
+      ::LEDControl.refreshAt(LEDAddr(key_addr_found));
     return EventHandlerResult::OK;
   }
 
-  if (row != 255 && col != 255) {
-    ::LEDControl.setCrgbAt(LEDAddr(row, col), color);
+  if (key_addr_found.isValid()) {
+    ::LEDControl.setCrgbAt(LEDAddr(key_addr_found), color);
   }
 
   return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
@@ -55,16 +55,16 @@ EventHandlerResult BootAnimationEffect::afterEachCycle() {
 
   KeyAddr key_addr_found;
 
-  for(auto key_addr: KeyAddr{}) {
-      Key k = Layer.lookupOnActiveLayer(key_addr);
-      Key g;
-      g.flags = 0;
-      g.keyCode = pgm_read_word(&greeting_[current_index_]);
+  for (auto key_addr : KeyAddr{}) {
+    Key k = Layer.lookupOnActiveLayer(key_addr);
+    Key g;
+    g.flags = 0;
+    g.keyCode = pgm_read_word(&greeting_[current_index_]);
 
-      if (k.raw == g.raw) {
-        key_addr_found = key_addr;
-        break;
-      }
+    if (k.raw == g.raw) {
+      key_addr_found = key_addr;
+      break;
+    }
   }
 
   if ((Kaleidoscope.millisAtCycleStart() - start_time_) > timeout) {

--- a/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
@@ -40,13 +40,13 @@ void BootGreetingEffect::findLed(void) {
   }
 
   // Find the LED key.
-  for(auto key_addr: KeyAddr{}) {
-      Key k = Layer.lookupOnActiveLayer(key_addr);
+  for (auto key_addr : KeyAddr{}) {
+    Key k = Layer.lookupOnActiveLayer(key_addr);
 
-      if (k.raw == search_key.raw) {
-        key_addr_ = key_addr;
-        return;
-      }
+    if (k.raw == search_key.raw) {
+      key_addr_ = key_addr;
+      return;
+    }
   }
 
   // We didn't find the LED key. Let's just pretend we're "done".

--- a/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
@@ -21,39 +21,32 @@ namespace kaleidoscope {
 namespace plugin {
 
 bool BootGreetingEffect::done_ = false;
-byte BootGreetingEffect::row_;
-byte BootGreetingEffect::col_;
-byte BootGreetingEffect::key_row = 255;
-byte BootGreetingEffect::key_col = 255;
+KeyAddr BootGreetingEffect::key_addr_;
+KeyAddr BootGreetingEffect::user_key_addr;
 Key BootGreetingEffect::search_key = Key_LEDEffectNext;
 uint8_t BootGreetingEffect::hue = 170;
 uint16_t BootGreetingEffect::start_time = 0;
 uint16_t BootGreetingEffect::timeout = 9200;
 
-BootGreetingEffect::BootGreetingEffect(byte pos_row, byte pos_col) {
-  key_row = pos_row;
-  key_col = pos_col;
+BootGreetingEffect::BootGreetingEffect(KeyAddr key_addr) {
+  user_key_addr = key_addr;
 }
 
 void BootGreetingEffect::findLed(void) {
-  if (key_col != 255 && key_row != 255) {
-    row_ = key_row;
-    col_ = key_col;
+  if (user_key_addr.isValid()) {
+    key_addr_ = user_key_addr;
     done_ = true;
     return;
   }
 
   // Find the LED key.
-  for (uint8_t r = 0; r < ROWS; r++) {
-    for (uint8_t c = 0; c < COLS; c++) {
-      Key k = Layer.lookupOnActiveLayer(KeyAddr(r, c));
+  for(auto key_addr: KeyAddr{}) {
+      Key k = Layer.lookupOnActiveLayer(key_addr);
 
       if (k.raw == search_key.raw) {
-        row_ = r;
-        col_ = c;
+        key_addr_ = key_addr;
         return;
       }
-    }
   }
 
   // We didn't find the LED key. Let's just pretend we're "done".
@@ -81,12 +74,12 @@ EventHandlerResult BootGreetingEffect::afterEachCycle() {
   //Only run for 'timeout' milliseconds
   if ((millis() - start_time) > timeout) {
     done_ = true;
-    ::LEDControl.refreshAt(row_, col_);
+    ::LEDControl.refreshAt(key_addr_);
     return EventHandlerResult::OK;
   }
 
   cRGB color = breath_compute(hue);
-  ::LEDControl.setCrgbAt(row_, col_, color);
+  ::LEDControl.setCrgbAt(key_addr_, color);
 
   return EventHandlerResult::OK;
 }

--- a/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
@@ -46,7 +46,7 @@ void BootGreetingEffect::findLed(void) {
   // Find the LED key.
   for (uint8_t r = 0; r < ROWS; r++) {
     for (uint8_t c = 0; c < COLS; c++) {
-      Key k = Layer.lookupOnActiveLayer(r, c);
+      Key k = Layer.lookupOnActiveLayer(KeyAddr(r, c));
 
       if (k.raw == search_key.raw) {
         row_ = r;

--- a/src/kaleidoscope/plugin/LEDEffect-BootGreeting.h
+++ b/src/kaleidoscope/plugin/LEDEffect-BootGreeting.h
@@ -26,7 +26,7 @@ class BootGreetingEffect : public kaleidoscope::Plugin {
   BootGreetingEffect(void) {}
   BootGreetingEffect(KeyAddr key_addr);
   KS_ROW_COL_FUNC BootGreetingEffect(byte row, byte col)
-     : BootGreetingEffect(KeyAddr(row, col)) {}
+    : BootGreetingEffect(KeyAddr(row, col)) {}
 
   static KeyAddr user_key_addr;
   static Key search_key;

--- a/src/kaleidoscope/plugin/LEDEffect-BootGreeting.h
+++ b/src/kaleidoscope/plugin/LEDEffect-BootGreeting.h
@@ -24,10 +24,11 @@ namespace plugin {
 class BootGreetingEffect : public kaleidoscope::Plugin {
  public:
   BootGreetingEffect(void) {}
-  BootGreetingEffect(byte, byte);
+  BootGreetingEffect(KeyAddr key_addr);
+  KS_ROW_COL_FUNC BootGreetingEffect(byte row, byte col)
+     : BootGreetingEffect(KeyAddr(row, col)) {}
 
-  static byte key_row;
-  static byte key_col;
+  static KeyAddr user_key_addr;
   static Key search_key;
   static uint8_t hue;
   static uint16_t timeout;
@@ -37,8 +38,7 @@ class BootGreetingEffect : public kaleidoscope::Plugin {
  private:
   static void findLed(void);
   static bool done_;
-  static byte row_;
-  static byte col_;
+  static KeyAddr key_addr_;
   static uint16_t start_time;
 };
 }

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
@@ -38,9 +38,9 @@ void LEDChaseEffect::update(void) {
   // changes direction, for the first few updates, `pos2` will be out of bounds.
   // Since it's an unsigned integer, even when it would have a value below zero,
   // it underflows and so one test is good for both ends of the range.
-  ::LEDControl.setCrgbAt(LEDAddr(uint8_t(pos_)), CRGB(0, 0, 0));
+  ::LEDControl.setCrgbAt(pos_, CRGB(0, 0, 0));
   if (pos2 < LED_COUNT)
-    ::LEDControl.setCrgbAt(LEDAddr(uint8_t(pos2)), CRGB(0, 0, 0));
+    ::LEDControl.setCrgbAt(pos2, CRGB(0, 0, 0));
 
   // Next, we adjust the red light's position. If the direction hasn't changed (the red
   // light isn't out of bounds), we also adjust the blue light's position to match the red
@@ -59,9 +59,9 @@ void LEDChaseEffect::update(void) {
 
   // Last, we turn on the LEDs at their new positions. As before, the blue light (pos2) is
   // only set if it's in the valid LED range.
-  ::LEDControl.setCrgbAt(LEDAddr(uint8_t(pos_)), CRGB(255, 0, 0));
+  ::LEDControl.setCrgbAt(pos_, CRGB(255, 0, 0));
   if (pos2 < LED_COUNT)
-    ::LEDControl.setCrgbAt(LEDAddr(uint8_t(pos2)), CRGB(0, 0, 255));
+    ::LEDControl.setCrgbAt(pos2, CRGB(0, 0, 255));
 }
 
 }

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
@@ -38,9 +38,9 @@ void LEDChaseEffect::update(void) {
   // changes direction, for the first few updates, `pos2` will be out of bounds.
   // Since it's an unsigned integer, even when it would have a value below zero,
   // it underflows and so one test is good for both ends of the range.
-  ::LEDControl.setCrgbAt(pos_, CRGB(0, 0, 0));
+  ::LEDControl.setCrgbAt(LEDAddr(uint8_t(pos_)), CRGB(0, 0, 0));
   if (pos2 < LED_COUNT)
-    ::LEDControl.setCrgbAt(pos2, CRGB(0, 0, 0));
+    ::LEDControl.setCrgbAt(LEDAddr(uint8_t(pos2)), CRGB(0, 0, 0));
 
   // Next, we adjust the red light's position. If the direction hasn't changed (the red
   // light isn't out of bounds), we also adjust the blue light's position to match the red
@@ -59,9 +59,9 @@ void LEDChaseEffect::update(void) {
 
   // Last, we turn on the LEDs at their new positions. As before, the blue light (pos2) is
   // only set if it's in the valid LED range.
-  ::LEDControl.setCrgbAt(pos_, CRGB(255, 0, 0));
+  ::LEDControl.setCrgbAt(LEDAddr(uint8_t(pos_)), CRGB(255, 0, 0));
   if (pos2 < LED_COUNT)
-    ::LEDControl.setCrgbAt(pos2, CRGB(0, 0, 255));
+    ::LEDControl.setCrgbAt(LEDAddr(uint8_t(pos2)), CRGB(0, 0, 255));
 }
 
 }

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.h
@@ -41,7 +41,7 @@ class LEDChaseEffect : public LEDMode {
   void update(void) final;
 
  private:
-  int8_t pos_ = 0;
+  int8_t pos_ = uint8_t(0);
   int8_t direction_ = 1;
   uint8_t distance_ = 5;
   uint16_t update_delay_ = 150;

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
@@ -61,7 +61,7 @@ void LEDRainbowWaveEffect::update(void) {
     rainbow_last_update = now;
   }
 
-  for (auto led_addr : LEDAddr{}) {
+  for (auto led_addr : KeyLEDAddr{}) {
     uint16_t key_hue = rainbow_hue + 16 * (led_addr.toInt() / 4);
     if (key_hue >= 255)          {
       key_hue -= 255;

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
@@ -67,7 +67,7 @@ void LEDRainbowWaveEffect::update(void) {
       key_hue -= 255;
     }
     cRGB rainbow = hsvToRgb(key_hue, rainbow_saturation, rainbow_value);
-    ::LEDControl.setCrgbAt(led_addr, rainbow);
+    ::LEDControl.setCrgbAt(led_addr.toInt(), rainbow);
   }
   rainbow_hue += rainbow_wave_steps;
   if (rainbow_hue >= 255) {

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
@@ -61,13 +61,13 @@ void LEDRainbowWaveEffect::update(void) {
     rainbow_last_update = now;
   }
 
-  for (int8_t i = 0; i < LED_COUNT; i++) {
-    uint16_t key_hue = rainbow_hue + 16 * (i / 4);
+  for (auto led_addr : LEDAddr{}) {
+    uint16_t key_hue = rainbow_hue + 16 * (led_addr.toInt() / 4);
     if (key_hue >= 255)          {
       key_hue -= 255;
     }
     cRGB rainbow = hsvToRgb(key_hue, rainbow_saturation, rainbow_value);
-    ::LEDControl.setCrgbAt(i, rainbow);
+    ::LEDControl.setCrgbAt(led_addr, rainbow);
   }
   rainbow_hue += rainbow_wave_steps;
   if (rainbow_hue >= 255) {

--- a/src/kaleidoscope/plugin/LEDEffect-SolidColor.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-SolidColor.cpp
@@ -28,7 +28,7 @@ void LEDSolidColor::onActivate(void) {
   ::LEDControl.set_all_leds_to(r, g, b);
 }
 
-void LEDSolidColor::refreshAt(LEDAddr led_addr) {
+void LEDSolidColor::refreshAt(KeyLEDAddr led_addr) {
   ::LEDControl.setCrgbAt(led_addr, CRGB(r, g, b));
 }
 

--- a/src/kaleidoscope/plugin/LEDEffect-SolidColor.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-SolidColor.cpp
@@ -28,8 +28,8 @@ void LEDSolidColor::onActivate(void) {
   ::LEDControl.set_all_leds_to(r, g, b);
 }
 
-void LEDSolidColor::refreshAt(byte row, byte col) {
-  ::LEDControl.setCrgbAt(row, col, CRGB(r, g, b));
+void LEDSolidColor::refreshAt(LEDAddr led_addr) {
+  ::LEDControl.setCrgbAt(led_addr, CRGB(r, g, b));
 }
 
 }

--- a/src/kaleidoscope/plugin/LEDEffect-SolidColor.h
+++ b/src/kaleidoscope/plugin/LEDEffect-SolidColor.h
@@ -26,9 +26,9 @@ class LEDSolidColor : public LEDMode {
 
  protected:
   void onActivate(void) final;
-  void refreshAt(LEDAddr led_addr) final;
+  void refreshAt(KeyLEDAddr led_addr) final;
   KS_ROW_COL_FUNC void refreshAt(byte row, byte col) final {
-    refreshAt(LEDAddr(row, col));
+    refreshAt(KeyLEDAddr(row, col));
   }
 
  private:

--- a/src/kaleidoscope/plugin/LEDEffect-SolidColor.h
+++ b/src/kaleidoscope/plugin/LEDEffect-SolidColor.h
@@ -26,7 +26,10 @@ class LEDSolidColor : public LEDMode {
 
  protected:
   void onActivate(void) final;
-  void refreshAt(byte row, byte col) final;
+  void refreshAt(LEDAddr led_addr) final;
+  KS_ROW_COL_FUNC void refreshAt(byte row, byte col) final {
+    refreshAt(LEDAddr(row, col));
+  }
 
  private:
   uint8_t r, g, b;

--- a/src/kaleidoscope/plugin/Leader.cpp
+++ b/src/kaleidoscope/plugin/Leader.cpp
@@ -77,11 +77,11 @@ void Leader::reset(void) {
 }
 
 void Leader::inject(Key key, uint8_t key_state) {
-  onKeyswitchEvent(key, UNKNOWN_KEYSWITCH_LOCATION, key_state);
+  onKeyswitchEvent2(key, UnknownKeyswitchLocation, key_state);
 }
 
 // --- hooks ---
-EventHandlerResult Leader::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState) {
+EventHandlerResult Leader::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
   if (keyState & INJECTED)
     return EventHandlerResult::OK;
 

--- a/src/kaleidoscope/plugin/Leader.h
+++ b/src/kaleidoscope/plugin/Leader.h
@@ -46,7 +46,7 @@ class Leader : public kaleidoscope::Plugin {
 
   void inject(Key key, uint8_t key_state);
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);
   EventHandlerResult afterEachCycle();
 
  private:

--- a/src/kaleidoscope/plugin/Macros.cpp
+++ b/src/kaleidoscope/plugin/Macros.cpp
@@ -223,8 +223,7 @@ EventHandlerResult Macros_::onKeyswitchEvent2(Key &mappedKey, KeyAddr key_addr, 
   if (mappedKey.flags != (SYNTHETIC | IS_MACRO))
     return EventHandlerResult::OK;
 
-  byte key_id = key_addr.offset();
-  addActiveMacroKey(mappedKey.keyCode, key_id, keyState);
+  addActiveMacroKey(mappedKey.keyCode, key_addr.toInt(), keyState);
 
   return EventHandlerResult::EVENT_CONSUMED;
 }

--- a/src/kaleidoscope/plugin/Macros.h
+++ b/src/kaleidoscope/plugin/Macros.h
@@ -53,7 +53,7 @@ class Macros_ : public kaleidoscope::Plugin {
     ++active_macro_count;
   }
 
-  EventHandlerResult onKeyswitchEvent(Key &mappedKey, byte row, byte col, uint8_t keyState);
+  EventHandlerResult onKeyswitchEvent2(Key &mappedKey, KeyAddr key_addr, uint8_t keyState);
   EventHandlerResult beforeReportingState();
   EventHandlerResult afterEachCycle();
 
@@ -74,7 +74,7 @@ class Macros_ : public kaleidoscope::Plugin {
     return type(strings...);
   }
 
-  static byte row, col;
+  static KeyAddr key_addr;
 
  private:
   Key lookupAsciiCode(uint8_t ascii_code);

--- a/src/kaleidoscope/plugin/Model01-TestMode.cpp
+++ b/src/kaleidoscope/plugin/Model01-TestMode.cpp
@@ -89,33 +89,30 @@ void TestMode::handleKeyEvent(side_data_t *side, keydata_t *oldState, keydata_t 
   constexpr cRGB blue = CRGB(0, 0, 201);
   constexpr cRGB green = CRGB(0, 201, 0);
 
-  auto row = key_addr.row();
-  auto col = key_addr.col();
+  auto key_id = key_addr.toInt();
 
-  const uint8_t keynum = (row * 8) + (col);
-
-  const uint8_t keyState = ((bitRead(oldState->all, keynum) << 1) |
-                            (bitRead(newState->all, keynum) << 0));
+  const uint8_t keyState = ((bitRead(oldState->all, key_id) << 1) |
+                            (bitRead(newState->all, key_id) << 0));
   if (keyState == TOGGLED_ON) {
-    if (side->cyclesSinceStateChange[keynum] < CHATTER_CYCLE_LIMIT) {
-      bitSet(side->badKeys, keynum);
+    if (side->cyclesSinceStateChange[key_id] < CHATTER_CYCLE_LIMIT) {
+      bitSet(side->badKeys, key_id);
     }
-    side->cyclesSinceStateChange[keynum] = 0;
-  } else if (side->cyclesSinceStateChange[keynum] <= CHATTER_CYCLE_LIMIT)  {
-    side->cyclesSinceStateChange[keynum]++;
+    side->cyclesSinceStateChange[key_id] = 0;
+  } else if (side->cyclesSinceStateChange[key_id] <= CHATTER_CYCLE_LIMIT)  {
+    side->cyclesSinceStateChange[key_id]++;
   }
 
 
 
   // If the key is held down
   if (keyState == HELD) {
-    KeyboardHardware.setCrgbAt(LEDAddr(row, col_offset - col), green);
-  } else if (bitRead(side->badKeys, keynum) == 1) {
+    KeyboardHardware.setCrgbAt(LEDAddr(key_addr.row(), col_offset - key_addr.col()), green);
+  } else if (bitRead(side->badKeys, key_addr.toInt()) == 1) {
     // If we triggered chatter detection ever on this key
-    KeyboardHardware.setCrgbAt(LEDAddr(row, col_offset - col), red);
+    KeyboardHardware.setCrgbAt(LEDAddr(key_addr.row(), col_offset - key_addr.col()), red);
   } else if (keyState == TOGGLED_OFF) {
     // If the key was just released
-    KeyboardHardware.setCrgbAt(LEDAddr(row, col_offset - col), blue);
+    KeyboardHardware.setCrgbAt(LEDAddr(key_addr.row(), col_offset - key_addr.col()), blue);
   }
 }
 
@@ -137,11 +134,9 @@ void TestMode::testMatrix() {
         KeyboardHardware.pressedKeyswitchCount() == 3) {
       break;
     }
-    for (byte row = 0; row < 4; row++) {
-      for (byte col = 0; col < 8; col++) {
-        handleKeyEvent(&left, &(KeyboardHardware.previousLeftHandState), &(KeyboardHardware.leftHandState), KeyAddr(row, col), 7);
-        handleKeyEvent(&right, &(KeyboardHardware.previousRightHandState), &(KeyboardHardware.rightHandState), KeyAddr(row, col), 15);
-      }
+    for (auto key_addr : KeyAddr{}) {
+      handleKeyEvent(&left, &(KeyboardHardware.previousLeftHandState), &(KeyboardHardware.leftHandState), key_addr, 7);
+      handleKeyEvent(&right, &(KeyboardHardware.previousRightHandState), &(KeyboardHardware.rightHandState), key_addr, 15);
     }
     ::LEDControl.syncLeds();
   }

--- a/src/kaleidoscope/plugin/Model01-TestMode.cpp
+++ b/src/kaleidoscope/plugin/Model01-TestMode.cpp
@@ -102,17 +102,17 @@ void TestMode::handleKeyEvent(side_data_t *side, keydata_t *oldState, keydata_t 
     side->cyclesSinceStateChange[key_id]++;
   }
 
-
+  auto led_addr = LEDAddr(key_addr.row(), col_offset - key_addr.col());
 
   // If the key is held down
   if (keyState == HELD) {
-    KeyboardHardware.setCrgbAt(LEDAddr(key_addr.row(), col_offset - key_addr.col()), green);
+    KeyboardHardware.setCrgbAt(led_addr, green);
   } else if (bitRead(side->badKeys, key_addr.toInt()) == 1) {
     // If we triggered chatter detection ever on this key
-    KeyboardHardware.setCrgbAt(LEDAddr(key_addr.row(), col_offset - key_addr.col()), red);
+    KeyboardHardware.setCrgbAt(led_addr, red);
   } else if (keyState == TOGGLED_OFF) {
     // If the key was just released
-    KeyboardHardware.setCrgbAt(LEDAddr(key_addr.row(), col_offset - key_addr.col()), blue);
+    KeyboardHardware.setCrgbAt(led_addr, blue);
   }
 }
 

--- a/src/kaleidoscope/plugin/Model01-TestMode.cpp
+++ b/src/kaleidoscope/plugin/Model01-TestMode.cpp
@@ -102,7 +102,7 @@ void TestMode::handleKeyEvent(side_data_t *side, keydata_t *oldState, keydata_t 
     side->cyclesSinceStateChange[key_id]++;
   }
 
-  auto led_addr = LEDAddr(key_addr.row(), col_offset - key_addr.col());
+  auto led_addr = KeyLEDAddr(key_addr.row(), col_offset - key_addr.col());
 
   // If the key is held down
   if (keyState == HELD) {

--- a/src/kaleidoscope/plugin/Model01-TestMode.cpp
+++ b/src/kaleidoscope/plugin/Model01-TestMode.cpp
@@ -83,11 +83,14 @@ void TestMode::test_leds(void) {
 
 
 
-void TestMode::handleKeyEvent(side_data_t *side, keydata_t *oldState, keydata_t *newState, uint8_t row, uint8_t col, uint8_t col_offset) {
+void TestMode::handleKeyEvent(side_data_t *side, keydata_t *oldState, keydata_t *newState, KeyAddr key_addr, uint8_t col_offset) {
 
   constexpr cRGB red = CRGB(201, 0, 0);
   constexpr cRGB blue = CRGB(0, 0, 201);
   constexpr cRGB green = CRGB(0, 201, 0);
+
+  auto row = key_addr.row();
+  auto col = key_addr.col();
 
   const uint8_t keynum = (row * 8) + (col);
 
@@ -106,13 +109,13 @@ void TestMode::handleKeyEvent(side_data_t *side, keydata_t *oldState, keydata_t 
 
   // If the key is held down
   if (keyState == HELD) {
-    KeyboardHardware.setCrgbAt(row, col_offset - col, green);
+    KeyboardHardware.setCrgbAt(LEDAddr(row, col_offset - col), green);
   } else if (bitRead(side->badKeys, keynum) == 1) {
     // If we triggered chatter detection ever on this key
-    KeyboardHardware.setCrgbAt(row, col_offset - col, red);
+    KeyboardHardware.setCrgbAt(LEDAddr(row, col_offset - col), red);
   } else if (keyState == TOGGLED_OFF) {
     // If the key was just released
-    KeyboardHardware.setCrgbAt(row, col_offset - col, blue);
+    KeyboardHardware.setCrgbAt(LEDAddr(row, col_offset - col), blue);
   }
 }
 
@@ -136,8 +139,8 @@ void TestMode::testMatrix() {
     }
     for (byte row = 0; row < 4; row++) {
       for (byte col = 0; col < 8; col++) {
-        handleKeyEvent(&left, &(KeyboardHardware.previousLeftHandState), &(KeyboardHardware.leftHandState), row, col, 7);
-        handleKeyEvent(&right, &(KeyboardHardware.previousRightHandState), &(KeyboardHardware.rightHandState), row, col, 15);
+        handleKeyEvent(&left, &(KeyboardHardware.previousLeftHandState), &(KeyboardHardware.leftHandState), KeyAddr(row, col), 7);
+        handleKeyEvent(&right, &(KeyboardHardware.previousRightHandState), &(KeyboardHardware.rightHandState), KeyAddr(row, col), 15);
       }
     }
     ::LEDControl.syncLeds();

--- a/src/kaleidoscope/plugin/Model01-TestMode.h
+++ b/src/kaleidoscope/plugin/Model01-TestMode.h
@@ -41,7 +41,7 @@ class TestMode : public kaleidoscope::Plugin {
   static void test_leds();
   static void testMatrix();
   static void toggle_programming_leds_on();
-  static void handleKeyEvent(side_data_t *side, keydata_t *oldState, keydata_t *newState, uint8_t row, uint8_t col, uint8_t col_offset);
+  static void handleKeyEvent(side_data_t *side, keydata_t *oldState, keydata_t *newState, KeyAddr key_addr, uint8_t col_offset);
   static void waitForKeypress();
   static void set_leds(cRGB color);
 };

--- a/src/kaleidoscope/plugin/MouseKeys.cpp
+++ b/src/kaleidoscope/plugin/MouseKeys.cpp
@@ -106,7 +106,7 @@ EventHandlerResult MouseKeys_::beforeReportingState() {
   return EventHandlerResult::OK;
 }
 
-EventHandlerResult MouseKeys_::onKeyswitchEvent(Key &mappedKey, byte row, byte col, uint8_t keyState) {
+EventHandlerResult MouseKeys_::onKeyswitchEvent2(Key &mappedKey, KeyAddr key_addr, uint8_t keyState) {
   if (mappedKey.flags != (SYNTHETIC | IS_MOUSE_KEY))
     return EventHandlerResult::OK;
 

--- a/src/kaleidoscope/plugin/MouseKeys.h
+++ b/src/kaleidoscope/plugin/MouseKeys.h
@@ -40,7 +40,7 @@ class MouseKeys_ : public kaleidoscope::Plugin {
   EventHandlerResult onSetup();
   EventHandlerResult beforeReportingState();
   EventHandlerResult afterEachCycle();
-  EventHandlerResult onKeyswitchEvent(Key &mappedKey, byte row, byte col, uint8_t keyState);
+  EventHandlerResult onKeyswitchEvent2(Key &mappedKey, KeyAddr key_addr, uint8_t keyState);
 
  private:
   static uint8_t mouseMoveIntent;

--- a/src/kaleidoscope/plugin/NumPad.cpp
+++ b/src/kaleidoscope/plugin/NumPad.cpp
@@ -44,15 +44,15 @@ void NumPad::setKeyboardLEDColors(void) {
       }
 
       if ((k != layer_key) || (k == Key_NoKey) || (k.flags != KEY_FLAGS)) {
-        ::LEDControl.refreshAt(LEDAddr(key_addr));
+        ::LEDControl.refreshAt(KeyLEDAddr(key_addr));
       } else {
-        ::LEDControl.setCrgbAt(LEDAddr(key_addr), color);
+        ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr), color);
       }
   }
 
   if (numpadLayerToggleKeyAddr.isValid()) {
     cRGB lock_color = breath_compute(lock_hue);
-    ::LEDControl.setCrgbAt(LEDAddr(numpadLayerToggleKeyAddr), lock_color);
+    ::LEDControl.setCrgbAt(KeyLEDAddr(numpadLayerToggleKeyAddr), lock_color);
   }
 }
 

--- a/src/kaleidoscope/plugin/NumPad.cpp
+++ b/src/kaleidoscope/plugin/NumPad.cpp
@@ -37,8 +37,8 @@ void NumPad::setKeyboardLEDColors(void) {
 
   for (uint8_t r = 0; r < ROWS; r++) {
     for (uint8_t c = 0; c < COLS; c++) {
-      Key k = Layer.lookupOnActiveLayer(r, c);
-      Key layer_key = Layer.getKey(numPadLayer, r, c);
+      Key k = Layer.lookupOnActiveLayer(KeyAddr(r, c));
+      Key layer_key = Layer.getKey(numPadLayer, KeyAddr(r, c));
 
       if (k == LockLayer(numPadLayer)) {
         numpadLayerToggleKeyRow = r;
@@ -46,9 +46,9 @@ void NumPad::setKeyboardLEDColors(void) {
       }
 
       if ((k != layer_key) || (k == Key_NoKey) || (k.flags != KEY_FLAGS)) {
-        ::LEDControl.refreshAt(r, c);
+        ::LEDControl.refreshAt(LEDAddr(r, c));
       } else {
-        ::LEDControl.setCrgbAt(r, c, color);
+        ::LEDControl.setCrgbAt(LEDAddr(r, c), color);
       }
     }
   }

--- a/src/kaleidoscope/plugin/NumPad.cpp
+++ b/src/kaleidoscope/plugin/NumPad.cpp
@@ -35,19 +35,19 @@ EventHandlerResult NumPad::onSetup(void) {
 void NumPad::setKeyboardLEDColors(void) {
   ::LEDControl.set_mode(::LEDControl.get_mode_index());
 
-  for(auto key_addr: KeyAddr{}) {
-      Key k = Layer.lookupOnActiveLayer(key_addr);
-      Key layer_key = Layer.getKey(numPadLayer, key_addr);
+  for (auto key_addr : KeyAddr{}) {
+    Key k = Layer.lookupOnActiveLayer(key_addr);
+    Key layer_key = Layer.getKey(numPadLayer, key_addr);
 
-      if (k == LockLayer(numPadLayer)) {
-        numpadLayerToggleKeyAddr = key_addr;
-      }
+    if (k == LockLayer(numPadLayer)) {
+      numpadLayerToggleKeyAddr = key_addr;
+    }
 
-      if ((k != layer_key) || (k == Key_NoKey) || (k.flags != KEY_FLAGS)) {
-        ::LEDControl.refreshAt(KeyLEDAddr(key_addr));
-      } else {
-        ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr), color);
-      }
+    if ((k != layer_key) || (k == Key_NoKey) || (k.flags != KEY_FLAGS)) {
+      ::LEDControl.refreshAt(KeyLEDAddr(key_addr));
+    } else {
+      ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr), color);
+    }
   }
 
   if (numpadLayerToggleKeyAddr.isValid()) {

--- a/src/kaleidoscope/plugin/NumPad.cpp
+++ b/src/kaleidoscope/plugin/NumPad.cpp
@@ -25,7 +25,7 @@ cRGB NumPad::color = CRGB(160, 0, 0);
 uint8_t NumPad::lock_hue = 170;
 
 // private:
-byte NumPad::numpadLayerToggleKeyRow = 255, NumPad::numpadLayerToggleKeyCol = 255;
+KeyAddr NumPad::numpadLayerToggleKeyAddr;
 bool NumPad::numpadActive = false;
 
 EventHandlerResult NumPad::onSetup(void) {
@@ -35,27 +35,24 @@ EventHandlerResult NumPad::onSetup(void) {
 void NumPad::setKeyboardLEDColors(void) {
   ::LEDControl.set_mode(::LEDControl.get_mode_index());
 
-  for (uint8_t r = 0; r < ROWS; r++) {
-    for (uint8_t c = 0; c < COLS; c++) {
-      Key k = Layer.lookupOnActiveLayer(KeyAddr(r, c));
-      Key layer_key = Layer.getKey(numPadLayer, KeyAddr(r, c));
+  for(auto key_addr: KeyAddr{}) {
+      Key k = Layer.lookupOnActiveLayer(key_addr);
+      Key layer_key = Layer.getKey(numPadLayer, key_addr);
 
       if (k == LockLayer(numPadLayer)) {
-        numpadLayerToggleKeyRow = r;
-        numpadLayerToggleKeyCol = c;
+        numpadLayerToggleKeyAddr = key_addr;
       }
 
       if ((k != layer_key) || (k == Key_NoKey) || (k.flags != KEY_FLAGS)) {
-        ::LEDControl.refreshAt(LEDAddr(r, c));
+        ::LEDControl.refreshAt(LEDAddr(key_addr));
       } else {
-        ::LEDControl.setCrgbAt(LEDAddr(r, c), color);
+        ::LEDControl.setCrgbAt(LEDAddr(key_addr), color);
       }
-    }
   }
 
-  if ((numpadLayerToggleKeyRow <= ROWS) && (numpadLayerToggleKeyCol <= COLS)) {
+  if (numpadLayerToggleKeyAddr.isValid()) {
     cRGB lock_color = breath_compute(lock_hue);
-    ::LEDControl.setCrgbAt(numpadLayerToggleKeyRow, numpadLayerToggleKeyCol, lock_color);
+    ::LEDControl.setCrgbAt(LEDAddr(numpadLayerToggleKeyAddr), lock_color);
   }
 }
 

--- a/src/kaleidoscope/plugin/NumPad.h
+++ b/src/kaleidoscope/plugin/NumPad.h
@@ -36,8 +36,7 @@ class NumPad : public kaleidoscope::Plugin {
 
   void setKeyboardLEDColors(void);
 
-  static uint8_t numpadLayerToggleKeyRow;
-  static uint8_t numpadLayerToggleKeyCol;
+  static KeyAddr numpadLayerToggleKeyAddr;
   static bool numpadActive;
 };
 }

--- a/src/kaleidoscope/plugin/OneShot.cpp
+++ b/src/kaleidoscope/plugin/OneShot.cpp
@@ -90,7 +90,7 @@ EventHandlerResult OneShot::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr,
       state_[idx].pressed = false;
     } else if (keyToggledOn(keyState)) {
       start_time_ = Kaleidoscope.millisAtCycleStart();
-      state_[idx].position = key_addr.offset();
+      state_[idx].position = key_addr.toInt();
       state_[idx].pressed = true;
       state_[idx].active = true;
       prev_key_ = mapped_key;
@@ -130,7 +130,7 @@ EventHandlerResult OneShot::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr,
         } else {
           start_time_ = Kaleidoscope.millisAtCycleStart();
 
-          state_[idx].position = key_addr.offset();
+          state_[idx].position = key_addr.toInt();
           state_[idx].active = true;
           prev_key_ = mapped_key;
 

--- a/src/kaleidoscope/plugin/OneShot.cpp
+++ b/src/kaleidoscope/plugin/OneShot.cpp
@@ -54,7 +54,6 @@ bool OneShot::isStickable(Key key) {
 // ---- OneShot stuff ----
 void OneShot::injectNormalKey(uint8_t idx, uint8_t key_state) {
   Key key;
-  byte row, col;
 
   if (idx < 8) {
     key.flags = Key_LeftControl.flags;
@@ -64,7 +63,7 @@ void OneShot::injectNormalKey(uint8_t idx, uint8_t key_state) {
     key.keyCode = LAYER_SHIFT_OFFSET + idx - 8;
   }
 
-  handleKeyswitchEvent(key, UNKNOWN_KEYSWITCH_LOCATION, key_state | INJECTED);
+  handleKeyswitchEvent(key, UnknownKeyswitchLocation, key_state | INJECTED);
 }
 
 void OneShot::activateOneShot(uint8_t idx) {
@@ -76,7 +75,7 @@ void OneShot::cancelOneShot(uint8_t idx) {
   injectNormalKey(idx, WAS_PRESSED);
 }
 
-EventHandlerResult OneShot::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState) {
+EventHandlerResult OneShot::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
   uint8_t idx = mapped_key.raw - ranges::OS_FIRST;
 
   if (keyState & INJECTED)
@@ -91,7 +90,7 @@ EventHandlerResult OneShot::onKeyswitchEvent(Key &mapped_key, byte row, byte col
       state_[idx].pressed = false;
     } else if (keyToggledOn(keyState)) {
       start_time_ = Kaleidoscope.millisAtCycleStart();
-      state_[idx].position = row * COLS + col;
+      state_[idx].position = key_addr.offset();
       state_[idx].pressed = true;
       state_[idx].active = true;
       prev_key_ = mapped_key;
@@ -131,7 +130,7 @@ EventHandlerResult OneShot::onKeyswitchEvent(Key &mapped_key, byte row, byte col
         } else {
           start_time_ = Kaleidoscope.millisAtCycleStart();
 
-          state_[idx].position = row * COLS + col;
+          state_[idx].position = key_addr.offset();
           state_[idx].active = true;
           prev_key_ = mapped_key;
 
@@ -204,7 +203,7 @@ EventHandlerResult OneShot::afterEachCycle() {
 }
 
 void OneShot::inject(Key mapped_key, uint8_t key_state) {
-  onKeyswitchEvent(mapped_key, UNKNOWN_KEYSWITCH_LOCATION, key_state);
+  onKeyswitchEvent2(mapped_key, UnknownKeyswitchLocation, key_state);
 }
 
 // --- glue code ---

--- a/src/kaleidoscope/plugin/OneShot.h
+++ b/src/kaleidoscope/plugin/OneShot.h
@@ -74,7 +74,7 @@ class OneShot : public kaleidoscope::Plugin {
 
   EventHandlerResult beforeReportingState();
   EventHandlerResult afterEachCycle();
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);
 
   void inject(Key mapped_key, uint8_t key_state);
 

--- a/src/kaleidoscope/plugin/Qukeys.cpp
+++ b/src/kaleidoscope/plugin/Qukeys.cpp
@@ -75,7 +75,7 @@ Key getDualUseAlternateKey(Key k) {
 
 Qukey::Qukey(int8_t layer, KeyAddr key_addr, Key alt_keycode) {
   this->layer = layer;
-  this->addr = key_addr.offset();
+  this->addr = key_addr.toInt();
   this->alt_keycode = alt_keycode;
 }
 
@@ -248,8 +248,7 @@ EventHandlerResult Qukeys::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, 
   }
 
   // get key addr & qukey (if any)
-  uint8_t key_addr_offset = key_addr.offset();
-  int8_t qukey_index = lookupQukey(key_addr_offset);
+  int8_t qukey_index = lookupQukey(key_addr.toInt());
 
   // If the key was injected (from the queue being flushed)
   if (flushing_queue_) {
@@ -266,13 +265,13 @@ EventHandlerResult Qukeys::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, 
     }
 
     // Otherwise, queue the key and stop processing:
-    enqueue(key_addr_offset);
+    enqueue(key_addr.toInt());
     // flushQueue() has already handled this key release
     return EventHandlerResult::EVENT_CONSUMED;
   }
 
   // In all other cases, we need to know if the key is queued already
-  int8_t queue_index = searchQueue(key_addr_offset);
+  int8_t queue_index = searchQueue(key_addr.toInt());
 
   // If the key was just released:
   if (keyToggledOff(key_state)) {

--- a/src/kaleidoscope/plugin/Qukeys.h
+++ b/src/kaleidoscope/plugin/Qukeys.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include <Kaleidoscope.h>
-#include <kaleidoscope/addr.h>
 #include <Kaleidoscope-Ranges.h>
 
 // Maximum length of the pending queue
@@ -61,7 +60,9 @@ namespace plugin {
 struct Qukey {
  public:
   Qukey(void) {}
-  Qukey(int8_t layer, byte row, byte col, Key alt_keycode);
+  Qukey(int8_t layer, KeyAddr key_addr, Key alt_keycode);
+  KS_ROW_COL_FUNC Qukey(int8_t layer, byte row, byte col, Key alt_keycode)
+    : Qukey(layer, KeyAddr(row, col), alt_keycode) {}
 
   int8_t layer;
   uint8_t addr;
@@ -104,7 +105,7 @@ class Qukeys : public kaleidoscope::Plugin {
   static uint8_t qukeys_count;
 
   EventHandlerResult onSetup();
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
   EventHandlerResult beforeReportingState();
 
  private:

--- a/src/kaleidoscope/plugin/Redial.cpp
+++ b/src/kaleidoscope/plugin/Redial.cpp
@@ -24,7 +24,7 @@ Key Redial::key_to_redial_;
 Key Redial::last_key_;
 bool Redial::redial_held_ = false;
 
-EventHandlerResult Redial::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
+EventHandlerResult Redial::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
   if (mapped_key == Key_Redial) {
     if (keyToggledOff(key_state))
       key_to_redial_ = last_key_;

--- a/src/kaleidoscope/plugin/Redial.h
+++ b/src/kaleidoscope/plugin/Redial.h
@@ -31,7 +31,7 @@ class Redial : public kaleidoscope::Plugin {
 
   static bool shouldRemember(Key mappedKey);
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 
  private:
   static Key key_to_redial_;

--- a/src/kaleidoscope/plugin/ShapeShifter.cpp
+++ b/src/kaleidoscope/plugin/ShapeShifter.cpp
@@ -30,7 +30,7 @@ EventHandlerResult ShapeShifter::beforeReportingState() {
   return EventHandlerResult::OK;
 }
 
-EventHandlerResult ShapeShifter::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
+EventHandlerResult ShapeShifter::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
   if (!dictionary)
     return EventHandlerResult::OK;
 

--- a/src/kaleidoscope/plugin/ShapeShifter.h
+++ b/src/kaleidoscope/plugin/ShapeShifter.h
@@ -32,7 +32,7 @@ class ShapeShifter : public kaleidoscope::Plugin {
 
   static const dictionary_t *dictionary;
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
   EventHandlerResult beforeReportingState();
 
  private:

--- a/src/kaleidoscope/plugin/SpaceCadet.cpp
+++ b/src/kaleidoscope/plugin/SpaceCadet.cpp
@@ -70,7 +70,7 @@ bool SpaceCadet::active() {
   return !disabled;
 }
 
-EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
+EventHandlerResult SpaceCadet::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
   //Handle our synthetic keys for enabling and disabling functionality
   if (mapped_key.raw >= kaleidoscope::ranges::SC_FIRST &&
       mapped_key.raw <= kaleidoscope::ranges::SC_LAST) {
@@ -130,7 +130,7 @@ EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, byte row, byte 
         //hit another key after this -- if it's a modifier, we want the modifier
         //key to be added to the report, for things like ctrl, alt, shift, etc)
         if (map[i].flagged) {
-          handleKeyswitchEvent(map[i].input, UNKNOWN_KEYSWITCH_LOCATION, IS_PRESSED | INJECTED);
+          handleKeyswitchEvent(map[i].input, UnknownKeyswitchLocation, IS_PRESSED | INJECTED);
         }
 
         //The keypress wasn't a match, so we need to mark it as not flagged and
@@ -225,7 +225,7 @@ EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, byte row, byte 
     //only need to send that key and not the original key.
 
     //inject our new key
-    handleKeyswitchEvent(alternate_key, row, col, IS_PRESSED | INJECTED);
+    handleKeyswitchEvent(alternate_key, key_addr, IS_PRESSED | INJECTED);
 
     //Unflag the key so we don't try this again.
     map[index].flagged = false;

--- a/src/kaleidoscope/plugin/SpaceCadet.h
+++ b/src/kaleidoscope/plugin/SpaceCadet.h
@@ -66,7 +66,7 @@ class SpaceCadet : public kaleidoscope::Plugin {
   static uint16_t time_out;  //  The global timeout in milliseconds
   static SpaceCadet::KeyBinding * map;  // The map of key bindings
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 
  private:
   static bool disabled;

--- a/src/kaleidoscope/plugin/Syster.cpp
+++ b/src/kaleidoscope/plugin/Syster.cpp
@@ -43,7 +43,7 @@ bool Syster::is_active(void) {
 }
 
 // --- hooks ---
-EventHandlerResult Syster::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState) {
+EventHandlerResult Syster::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
   if (!is_active_) {
     if (!isSyster(mapped_key))
       return EventHandlerResult::OK;
@@ -69,9 +69,9 @@ EventHandlerResult Syster::onKeyswitchEvent(Key &mapped_key, byte row, byte col,
   if (keyToggledOff(keyState)) {
     if (mapped_key == Key_Spacebar) {
       for (uint8_t i = 0; i <= symbol_pos_; i++) {
-        handleKeyswitchEvent(Key_Backspace, UNKNOWN_KEYSWITCH_LOCATION, IS_PRESSED | INJECTED);
+        handleKeyswitchEvent(Key_Backspace, UnknownKeyswitchLocation, IS_PRESSED | INJECTED);
         hid::sendKeyboardReport();
-        handleKeyswitchEvent(Key_Backspace, UNKNOWN_KEYSWITCH_LOCATION, WAS_PRESSED | INJECTED);
+        handleKeyswitchEvent(Key_Backspace, UnknownKeyswitchLocation, WAS_PRESSED | INJECTED);
         hid::sendKeyboardReport();
       }
 

--- a/src/kaleidoscope/plugin/Syster.h
+++ b/src/kaleidoscope/plugin/Syster.h
@@ -41,7 +41,7 @@ class Syster : public kaleidoscope::Plugin {
 
   bool is_active(void);
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);
 
  private:
   static char symbol_[SYSTER_MAX_SYMBOL_LENGTH + 1];

--- a/src/kaleidoscope/plugin/TapDance.cpp
+++ b/src/kaleidoscope/plugin/TapDance.cpp
@@ -26,20 +26,19 @@ uint32_t TapDance::end_time_;
 uint16_t TapDance::time_out = 200;
 TapDance::TapDanceState TapDance::state_[TapDance::TAPDANCE_KEY_COUNT];
 Key TapDance::last_tap_dance_key_;
-byte TapDance::last_tap_dance_row_;
-byte TapDance::last_tap_dance_col_;
+KeyAddr TapDance::last_tap_dance_addr_;
 
 // --- actions ---
 
-void TapDance::interrupt(byte row, byte col) {
+void TapDance::interrupt(KeyAddr key_addr) {
   uint8_t idx = last_tap_dance_key_.raw - ranges::TD_FIRST;
 
-  tapDanceAction(idx, last_tap_dance_row_, last_tap_dance_col_, state_[idx].count, Interrupt);
+  tapDanceAction(idx, last_tap_dance_addr_, state_[idx].count, Interrupt);
   state_[idx].triggered = true;
 
   end_time_ = 0;
 
-  KeyboardHardware.maskKey(row, col);
+  KeyboardHardware.maskKey(key_addr);
   kaleidoscope::hid::sendKeyboardReport();
   kaleidoscope::hid::releaseAllKeys();
 
@@ -52,7 +51,7 @@ void TapDance::interrupt(byte row, byte col) {
 void TapDance::timeout(void) {
   uint8_t idx = last_tap_dance_key_.raw - ranges::TD_FIRST;
 
-  tapDanceAction(idx, last_tap_dance_row_, last_tap_dance_col_, state_[idx].count, Timeout);
+  tapDanceAction(idx, last_tap_dance_addr_, state_[idx].count, Timeout);
   state_[idx].triggered = true;
 
   if (state_[idx].pressed)
@@ -78,7 +77,7 @@ void TapDance::tap(void) {
   state_[idx].count++;
   end_time_ = millis() + time_out;
 
-  tapDanceAction(idx, last_tap_dance_row_, last_tap_dance_col_, state_[idx].count, Tap);
+  tapDanceAction(idx, last_tap_dance_addr_, state_[idx].count, Tap);
 }
 
 // --- api ---
@@ -95,21 +94,21 @@ void TapDance::actionKeys(uint8_t tap_count, ActionType tap_dance_action, uint8_
     break;
   case Interrupt:
   case Timeout:
-    handleKeyswitchEvent(key, last_tap_dance_row_, last_tap_dance_col_, IS_PRESSED | INJECTED);
+    handleKeyswitchEvent(key, last_tap_dance_addr_, IS_PRESSED | INJECTED);
     break;
   case Hold:
-    handleKeyswitchEvent(key, last_tap_dance_row_, last_tap_dance_col_, IS_PRESSED | WAS_PRESSED | INJECTED);
+    handleKeyswitchEvent(key, last_tap_dance_addr_, IS_PRESSED | WAS_PRESSED | INJECTED);
     break;
   case Release:
     hid::sendKeyboardReport();
-    handleKeyswitchEvent(key, last_tap_dance_row_, last_tap_dance_col_, WAS_PRESSED | INJECTED);
+    handleKeyswitchEvent(key, last_tap_dance_addr_, WAS_PRESSED | INJECTED);
     break;
   }
 }
 
 // --- hooks ---
 
-EventHandlerResult TapDance::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState) {
+EventHandlerResult TapDance::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
   if (keyState & INJECTED)
     return EventHandlerResult::OK;
 
@@ -118,10 +117,10 @@ EventHandlerResult TapDance::onKeyswitchEvent(Key &mapped_key, byte row, byte co
       return EventHandlerResult::OK;
 
     if (keyToggledOn(keyState))
-      interrupt(row, col);
+      interrupt(key_addr);
 
-    if (KeyboardHardware.isKeyMasked(row, col)) {
-      KeyboardHardware.unMaskKey(row, col);
+    if (KeyboardHardware.isKeyMasked(key_addr)) {
+      KeyboardHardware.unMaskKey(key_addr);
       return EventHandlerResult::EVENT_CONSUMED;
     }
     return EventHandlerResult::OK;
@@ -143,8 +142,7 @@ EventHandlerResult TapDance::onKeyswitchEvent(Key &mapped_key, byte row, byte co
       }
 
       last_tap_dance_key_.raw = mapped_key.raw;
-      last_tap_dance_row_ = row;
-      last_tap_dance_col_ = col;
+      last_tap_dance_addr_ = key_addr;
 
       tap();
 
@@ -159,7 +157,7 @@ EventHandlerResult TapDance::onKeyswitchEvent(Key &mapped_key, byte row, byte co
         return EventHandlerResult::EVENT_CONSUMED;
       }
 
-      interrupt(row, col);
+      interrupt(key_addr);
     }
   }
 
@@ -170,8 +168,7 @@ EventHandlerResult TapDance::onKeyswitchEvent(Key &mapped_key, byte row, byte co
   }
 
   last_tap_dance_key_.raw = mapped_key.raw;
-  last_tap_dance_row_ = row;
-  last_tap_dance_col_ = col;
+  last_tap_dance_addr_ = key_addr;
   state_[tap_dance_index].pressed = true;
 
   if (keyToggledOn(keyState)) {
@@ -180,7 +177,7 @@ EventHandlerResult TapDance::onKeyswitchEvent(Key &mapped_key, byte row, byte co
   }
 
   if (state_[tap_dance_index].triggered)
-    tapDanceAction(tap_dance_index, row, col, state_[tap_dance_index].count, Hold);
+    tapDanceAction(tap_dance_index, key_addr, state_[tap_dance_index].count, Hold);
 
   return EventHandlerResult::EVENT_CONSUMED;
 }
@@ -190,7 +187,7 @@ EventHandlerResult TapDance::afterEachCycle() {
     if (!state_[i].release_next)
       continue;
 
-    tapDanceAction(i, last_tap_dance_row_, last_tap_dance_col_, state_[i].count, Release);
+    tapDanceAction(i, last_tap_dance_addr_, state_[i].count, Release);
     state_[i].count = 0;
     state_[i].release_next = false;
   }
@@ -207,8 +204,14 @@ EventHandlerResult TapDance::afterEachCycle() {
 }
 }
 
-__attribute__((weak)) void tapDanceAction(uint8_t tap_dance_index, byte row, byte col, uint8_t tap_count,
+KS_ROW_COL_FUNC __attribute__((weak)) void tapDanceAction(uint8_t tap_dance_index, byte row, byte col, uint8_t tap_count,
     kaleidoscope::plugin::TapDance::ActionType tap_dance_action) {
+}
+
+// Let the future version be the wrapper to enable backward compatibility.
+__attribute__((weak)) void tapDanceAction(uint8_t tap_dance_index, KeyAddr key_addr, uint8_t tap_count,
+    kaleidoscope::plugin::TapDance::ActionType tap_dance_action) {
+  tapDanceAction(tap_dance_index, key_addr.row(), key_addr.col(), tap_count, tap_dance_action);
 }
 
 kaleidoscope::plugin::TapDance TapDance;

--- a/src/kaleidoscope/plugin/TapDance.h
+++ b/src/kaleidoscope/plugin/TapDance.h
@@ -46,7 +46,7 @@ class TapDance : public kaleidoscope::Plugin {
 
   void actionKeys(uint8_t tap_count, ActionType tap_dance_action, uint8_t max_keys, const Key tap_keys[]);
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);
   EventHandlerResult afterEachCycle();
 
  private:
@@ -61,11 +61,10 @@ class TapDance : public kaleidoscope::Plugin {
 
   static uint32_t end_time_;
   static Key last_tap_dance_key_;
-  static byte last_tap_dance_row_;
-  static byte last_tap_dance_col_;
+  static KeyAddr last_tap_dance_addr_;
 
   static void tap(void);
-  static void interrupt(byte row, byte col);
+  static void interrupt(KeyAddr key_addr);
   static void timeout(void);
   static void release(uint8_t tap_dance_index);
 };
@@ -73,7 +72,9 @@ class TapDance : public kaleidoscope::Plugin {
 
 }
 
-void tapDanceAction(uint8_t tap_dance_index, byte row, byte col, uint8_t tap_count,
+void tapDanceAction(uint8_t tap_dance_index, KeyAddr key_addr, uint8_t tap_count,
                     kaleidoscope::plugin::TapDance::ActionType tap_dance_action);
+KS_ROW_COL_FUNC void tapDanceAction(uint8_t tap_dance_index, byte row, byte col, uint8_t tap_count,
+                                    kaleidoscope::plugin::TapDance::ActionType tap_dance_action);
 
 extern kaleidoscope::plugin::TapDance TapDance;

--- a/src/kaleidoscope/plugin/TopsyTurvy.cpp
+++ b/src/kaleidoscope/plugin/TopsyTurvy.cpp
@@ -36,7 +36,7 @@ EventHandlerResult TopsyTurvy::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_ad
 
   if (mapped_key < ranges::TT_FIRST || mapped_key > ranges::TT_LAST) {
     if (keyToggledOn(key_state) && (mapped_key < Key_LeftControl || mapped_key > Key_RightGui)) {
-      last_pressed_position_ = key_addr.offset();
+      last_pressed_position_ = key_addr.toInt();
     }
 
     return EventHandlerResult::OK;
@@ -45,9 +45,9 @@ EventHandlerResult TopsyTurvy::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_ad
   is_active_ = keyIsPressed(key_state);
 
   if (keyToggledOn(key_state)) {
-    last_pressed_position_ = key_addr.offset();
+    last_pressed_position_ = key_addr.toInt();
   } else {
-    if (last_pressed_position_ != key_addr.offset()) {
+    if (last_pressed_position_ != key_addr.toInt()) {
       return EventHandlerResult::EVENT_CONSUMED;
     }
   }

--- a/src/kaleidoscope/plugin/TopsyTurvy.cpp
+++ b/src/kaleidoscope/plugin/TopsyTurvy.cpp
@@ -25,7 +25,7 @@ uint8_t TopsyTurvy::last_pressed_position_;
 bool TopsyTurvy::is_shifted_;
 bool TopsyTurvy::is_active_;
 
-EventHandlerResult TopsyTurvy::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
+EventHandlerResult TopsyTurvy::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
 
   if (mapped_key == Key_LeftShift ||
       mapped_key == Key_RightShift) {
@@ -36,7 +36,7 @@ EventHandlerResult TopsyTurvy::onKeyswitchEvent(Key &mapped_key, byte row, byte 
 
   if (mapped_key < ranges::TT_FIRST || mapped_key > ranges::TT_LAST) {
     if (keyToggledOn(key_state) && (mapped_key < Key_LeftControl || mapped_key > Key_RightGui)) {
-      last_pressed_position_ = row * COLS + col;
+      last_pressed_position_ = key_addr.offset();
     }
 
     return EventHandlerResult::OK;
@@ -45,9 +45,9 @@ EventHandlerResult TopsyTurvy::onKeyswitchEvent(Key &mapped_key, byte row, byte 
   is_active_ = keyIsPressed(key_state);
 
   if (keyToggledOn(key_state)) {
-    last_pressed_position_ = row * COLS + col;
+    last_pressed_position_ = key_addr.offset();
   } else {
-    if (last_pressed_position_ != row * COLS + col) {
+    if (last_pressed_position_ != key_addr.offset()) {
       return EventHandlerResult::EVENT_CONSUMED;
     }
   }

--- a/src/kaleidoscope/plugin/TopsyTurvy.h
+++ b/src/kaleidoscope/plugin/TopsyTurvy.h
@@ -29,7 +29,7 @@ class TopsyTurvy: public kaleidoscope::Plugin {
  public:
   TopsyTurvy(void) {}
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 
  private:
   static uint8_t last_pressed_position_;

--- a/src/kaleidoscope/plugin/TriColor.cpp
+++ b/src/kaleidoscope/plugin/TriColor.cpp
@@ -32,7 +32,7 @@ void TriColor::update(void) {
 
       // Special keys are always mod_color
       if (k.flags != 0) {
-        ::LEDControl.setCrgbAt(LEDAddr(key_addr), mod_color_);
+        ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr), mod_color_);
         continue;
       }
 
@@ -52,7 +52,7 @@ void TriColor::update(void) {
         break;
       }
 
-      ::LEDControl.setCrgbAt(LEDAddr(key_addr), color);
+      ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr), color);
     }
 }
 

--- a/src/kaleidoscope/plugin/TriColor.cpp
+++ b/src/kaleidoscope/plugin/TriColor.cpp
@@ -29,11 +29,11 @@ TriColor::TriColor(cRGB base_color, cRGB mod_color, cRGB esc_color) {
 void TriColor::update(void) {
   for (uint8_t r = 0; r < ROWS; r++) {
     for (uint8_t c = 0; c < COLS; c++) {
-      Key k = Layer.lookup(r, c);
+      Key k = Layer.lookup(KeyAddr(r, c));
 
       // Special keys are always mod_color
       if (k.flags != 0) {
-        ::LEDControl.setCrgbAt(r, c, mod_color_);
+        ::LEDControl.setCrgbAt(LEDAddr(r, c), mod_color_);
         continue;
       }
 
@@ -53,7 +53,7 @@ void TriColor::update(void) {
         break;
       }
 
-      ::LEDControl.setCrgbAt(r, c, color);
+      ::LEDControl.setCrgbAt(LEDAddr(r, c), color);
     }
   }
 }

--- a/src/kaleidoscope/plugin/TriColor.cpp
+++ b/src/kaleidoscope/plugin/TriColor.cpp
@@ -27,13 +27,12 @@ TriColor::TriColor(cRGB base_color, cRGB mod_color, cRGB esc_color) {
 }
 
 void TriColor::update(void) {
-  for (uint8_t r = 0; r < ROWS; r++) {
-    for (uint8_t c = 0; c < COLS; c++) {
-      Key k = Layer.lookup(KeyAddr(r, c));
+   for(auto key_addr: KeyAddr{}) {
+      Key k = Layer.lookup(key_addr);
 
       // Special keys are always mod_color
       if (k.flags != 0) {
-        ::LEDControl.setCrgbAt(LEDAddr(r, c), mod_color_);
+        ::LEDControl.setCrgbAt(LEDAddr(key_addr), mod_color_);
         continue;
       }
 
@@ -53,9 +52,8 @@ void TriColor::update(void) {
         break;
       }
 
-      ::LEDControl.setCrgbAt(LEDAddr(r, c), color);
+      ::LEDControl.setCrgbAt(LEDAddr(key_addr), color);
     }
-  }
 }
 
 }

--- a/src/kaleidoscope/plugin/TriColor.cpp
+++ b/src/kaleidoscope/plugin/TriColor.cpp
@@ -27,33 +27,33 @@ TriColor::TriColor(cRGB base_color, cRGB mod_color, cRGB esc_color) {
 }
 
 void TriColor::update(void) {
-   for(auto key_addr: KeyAddr{}) {
-      Key k = Layer.lookup(key_addr);
+  for (auto key_addr : KeyAddr{}) {
+    Key k = Layer.lookup(key_addr);
 
-      // Special keys are always mod_color
-      if (k.flags != 0) {
-        ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr), mod_color_);
-        continue;
-      }
-
-      cRGB color = mod_color_;
-
-      switch (k.keyCode) {
-      case Key_A.keyCode ... Key_0.keyCode:
-      case Key_Spacebar.keyCode:
-      case Key_KeypadDivide.keyCode ... Key_KeypadSubtract.keyCode:
-      case Key_Keypad1.keyCode ... Key_KeypadDot.keyCode:
-      case Key_F1.keyCode ... Key_F4.keyCode:
-      case Key_F9.keyCode ... Key_F12.keyCode:
-        color = base_color_;
-        break;
-      case Key_Escape.keyCode:
-        color = esc_color_;
-        break;
-      }
-
-      ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr), color);
+    // Special keys are always mod_color
+    if (k.flags != 0) {
+      ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr), mod_color_);
+      continue;
     }
+
+    cRGB color = mod_color_;
+
+    switch (k.keyCode) {
+    case Key_A.keyCode ... Key_0.keyCode:
+    case Key_Spacebar.keyCode:
+    case Key_KeypadDivide.keyCode ... Key_KeypadSubtract.keyCode:
+    case Key_Keypad1.keyCode ... Key_KeypadDot.keyCode:
+    case Key_F1.keyCode ... Key_F4.keyCode:
+    case Key_F9.keyCode ... Key_F12.keyCode:
+      color = base_color_;
+      break;
+    case Key_Escape.keyCode:
+      color = esc_color_;
+      break;
+    }
+
+    ::LEDControl.setCrgbAt(KeyLEDAddr(key_addr), color);
+  }
 }
 
 }

--- a/src/kaleidoscope/plugin/TypingBreaks.cpp
+++ b/src/kaleidoscope/plugin/TypingBreaks.cpp
@@ -37,7 +37,7 @@ uint16_t TypingBreaks::left_hand_keys_;
 uint16_t TypingBreaks::right_hand_keys_;
 uint16_t TypingBreaks::settings_base_;
 
-EventHandlerResult TypingBreaks::onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state) {
+EventHandlerResult TypingBreaks::onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
   uint32_t lock_length = settings.lock_length * 1000;
   uint32_t idle_time_limit = settings.idle_time_limit * 1000;
   uint32_t lock_time_out = settings.lock_time_out * 1000;
@@ -100,7 +100,7 @@ EventHandlerResult TypingBreaks::onKeyswitchEvent(Key &mapped_key, byte row, byt
   // counters if need be.
 
   if (keyToggledOn(key_state)) {
-    if (col <= COLS / 2)
+    if (key_addr.col() <= COLS / 2)
       left_hand_keys_++;
     else
       right_hand_keys_++;

--- a/src/kaleidoscope/plugin/TypingBreaks.h
+++ b/src/kaleidoscope/plugin/TypingBreaks.h
@@ -36,7 +36,7 @@ class TypingBreaks : public kaleidoscope::Plugin {
 
   static settings_t settings;
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
+  EventHandlerResult onKeyswitchEvent2(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
   EventHandlerResult onFocusEvent(const char *command);
   EventHandlerResult onSetup();
 

--- a/src/kaleidoscope/plugin/WinKeyToggle.cpp
+++ b/src/kaleidoscope/plugin/WinKeyToggle.cpp
@@ -23,7 +23,7 @@ namespace plugin {
 
 bool WinKeyToggle::enabled_;
 
-EventHandlerResult WinKeyToggle::onKeyswitchEvent(Key &key, byte row, byte col, uint8_t key_state) {
+EventHandlerResult WinKeyToggle::onKeyswitchEvent2(Key &key, KeyAddr key_addr, uint8_t key_state) {
   if (!enabled_)
     return EventHandlerResult::OK;
 

--- a/src/kaleidoscope/plugin/WinKeyToggle.h
+++ b/src/kaleidoscope/plugin/WinKeyToggle.h
@@ -25,7 +25,7 @@ class WinKeyToggle: public kaleidoscope::Plugin {
  public:
   WinKeyToggle() {}
 
-  EventHandlerResult onKeyswitchEvent(Key &key, byte row, byte col, uint8_t key_state);
+  EventHandlerResult onKeyswitchEvent2(Key &key, KeyAddr key_addr, uint8_t key_state);
   void toggle() {
     enabled_ = !enabled_;
   }

--- a/test/MatrixAddr/Makefile
+++ b/test/MatrixAddr/Makefile
@@ -1,0 +1,2 @@
+test: test.cpp ../../src/kaleidoscope/MatrixAddr.h
+	g++ -std=c++11 -o test test.cpp

--- a/test/MatrixAddr/test.cpp
+++ b/test/MatrixAddr/test.cpp
@@ -1,0 +1,102 @@
+#define MATRIX_ADDR_TESTING
+
+#include "../../src/kaleidoscope/MatrixAddr.h"
+
+#include <iostream>
+#include <cassert>
+#include <string>
+#include <cxxabi.h>
+
+template<typename MA__>
+void logType() {
+  std::cout << "   rows:" << (int)MA__::rows << std::endl;
+  std::cout << "   cols:" << (int)MA__::cols << std::endl;
+  std::cout << "   rowSize:" << (int)MA__::rowSize << std::endl;
+}
+
+template<typename MA__>
+void testIndexedAccess() {
+  MA__ ma2;
+
+  ma2.setRow(1);
+  ma2.setCol(3);
+  assert(ma2 == MA__(1, 3));
+
+  ma2.setRow(7);
+  assert(ma2 == MA__(7, 3));
+
+  ma2.setCol(5);
+  assert(ma2 == MA__(7, 5));
+
+  MA__ ma3(3, 5);
+
+  assert(ma3.row() == 3);
+  assert(ma3.col() == 5);
+}
+
+template<typename MA__>
+std::string typenameString() {
+  std::string nameString;
+  char * name = 0;
+  int status;
+  name = abi::__cxa_demangle(typeid(MA__).name(), 0, 0, &status);
+  if (name != 0) {
+    nameString = name;
+  }
+  free(name);
+  return nameString;
+}
+
+template<typename MA1__, typename MA2__>
+void testRelation() {
+
+  std::cout << "***************************************" << std::endl;
+  std::cout << "MA1:" << typenameString<MA1__>() << std::endl;
+  logType<MA1__>();
+
+  std::cout << "MA2:" << typenameString<MA2__>()  << std::endl;
+  logType<MA2__>();
+
+  MA1__ mAddr1(3, 5);
+  MA2__ mAddr2(2, 5);
+  MA1__ mAddr3;
+
+  assert(mAddr1.isValid());
+  assert(!mAddr3.isValid());
+
+  assert(mAddr1 != mAddr2);
+
+  MA2__ mAddr1Copy = mAddr1;
+  assert(mAddr1Copy == mAddr1);
+
+  MA2__ mAddr1Assigned;
+  mAddr1Assigned = mAddr1;
+  assert(mAddr1Assigned == mAddr1);
+
+  assert(mAddr2 < mAddr1);
+  assert(mAddr1 > mAddr2);
+
+  assert(mAddr2 <= mAddr1);
+  assert(mAddr1 >= mAddr2);
+
+  assert(mAddr1 <= mAddr1);
+  assert(mAddr2 >= mAddr2);
+}
+
+int main(int argc, char **argv) {
+  typedef kaleidoscope::MatrixAddr<7, 14> MA1;
+  typedef kaleidoscope::MatrixAddrCompressed<7, 14> MA2;
+  typedef kaleidoscope::MatrixAddrCompressed<7, 8> MA3;
+
+  testIndexedAccess<MA1>();
+  testIndexedAccess<MA2>();
+
+  testRelation<MA1, MA1>();
+  testRelation<MA2, MA2>();
+  testRelation<MA1, MA2>();
+  testRelation<MA2, MA1>();
+
+  testRelation<MA3, MA3>();
+  testRelation<MA3, MA1>();
+  testRelation<MA1, MA3>();
+}


### PR DESCRIPTION
I thought quite a while about whether it makes sense to divide this PR up into several smaller PR but finally decided against as in my eyes everything pretty much belongs together.

# Introduction

This PR introduces matrix address classes and intends to deprecate direct row/column indexing throughout the firmware core and in all core plugins.

In the following the motivation for and the advantages of a modified design are provided. Then the committed changes are explained and the services that are provided by the newly introduced classes are described. After that a description follows of how the transition to the new design has taken place. Finally this text explains where changes have been applied, what has been tested so far and the expected impact on the firmware behavior.

# Motivation

## Structured and uniform design

We have structures/classes for keys, colors and many other small pieces of 
information that belong together. To allow for a uniform object-oriented design it is beneficial
to also have have matrix address classes instead of using raw C-style row/col parameters.

The newly introduced classes provide an easy to use interface for key indexing, validity checks and matrix index calculations.

## Key addresses != LED addresses

Some keyboards have no LEDs, others have some LEDs and some keyboards even have LEDs on all keys. That's why row/col potentially mean a different thing for keys and LEDs. 

Although the newly introduced matrix address classes currently allow free conversion between key and LED addresses, they make it easily possible to prevent this possible conversion if necessary in the future. If no conversion between key and LED indices is desired in the future (currently only used in some LED effect plugins), by replacing the templated copy constructors and assignment operators with non-templated version it is possible to add protection against undesired conversions.

## Debugging

Debugging statements (assertions) could be added to the matrix address classes' accessor methods that test if indices are within the allowed range. This will be especially beneficial once there is a x86 based test bench.

## Reduced RAM footprint

One of the classes (`MatrixAddrCompressed`) introduced by this PR stores row/col information in a single byte. Conversion between row/col and raw offset information is
performed in an efficient manner by avoiding any integer divisions through column padding.


## Flexibility in design 

This PR introduces two matrix address classes both of which are interchangeable and interoperable. One is targeted towards processing speed, the other towards saving storage. The latter codes row/col information in one byte. Every hardware class defines the type of address classes that are optimal for its needs.

As both, `MatrixAddr` and `MatrixAddrCompressed` have compatible interfaces, it is easy to replace one with the other by changing one line in the hardware class. Thus, implementors of new hardware classes or features can test the impact of the different matrix address class designs on their particular version of the firmware.

## Remove/wrap boiler plate code

Some boiler plate code such as 
```cpp
row*COLS + col

row = offset/COLS

col = offset%COLS

if(row >= ROWS || col >= COLS)
```
was moved to the matrix addressing class. This makes many regions of code of the core firmware more readable.

## Key/LED address constants

The new approach allows for the definition of `constexpr` compile time constants for key and LED addresses. This was not possible before and required akward and unsafe preprocessor macros or individual constant definitions for row and col values. The following definition of a Qukey in a firmware sketch now becomes more descriptive.
```cpp
static constexpr KeyAddr LeftPalmKey(3, 6);
...
QUKEYS(
  kaleidoscope::plugin::Qukey(0, LeftPalmKey, Key_LeftControl)
  ...
)
```

# Changes

This PR comes with quite a bunch of changes in many files. Fortunately, most of these changes are of little complexity as they only affect function/method interfaces. Appart from its occurence in function signatures, the use of row/col indexing was replaced by matrix address based access wherever beneficial, thereby using the newly introduced methods `MatrixAddr::isValid()` and `MatrixAddr::offset()` to replace boiler plate code.

## Function- and method-wrappers

Although functions and method signatures have been changed, the firmware is still 100% backward compatible. This is accomplished by introducing wrapper functions/methods that replace the `byte row, byte col` part of a function signature with `KeyAddr keyAddr`. All such wrappers are inline functions and methods. Thus, no runtime penalty is to be expected. 

## Posibility of deprecation of old-style functions and methods

The newly introduced interface functions and methods are intented to be the future defaults. To simplify deprecation of their old-style row/col siblings, a macro `KS_ROW_COL_FUNC` was introduced that may in the future serve as a modifier to supply deprecation attributes (see comments at the end of `MatrixAddr.h`).

A typical wrapper method definition looks as follows
```
// The new interface method
void setCrgbAt(LEDAddr ledAddr, cRGB color);

// The old interface method (the wrapper)
KS_ROW_COL_FUNC void setCrgbAt(byte row, byte col, cRGB color) {
   setCrgbAt(LEDAddr(row, col), color);
}
```
`KS_ROW_COL_FUNC` currently is an emptily defined macro. By defining the following in the future (see `MatrixAddr.h`)
```
#define _DEPRECATED_MESSAGE_ROW_COL_FUNC \
   "Row/col based access functions have been deprecated. Please use " \
   "the KeyAttr/LEDAttr based versions instead."
#define KS_ROW_COL_FUNC DEPRECATED(ROW_COL_FUNC)
```
all calls to old-style interface methods will trigger a deprecation warning. 

Once a future deprecation periode expired, the tag macros `KS_ROW_COL_FUNC` will greatly help identifying 
all deprecated functions and macros that are supposed to be removed.

## Hook `onKeyswitchEvent(...)`

One of the plugin hook methods, `onKeyswitchEvent`, currently also features col/row parameters. As since the v2 plugin API hook methods are non virtual, there is no straight forward way to introduce an equally named wrapper-hook with a different signature (hook overloading is not supported). If a plugin defines a second method that is named as one of the hooks, system would regard this as an error and a `static_assert` would fire. Remember, that's intentional behavior as we want to protect the user from messing with the signature in derived plugins.

Fortunately, by design, the hook infrastrukture can deal especially well with unimplemented or empty inlined hook methods. Because of this, versioning for hook methods becomes possible. This PR introduces a new hook method `onKeyswitchEvent2`, its signature is identical to the one of the original `onKeyswitchEvent` except for replacing the parameters `byte row, byte col` with `KeyAddr keyAddr`. 

By calling both versions of the hook sequencially in `handleKeyswitchEvent(...)` (`key_events.cpp`), the firmware remains backward compatible without adding significant runtime overhead. This is due to the compiler's ability to optimize out emptily defined hook methods.
If a plugin only defines the old style hook, the call to the new-style hook will be optimized out in the same way as it happens with any other hooks that a plugin does not implement. The only restriction that comes with this solution is that a plugin must not implement both the new- and the old-style version of the same hook.

With a technique similar to the one that the firmware core applies to check if a hook implemented as a plugin method has the correct signature, we could possibly implement a future mechanism that allows to deprecate hook methods. Thus, a future deprecation of the original `onKeyswitchEvent` will be possible.

The current implementation, however, supports both version of the hook. And as there is no significant penalty in terms of PROGMEM from supporting two types of hook signatures, a deprecation is of lesser importance (see information about PROGMEM usage later on in this document).

# Services provided by the matrix address classes

## Row/col <-> offset conversion

In many places of the current firmware version we can find the construct `row*COLS + col` that calculates a contiguous zero-based integer offset from a row/col pair. The inverse operations `row = offset/COLS` and `col = offset%COLS` can as well be found in many places. Both types of conversions are now taken over by the matrix address classes. The former by the `offset()` method, the latter by the accessors `row()` and `col()`. This removes a lot of boiler plate code in many places of the firmware.

Note: The header `Kaleidoscope/src/kaleidoscope/addr.h` contains functions whose features are now taken over by the matrix address classes. Thus, `addr.h` could be deprecated.

## Validity check

Instances of the new address classes are, when default initialized, intentionally in invalid state. The validity of the coordinates ot a matrix address may be queried through its `isValid()` method. A valid state is 
characterized as row and col being within the allowed range. This wraps and simplifies the following piece of ubiquitous boiler plate code `if(row >= ROWS || col >= COLS)` which becomes the more descriptive `if(!keyAddr.isValid())`.

## Unknown keyswitch location as a flag

The old style functions used the preprocessor macro `UNKNOWN_KEYSWITCH_LOCATION` as a flag value. This has been superseeded by a

```cpp
static constexpr KeyAddr UnknownKeyswitchLocation;
``` 
that is defined in header `key_events.h` where also `UNKNOWN_KEYSWITCH_LOCATION` is defined.

## Module test for matrix address classes

This PR comes with a module test program for header `MatrixAddr.h`. The test resides in `test/MatrixAddr` in the Kaleidoscope git repository. To run the test on a unixoid platform that supports gcc (host version) and make, run the following
```
cd Kaleidoscope/test/MatrixAddr
make
./test
```

# Where have changes been applied

Great care has been taken not to miss any occurences of functions and macros whose signature comprises row/col. The following regex were used to find such occurrences.
```
\w+\s+row\s*,\s*\w+\s+col
row\s*,\s*col
\brow\b
\bcol\b
```
A regex search was ran recursively on all files `*.h,*.cpp,*.ino,*.md` within the Kaleidoscope-Bundle-Keyboardio repo. This affected not only the Kaleidoscope but also the Kaleidoscop-Hardware-Virtual submodule.

It is important to mention that if any occurences might have been missed, the firmware can still be expected to work correctly. No functions and methods have been removed from any interfaces. Only additional wrappers have been added and the implementations have been adapted in a few places.

There is a small chance that in some corners of the firmware core the old row/col values are still used (e.g. if row/col were named foo/bar). This would mean that some of the newly introduced wrappers would be called. But as all of them were inlined there results zero runtime penalty.

# Expected impact on PROGMEM and processing speed

The submitted PR uses `MatrixAddr` throughout (`MatrixAddrCompressed` is currently unused).

A testfirmare has been build with the current master bundle and with this PR included. Both versions have been compared in terms of binary size, symbol count and symbol size (function binary code).
With this PR comes a slight increase of firmware size of ~0.5% (84 bytes) for a medium sized firmware of ~16000 bytes. This can be explained by the newly introduced additional hook function. The firmware can be expected to shrink again back to the original size once the old-style access functions and the superfluous hook have been removed.

Disassemblies have been checked at random. Some functions/methods grow, some shrink due to the submitted changes. In average no significant change in size of symbols can be observed. The total amount of symbols remains almost exactly the same. Only one additional function was found using avr-objdump which is a Qukeys wrapper constructor that the compiler for strange reasons didn't inline.

As algorithms remain untouched and the average binary size of most functions did not change, no change in runtime is to be expected after merging the submitted changes.

An alternative version that uses `MatrixAddrCompressed` was also tested. For the above mentioned test firmware the increase of firmware binary size is ~3% (458 bytes). But same as for the submitted version, some increase in PROGMEM consumption (~84 bytes) results from additional wrappers and hook function.

To use such an an alternative version only makes sense when a plugin is used that needs to store a greater number of key addresses in memory. With `MatrixAddrCompressed` this would half the RAM consumption for matrix address storage. In such a use case a slight increase in binary size would probably be acceptable.

# Tests

As this is a quite intrusive set of changes, special care must be taken not to break any existing code. The following types of tests have been run so far:

* compile and link tests with the Model01 firmware and all available plugins

The author of this PR could only run tests with the Keyboardio Model01. Tests with other hardware would be useful before merging this PR.

In general, before this PR is going to be merged, it is important that as many eyes have checked it as possible!

# Aknowledgements

The design of the MatrixAddr class was in parts influenced by gedankenexperimenters [KeyAddr](https://github.com/gedankenlab/Kaleidoglyph-Hardware-Model01/blob/2f771f63184f6cefee83c20df4bc210fd808b85f/src/model01/KeyAddr.h) class.