### PR TITLE
Speed up LED-Stalker plugin

### DIFF
--- a/src/kaleidoscope/plugin/LED-Stalker.cpp
+++ b/src/kaleidoscope/plugin/LED-Stalker.cpp
@@ -53,8 +53,9 @@ void StalkerEffect::update(void) {
   if (!variant)
     return;
 
-  uint16_t now = millis();
   uint16_t elapsed = Kaleidoscope.millisAtCycleStart() - step_start_time_;
+  if (elapsed < step_length)
+    return;
 
   for (byte r = 0; r < ROWS; r++) {
     for (byte c = 0; c < COLS; c++) {
@@ -63,17 +64,14 @@ void StalkerEffect::update(void) {
         ::LEDControl.setCrgbAt(r, c, variant->compute(&step));
       }
 
-      if (elapsed > step_length) {
-        map_[r][c] = step;
-      }
+      map_[r][c] = step;
 
       if (!map_[r][c])
         ::LEDControl.setCrgbAt(r, c, inactive_color);
     }
   }
 
-  if (elapsed > step_length)
-    step_start_time_ = Kaleidoscope.millisAtCycleStart();
+  step_start_time_ = Kaleidoscope.millisAtCycleStart();
 }
 
 namespace stalker {


### PR DESCRIPTION
The LED-Stalker plugin was looping through its table of `step` values (one for each key) on every call to `update()`, and calling `compute()` on every value there, but those table entries were only updated once every 50ms (by default), resulting in a lot of repeated computation. This resulted in the mean idle cycle time increasing from 565µs to 1317µs on the Model01 with an (almost) unmodified standard sketch.

This change moves the check for the timeout before the loop through the `step` values, and aborts processing there if not enough time has elapsed. The resulting mean idle cycle time becomes 577µs -- an almost negligible increase. It also reduces the PROGMEM footprint by 44 bytes.

I also tried to measure worst-case cycle times by mashing on the keys. Before this change, it got up to ~2000µs; after this change it was ~930µs.

|                     | No LED mode | Current LED-Stalker | This PR  |
|------------|---------------|---------------------|----------|
| idle              | 565 µs            | 1317 µs                     | 577 µs |
| worst-case | 752 µs             | 2006 µs                   | 929 µs |

Note: much of the savings could be had by having LEDControl only call `update()` on cycles
when it also calls `syncLeds()`, but I don't know if that would have undesirable effects on other plugins.