### PR TITLE
Led control efficiency changes

### DIFF
--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -22,7 +22,7 @@ namespace plugin {
 
 LEDMode *LEDControl::modes[LED_MAX_MODES];
 uint8_t LEDControl::mode;
-uint16_t LEDControl::syncDelay = 16;
+uint16_t LEDControl::syncDelay = 32; // 32ms interval => 30Hz refresh rate
 uint16_t LEDControl::syncTimer;
 bool LEDControl::paused = false;
 

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -176,8 +176,8 @@ kaleidoscope::EventHandlerResult LEDControl::beforeReportingState(void) {
   if (elapsed > syncDelay) {
     syncLeds();
     syncTimer += syncDelay;
+    update();
   }
-  update();
 
   return kaleidoscope::EventHandlerResult::OK;
 }


### PR DESCRIPTION
I'm proposing two very small changes to how LEDControl operates:

First, changing the frequency at which updates are pushed to the hardware from ~60Hz to ~30Hz. 60Hz is overkill for this application; with such a grainy "display", I would be quite surprised if it was possible for humans to detect a difference. However, I have only one Model01, so I don't have the ability to do a side-by-side blind comparison to verify that this is the case.

Second, I'm proposing only calling the `update()` method of the active LED mode once per LED update cycle, rather than once per scan cycle. It doesn't make sense to me to be doing (depending on the LED mode) all that computation when it doesn't show up in the output.

I've tried both of these things out, and have not been able to detect a visual difference with any of the standard sketch's LED modes. For some modes, however, there is a marked decrease in the average scan cycle time.