### PR TITLE
OneShot: Fix buffer overflow

### DIFF
--- a/src/kaleidoscope/plugin/OneShot.cpp
+++ b/src/kaleidoscope/plugin/OneShot.cpp
@@ -163,7 +163,7 @@ EventHandlerResult OneShot::onKeyswitchEvent(Key &mapped_key, byte row, byte col
 }
 
 EventHandlerResult OneShot::beforeReportingState() {
-  for (uint8_t i = 0; i < 8; i++) {
+  for (uint8_t i = 0; i < ONESHOT_KEY_COUNT / 2; i++) {
     if (state_[i].active) {
       activateOneShot(i);
     }
@@ -178,7 +178,7 @@ EventHandlerResult OneShot::afterEachCycle() {
 
   bool is_cancelled = false;
 
-  for (uint8_t i = 0; i < 32; i++) {
+  for (uint8_t i = 0; i < ONESHOT_KEY_COUNT; i++) {
     if (should_cancel_) {
       if (state_[i].sticky) {
         if (should_cancel_stickies_) {


### PR DESCRIPTION
This PR fixes a buffer overflow in OneShot (I think missed by 51a7537d87fe).

My Model 01 (with custom `Model01-Firmware.ino`) often froze when changing the LED effect... I tried to turn plugins on/off one by one and tracked the bug down to OneShot. This PR fixed the issue.
