### PR TITLE
OneShot: Fix maybe uninitialized state

### DIFF
--- a/src/kaleidoscope/plugin/OneShot.h
+++ b/src/kaleidoscope/plugin/OneShot.h
@@ -30,6 +30,7 @@ class OneShot : public kaleidoscope::Plugin {
  public:
   OneShot(void) {
     for (uint8_t i = 0; i < ONESHOT_KEY_COUNT; i++) {
+      state_[i] = {};
       state_[i].stickable = true;
     }
   }


### PR DESCRIPTION
I'm think `OneShot::state_` is not fully initialized. I did **not** actually experienced OneShot bugs (other than #597), but just in case, I suggest initializing it?

It went from fully initialized (statically) to only `stickable` initialized (in constructor) here: 032da484bc8b.

