### PR TITLE
KEYMAP_*+_GENERIC macros and keymasks

### DIFF
--- a/examples/LEDs/LED-Wavepool/LED-Wavepool.ino
+++ b/examples/LEDs/LED-Wavepool/LED-Wavepool.ino
@@ -20,25 +20,26 @@
 #include <Kaleidoscope-LEDControl.h>
 #include <Kaleidoscope-LED-Wavepool.h>
 
-const Key keymaps[][ROWS][COLS] PROGMEM = {
+KEYMAPS(
   [0] = KEYMAP_STACKED
-  (
-    Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext,
-    Key_Backtick,      Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
-    Key_PageUp,        Key_A, Key_S, Key_D, Key_F, Key_G,
-    Key_PageDown,      Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+        (
+          Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext,
+          Key_Backtick,      Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+          Key_PageUp,        Key_A, Key_S, Key_D, Key_F, Key_G,
+          Key_PageDown,      Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
 
-    Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
-    Key_NoKey,
+          Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+          Key_NoKey,
 
-    Key_skip,  Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
-    Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
-    Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
-    Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
+          Key_skip,  Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
+          Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
+          Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
+          Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
 
-    Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
-    Key_NoKey),
-};
+          Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
+          Key_NoKey
+        )
+) // KEYMAPS(
 
 KALEIDOSCOPE_INIT_PLUGINS(
   LEDControl,

--- a/src/kaleidoscope/Kaleidoscope.h
+++ b/src/kaleidoscope/Kaleidoscope.h
@@ -40,6 +40,14 @@ void setup();
 
 extern HARDWARE_IMPLEMENTATION KeyboardHardware;
 
+#ifdef KEYMAP_STACKED_GENERIC
+#define KEYMAP_STACKED(...) { KEYMAP_STACKED_GENERIC(XXX, __VA_ARGS__) }
+#endif
+
+#ifdef KEYMAP_GENERIC
+#define KEYMAP(...) { KEYMAP_GENERIC(XXX, __VA_ARGS__) }
+#endif
+
 #define ROWS (KeyboardHardware.matrix_rows)
 #define COLS (KeyboardHardware.matrix_columns)
 #define LED_COUNT (KeyboardHardware.led_count)

--- a/src/kaleidoscope/bitfields.cpp
+++ b/src/kaleidoscope/bitfields.cpp
@@ -1,0 +1,53 @@
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2018  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Kaleidoscope.h"
+
+#include "bitfields.h"
+
+namespace kaleidoscope {
+namespace bitfields {
+namespace internal {
+
+bool _BaseBitfield::isBitSetP(const void *bit_field, uint8_t raw_pos) {
+  uint8_t byte_id = raw_pos >> 3;
+  uint8_t bit_pos = raw_pos & 0x7;
+  const uint8_t *bytes = reinterpret_cast<const uint8_t *>(bit_field);
+  return bytes[byte_id] & (0x1 << bit_pos);
+}
+
+void _BaseBitfield::setBitP(void *bit_field, uint8_t raw_pos, uint8_t val) {
+  uint8_t byte_id = raw_pos >> 3;
+  uint8_t bit_pos = raw_pos & 0x7;
+  uint8_t *bytes = reinterpret_cast<uint8_t *>(bit_field);
+  if (val) {
+    bytes[byte_id] |= (0x1 << bit_pos);
+  } else {
+    bytes[byte_id] &= ~(0x1 << bit_pos);
+  }
+}
+
+bool _BaseBitfield::isBitSetPROGMEM_P(const void *bit_field, uint8_t raw_pos) {
+  uint8_t byte_id = raw_pos >> 3;
+  uint8_t bit_pos = raw_pos & 0x7;
+  const uint8_t *bytes = reinterpret_cast<const uint8_t *>(bit_field);
+  uint8_t byte = pgm_read_byte(&(bytes[byte_id]));
+  return byte & (0x1 << bit_pos);
+}
+
+} // end namespace internal
+} // end namespace bitfields
+} // end namespace kaleidoscope

--- a/src/kaleidoscope/bitfields.h
+++ b/src/kaleidoscope/bitfields.h
@@ -1,0 +1,200 @@
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2018  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+namespace kaleidoscope {
+namespace bitfields {
+
+namespace internal {
+
+// To store the bitfield we use a recursively defined template struct.
+// It contains one byte of storage and a nested template struct
+// that wraps the remaining bytes. A specialization of the template
+// is used to end the recursion.
+//
+// By tagging the struct with __attribute__((packed)), we make sure
+// that no padding bytes are added between the struct instances
+// if the struct is used on non-8 bit architectures. This is important
+// to ensure that all bytes are stored contiguously like it is the
+// case in an intrinsic array.
+//
+template<uint8_t Byte_Count__>
+struct _Bitfield {
+
+  uint8_t byte_;
+
+  _Bitfield < Byte_Count__ - 1 > more_bytes_;
+
+  // The constructor initializes the first eight bits that are stored
+  // in this struct and passes the remaining bits on to the nested
+  // more_bytes_ struct.
+  //
+  template<typename ... Bits__>
+  constexpr _Bitfield(uint8_t b0, uint8_t b1, uint8_t b2, uint8_t b3,
+                      uint8_t b4, uint8_t b5, uint8_t b6, uint8_t b7,
+                      Bits__ ... bits)
+    :  byte_(b0 << 0
+             |   b1 << 1
+             |   b2 << 2
+             |   b3 << 3
+             |   b4 << 4
+             |   b5 << 5
+             |   b6 << 6
+             |   b7 << 7),
+       more_bytes_(bits...)
+  {}
+
+} __attribute__((packed));
+
+// A specialization that stores any remaining 1 to 8 bits. Any bits that
+// are unused are zeroed by default.
+//
+template<>
+struct _Bitfield<1 /* the last byte */> {
+
+  uint8_t byte_;
+
+  constexpr _Bitfield(uint8_t b0 = 0, uint8_t b1 = 0, uint8_t b2 = 0, uint8_t b3 = 0,
+                      uint8_t b4 = 0, uint8_t b5 = 0, uint8_t b6 = 0, uint8_t b7 = 0)
+    :  byte_(b0 << 0
+             |   b1 << 1
+             |   b2 << 2
+             |   b3 << 3
+             |   b4 << 4
+             |   b5 << 5
+             |   b6 << 6
+             |   b7 << 7)
+  {}
+} __attribute__((packed));
+
+// A common base class that provides methods to access the bits in
+// a _Bitfield instance by treating it as a raw array.
+//
+class _BaseBitfield {
+
+ protected:
+
+  static bool isBitSetP(const void *bit_field, uint8_t raw_pos);
+  static void setBitP(void *bit_field, uint8_t raw_pos, uint8_t val);
+  static bool isBitSetPROGMEM_P(const void *bit_field, uint8_t raw_pos);
+};
+
+} // end namespace internal
+
+// This is the actual user class.
+//
+template<size_t BitCount__>
+class Bitfield : public internal::_BaseBitfield {
+
+ public:
+
+  static constexpr size_t nBytesForBits(size_t n_bits) {
+    return (n_bits % 8) ? n_bits / 8 + 1 : n_bits / 8;
+  }
+
+  static constexpr size_t n_bits_ = BitCount__;
+  static constexpr size_t n_bytes_ = nBytesForBits(BitCount__);
+
+  template<typename ... Bits__>
+  constexpr Bitfield(Bits__...bits) : bits_(bits...) {
+    static_assert(sizeof...(Bits__) == n_bits_,
+                  "Invalid number of bits supplied to Bitfield<BitCount__> constructor. \n"
+                  "Compare the number of bits supplied with the provided template \n"
+                  "parameter BitCount__ to find out what went wrong.\n");
+  }
+
+  bool isBitSet(uint8_t raw_pos) const {
+    return isBitSetP(&bits_, raw_pos);
+  }
+
+  bool isBitSetPROGMEM(uint8_t raw_pos) const {
+    return isBitSetPROGMEM_P(&bits_, raw_pos);
+  }
+
+  void setBit(uint8_t raw_pos, uint8_t val) {
+    setBitP(&bits_, raw_pos, val);
+  }
+
+  // An operator to query bits.
+  // Note: This assumes bitfield to be stored in PROGMEM. Use the
+  //       access method isBitSet(raw_pos) otherwise.
+  //
+  constexpr bool operator[](uint8_t raw_pos) const {
+    return this->isBitSetPROGMEM_P(raw_pos);
+  }
+
+ private:
+
+  internal::_Bitfield<n_bytes_> bits_;
+};
+
+// The method generateBitfield may be used to conveniently create bitfields.
+//
+// auto my_bitfield = generateBitfield(1, 2, 3);
+//
+// Note: Due to a restriction in all gcc versions < 6.0
+//       this function cannot be called with the output of KEYMAP_STACKED(...)
+//       or KEYMAP(...) as its arguments.
+//
+template<typename...Bits__>
+constexpr Bitfield<sizeof...(Bits__)> generateBitfield(Bits__...bits) {
+  return Bitfield<sizeof...(Bits__)>(bits...);
+}
+
+// This auxiliary method determines the number of entries in a list.
+//
+namespace internal {
+
+template<typename...Args__>
+constexpr size_t nListEntries(Args__...) {
+  return sizeof...(Args__);
+}
+
+} // end namespace internal
+
+// Defines a bitfield named VAR_NAME. Applies MODIFIER (could e.g. set to const PROGMEM).
+//
+#define BITFIELD__(VAR_NAME, MODIFIER, ...)                                    \
+    constexpr size_t VAR_NAME##_n_bits                                  __NL__ \
+         = kaleidoscope::bitfields::internal::nListEntries(__VA_ARGS__);__NL__ \
+                                                                        __NL__ \
+    MODIFIER kaleidoscope::bitfields::Bitfield<VAR_NAME##_n_bits>       __NL__ \
+         VAR_NAME{__VA_ARGS__};
+
+#define BITFIELD(VAR_NAME, ...) BITFIELD__(VAR_NAME,, __VA_ARGS__)
+#define BITFIELD_PROGMEM(VAR_NAME, ...) BITFIELD__(VAR_NAME, const PROGMEM, __VA_ARGS__)
+
+#ifdef KEYMAP_GENERIC
+#define KEYMAP_BITFIELD(VAR_NAME, ...) \
+    BITFIELD(VAR_NAME, KEYMAP_GENERIC(0 /*default for non-existent keys*/, __VA_ARGS__))
+
+#define KEYMAP_BITFIELD_PROGMEM(VAR_NAME, ...) \
+    BITFIELD_PROGMEM(VAR_NAME, KEYMAP_GENERIC(0 /*default for non-existent keys*/, __VA_ARGS__))
+#endif
+
+#ifdef KEYMAP_STACKED_GENERIC
+#define KEYMAP_BITFIELDK_STACKED(VAR_NAME, ...) \
+    BITFIELD(VAR_NAME, KEYMAP_STACKED_GENERIC(0 /*default for non-existent keys*/, __VA_ARGS__))
+
+#define KEYMAP_BITFIELD_STACKED_PROGMEM(VAR_NAME, ...) \
+    BITFIELD_PROGMEM(VAR_NAME, KEYMAP_STACKED_GENERIC(0 /*default for non-existent keys*/, __VA_ARGS__))
+#endif
+
+} // end namespace bitfields
+} // end namespace kaleidoscope

--- a/src/kaleidoscope/hardware/ez/ErgoDox.h
+++ b/src/kaleidoscope/hardware/ez/ErgoDox.h
@@ -89,7 +89,7 @@ class ErgoDox : public kaleidoscope::Hardware {
   static void readMatrixRow(uint8_t row);
 };
 
-#define KEYMAP_STACKED(                                                 \
+#define KEYMAP_STACKED_GENERIC(dflt,                                    \
     /* left hand, spatial positions */                                  \
     r0c0, r0c1, r0c2, r0c3, r0c4, r0c5, r0c6,                           \
     r1c0, r1c1, r1c2, r1c3, r1c4, r1c5, r1c6,                           \
@@ -111,23 +111,22 @@ class ErgoDox : public kaleidoscope::Hardware {
     r5c12, r5c11, r5c10 )                                               \
                                                                         \
   /* matrix positions */                                                \
-  {                                                                     \
-    { r0c0, r1c0, r2c0, r3c0, r4c0, XXX  },                             \
-    { r0c1, r1c1, r2c1, r3c1, r4c1, r5c1 },                             \
-    { r0c2, r1c2, r2c2, r3c2, r4c2, r5c2 },                             \
-    { r0c3, r1c3, r2c3, r3c3, r4c3, r5c3 },                             \
-    { r0c4, r1c4, r2c4, r3c4, r4c4, r5c4 },                             \
-    { r0c5, r1c5, r2c5, r3c5, XXX,  r5c5 },                             \
-    { r0c6, r1c6, XXX,  r3c6, XXX,  r5c6 },                             \
                                                                         \
-    { r0c7,  r1c7,  XXX,   r3c7,  XXX,   r5c7  },                       \
-    { r0c8,  r1c8,  r2c8,  r3c8,  XXX,   r5c8  },                       \
-    { r0c9,  r1c9,  r2c9,  r3c9,  r4c9,  r5c9  },                       \
-    { r0c10, r1c10, r2c10, r3c10, r4c10, r5c10 },                       \
-    { r0c11, r1c11, r2c11, r3c11, r4c11, r5c11 },                       \
-    { r0c12, r1c12, r2c12, r3c12, r4c12, r5c12 },                       \
-    { r0c13, r1c13, r2c13, r3c13, r4c13, XXX   }                        \
-  }
+    r0c0, r1c0, r2c0, r3c0, r4c0, dflt,                                 \
+    r0c1, r1c1, r2c1, r3c1, r4c1, r5c1,                                 \
+    r0c2, r1c2, r2c2, r3c2, r4c2, r5c2,                                 \
+    r0c3, r1c3, r2c3, r3c3, r4c3, r5c3,                                 \
+    r0c4, r1c4, r2c4, r3c4, r4c4, r5c4,                                 \
+    r0c5, r1c5, r2c5, r3c5, dflt, r5c5,                                 \
+    r0c6, r1c6, dflt, r3c6, dflt, r5c6,                                 \
+                                                                        \
+    r0c7,  r1c7,  dflt,  r3c7,  dflt,  r5c7,                            \
+    r0c8,  r1c8,  r2c8,  r3c8,  dflt,  r5c8,                            \
+    r0c9,  r1c9,  r2c9,  r3c9,  r4c9,  r5c9,                            \
+    r0c10, r1c10, r2c10, r3c10, r4c10, r5c10,                           \
+    r0c11, r1c11, r2c11, r3c11, r4c11, r5c11,                           \
+    r0c12, r1c12, r2c12, r3c12, r4c12, r5c12,                           \
+    r0c13, r1c13, r2c13, r3c13, r4c13, dflt
 }
 }
 }

--- a/src/kaleidoscope/hardware/kbdfans/KBD4x.h
+++ b/src/kaleidoscope/hardware/kbdfans/KBD4x.h
@@ -48,17 +48,16 @@ class KBD4x: public kaleidoscope::hardware::ATMegaKeyboard {
   void resetDevice();
 };
 
-#define KEYMAP(                                                                    \
+#define KEYMAP_GENERIC(dflt,                                                       \
          R0C0, R0C1, R0C2, R0C3, R0C4, R0C5, R0C6, R0C7, R0C8, R0C9, R0C10, R0C11, \
          R1C0, R1C1, R1C2, R1C3, R1C4, R1C5, R1C6, R1C7, R1C8, R1C9, R1C10, R1C11, \
          R2C0, R2C1, R2C2, R2C3, R2C4, R2C5, R2C6, R2C7, R2C8, R2C9, R2C10, R2C11, \
-         R3C0, R3C1, R3C2, R3C3, R3C4,    R3C5,    R3C7, R3C8, R3C9, R3C10, R3C11 \
-  ) {                                                                                  \
-         { R0C0, R0C1, R0C2, R0C3, R0C4, R0C5, R0C6, R0C7, R0C8, R0C9, R0C10, R0C11, }, \
-         { R1C0, R1C1, R1C2, R1C3, R1C4, R1C5, R1C6, R1C7, R1C8, R1C9, R1C10, R1C11, }, \
-         { R2C0, R2C1, R2C2, R2C3, R2C4, R2C5, R2C6, R2C7, R2C8, R2C9, R2C10, R2C11, }, \
-         { R3C0, R3C1, R3C2, R3C3, R3C4, R3C5, R3C5, R3C7, R3C8, R3C9, R3C10, R3C11, } \
-  }
+         R3C0, R3C1, R3C2, R3C3, R3C4,    R3C5,    R3C7, R3C8, R3C9, R3C10, R3C11  \
+  )                                                                                \
+         R0C0, R0C1, R0C2, R0C3, R0C4, R0C5, R0C6, R0C7, R0C8, R0C9, R0C10, R0C11, \
+         R1C0, R1C1, R1C2, R1C3, R1C4, R1C5, R1C6, R1C7, R1C8, R1C9, R1C10, R1C11, \
+         R2C0, R2C1, R2C2, R2C3, R2C4, R2C5, R2C6, R2C7, R2C8, R2C9, R2C10, R2C11, \
+         R3C0, R3C1, R3C2, R3C3, R3C4, R3C5, R3C5, R3C7, R3C8, R3C9, R3C10, R3C11
 }
 
 }

--- a/src/kaleidoscope/hardware/keyboardio/Model01.h
+++ b/src/kaleidoscope/hardware/keyboardio/Model01.h
@@ -94,7 +94,7 @@ class Model01 : public kaleidoscope::Hardware {
 
 #include "kaleidoscope/hardware/key_indexes.h"
 
-#define KEYMAP_STACKED(                                                 \
+#define KEYMAP_STACKED_GENERIC(dflt,                                    \
                r0c0, r0c1, r0c2, r0c3, r0c4, r0c5, r0c6,                \
                r1c0, r1c1, r1c2, r1c3, r1c4, r1c5, r1c6,                \
                r2c0, r2c1, r2c2, r2c3, r2c4, r2c5,                      \
@@ -108,25 +108,22 @@ class Model01 : public kaleidoscope::Hardware {
                r2c9,  r3c10, r3c11, r3c12, r3c13, r3c14, r3c15,         \
                r3c8,  r2c8,  r1c8, r0c8,                                \
                r3c9, ...)                                               \
-  {                                                                     \
-    {r0c0, r0c1, r0c2, r0c3, r0c4, r0c5, r0c6, r0c7, r0c8, r0c9, r0c10, r0c11, r0c12, r0c13, r0c14, r0c15}, \
-    {r1c0, r1c1, r1c2, r1c3, r1c4, r1c5, r1c6, r1c7, r1c8, r1c9, r1c10, r1c11, r1c12, r1c13, r1c14, r1c15}, \
-    {r2c0, r2c1, r2c2, r2c3, r2c4, r2c5, r2c6, r2c7, r2c8, r2c9, r2c10, r2c11, r2c12, r2c13, r2c14, r2c15}, \
-    {r3c0, r3c1, r3c2, r3c3, r3c4, r3c5, r3c6, r3c7, r3c8, r3c9, r3c10, r3c11, r3c12, r3c13, r3c14, RESTRICT_ARGS_COUNT((r3c15), 64, KEYMAP_STACKED, ##__VA_ARGS__)}, \
-  }
+                                                                        \
+    r0c0, r0c1, r0c2, r0c3, r0c4, r0c5, r0c6, r0c7, r0c8, r0c9, r0c10, r0c11, r0c12, r0c13, r0c14, r0c15, \
+    r1c0, r1c1, r1c2, r1c3, r1c4, r1c5, r1c6, r1c7, r1c8, r1c9, r1c10, r1c11, r1c12, r1c13, r1c14, r1c15, \
+    r2c0, r2c1, r2c2, r2c3, r2c4, r2c5, r2c6, r2c7, r2c8, r2c9, r2c10, r2c11, r2c12, r2c13, r2c14, r2c15, \
+    r3c0, r3c1, r3c2, r3c3, r3c4, r3c5, r3c6, r3c7, r3c8, r3c9, r3c10, r3c11, r3c12, r3c13, r3c14, RESTRICT_ARGS_COUNT((r3c15), 64, KEYMAP_STACKED, ##__VA_ARGS__)
 
-#define KEYMAP(                                                                                     \
+#define KEYMAP_GENERIC(dflt,                                                                                 \
   r0c0, r0c1, r0c2, r0c3, r0c4, r0c5, r0c6,        r0c9,  r0c10, r0c11, r0c12, r0c13, r0c14, r0c15, \
   r1c0, r1c1, r1c2, r1c3, r1c4, r1c5, r1c6,        r1c9,  r1c10, r1c11, r1c12, r1c13, r1c14, r1c15, \
   r2c0, r2c1, r2c2, r2c3, r2c4, r2c5,                     r2c10, r2c11, r2c12, r2c13, r2c14, r2c15, \
   r3c0, r3c1, r3c2, r3c3, r3c4, r3c5, r2c6,        r2c9,  r3c10, r3c11, r3c12, r3c13, r3c14, r3c15, \
               r0c7, r1c7, r2c7, r3c7,                             r3c8,  r2c8,  r1c8, r0c8,         \
                           r3c6,                                          r3c9, ...)                      \
-  {                                                                                                 \
-    {r0c0, r0c1, r0c2, r0c3, r0c4, r0c5, r0c6, r0c7, r0c8, r0c9, r0c10, r0c11, r0c12, r0c13, r0c14, r0c15}, \
-    {r1c0, r1c1, r1c2, r1c3, r1c4, r1c5, r1c6, r1c7, r1c8, r1c9, r1c10, r1c11, r1c12, r1c13, r1c14, r1c15}, \
-    {r2c0, r2c1, r2c2, r2c3, r2c4, r2c5, r2c6, r2c7, r2c8, r2c9, r2c10, r2c11, r2c12, r2c13, r2c14, r2c15}, \
-    {r3c0, r3c1, r3c2, r3c3, r3c4, r3c5, r3c6, r3c7, r3c8, r3c9, r3c10, r3c11, r3c12, r3c13, r3c14, RESTRICT_ARGS_COUNT((r3c15), 64, KEYMAP, ##__VA_ARGS__)}, \
-  }
+    r0c0, r0c1, r0c2, r0c3, r0c4, r0c5, r0c6, r0c7, r0c8, r0c9, r0c10, r0c11, r0c12, r0c13, r0c14, r0c15, \
+    r1c0, r1c1, r1c2, r1c3, r1c4, r1c5, r1c6, r1c7, r1c8, r1c9, r1c10, r1c11, r1c12, r1c13, r1c14, r1c15, \
+    r2c0, r2c1, r2c2, r2c3, r2c4, r2c5, r2c6, r2c7, r2c8, r2c9, r2c10, r2c11, r2c12, r2c13, r2c14, r2c15, \
+    r3c0, r3c1, r3c2, r3c3, r3c4, r3c5, r3c6, r3c7, r3c8, r3c9, r3c10, r3c11, r3c12, r3c13, r3c14, RESTRICT_ARGS_COUNT((r3c15), 64, KEYMAP, ##__VA_ARGS__)
 
 #endif

--- a/src/kaleidoscope/hardware/olkb/Planck.h
+++ b/src/kaleidoscope/hardware/olkb/Planck.h
@@ -43,17 +43,17 @@ class Planck: public kaleidoscope::hardware::ATMegaKeyboard {
   static constexpr int8_t led_count = 0;
 };
 
-#define KEYMAP(                                                                    \
+#define KEYMAP_GENERIC(dflt,                                                       \
          R0C0, R0C1, R0C2, R0C3, R0C4, R0C5, R0C6, R0C7, R0C8, R0C9, R0C10, R0C11, \
          R1C0, R1C1, R1C2, R1C3, R1C4, R1C5, R1C6, R1C7, R1C8, R1C9, R1C10, R1C11, \
          R2C0, R2C1, R2C2, R2C3, R2C4, R2C5, R2C6, R2C7, R2C8, R2C9, R2C10, R2C11, \
-         R3C0, R3C1, R3C2, R3C3, R3C4, R3C5, R3C6, R3C7, R3C8, R3C9, R3C10, R3C11 \
-  ) {                                                                                  \
-         { R0C0, R0C1, R0C2, R0C3, R0C4, R0C5, R0C6, R0C7, R0C8, R0C9, R0C10, R0C11, }, \
-         { R1C0, R1C1, R1C2, R1C3, R1C4, R1C5, R1C6, R1C7, R1C8, R1C9, R1C10, R1C11, }, \
-         { R2C0, R2C1, R2C2, R2C3, R2C4, R2C5, R2C6, R2C7, R2C8, R2C9, R2C10, R2C11, }, \
-         { R3C0, R3C1, R3C2, R3C3, R3C4, R3C5, R3C6, R3C7, R3C8, R3C9, R3C10, R3C11, } \
-  }
+         R3C0, R3C1, R3C2, R3C3, R3C4, R3C5, R3C6, R3C7, R3C8, R3C9, R3C10, R3C11  \
+  )                                                                                \
+         R0C0, R0C1, R0C2, R0C3, R0C4, R0C5, R0C6, R0C7, R0C8, R0C9, R0C10, R0C11, \
+         R1C0, R1C1, R1C2, R1C3, R1C4, R1C5, R1C6, R1C7, R1C8, R1C9, R1C10, R1C11, \
+         R2C0, R2C1, R2C2, R2C3, R2C4, R2C5, R2C6, R2C7, R2C8, R2C9, R2C10, R2C11, \
+         R3C0, R3C1, R3C2, R3C3, R3C4, R3C5, R3C6, R3C7, R3C8, R3C9, R3C10, R3C11
+
 }
 
 }

--- a/src/kaleidoscope/hardware/softhruf/Splitography.h
+++ b/src/kaleidoscope/hardware/softhruf/Splitography.h
@@ -52,36 +52,33 @@ class Splitography: public kaleidoscope::hardware::ATMegaKeyboard {
   static constexpr int8_t led_count = 0;
 };
 
-#define KEYMAP(                                                                    \
+#define KEYMAP_GENERIC(dflt,                                                       \
       r0c0 ,r0c1 ,r0c2 ,r0c3 ,r0c4 ,r0c5   ,r0c6 ,r0c7 ,r0c8 ,r0c9 ,r0c10 ,r0c11   \
      ,r1c0 ,r1c1 ,r1c2 ,r1c3 ,r1c4 ,r1c5   ,r1c6 ,r1c7 ,r1c8 ,r1c9 ,r1c10 ,r1c11   \
      ,r2c0 ,r2c1 ,r2c2 ,r2c3 ,r2c4 ,r2c5   ,r2c6 ,r2c7 ,r2c8 ,r2c9 ,r2c10 ,r2c11   \
                              ,r3c4 ,r3c5   ,r3c6 ,r3c7                             \
   )                                                                                \
-  {                                                                                \
-    { r0c0 ,r0c1 ,r0c2 ,r0c3 ,r0c4 ,r0c5 , r0c6 ,r0c7 ,r0c8 ,r0c9 ,r0c10 ,r0c11 }, \
-    { r1c0 ,r1c1 ,r1c2 ,r1c3 ,r1c4 ,r1c5 , r1c6 ,r1c7 ,r1c8 ,r1c9 ,r1c10 ,r1c11 }, \
-    { r2c0 ,r2c1 ,r2c2 ,r2c3 ,r2c4 ,r2c5 , r2c6 ,r2c7 ,r2c8 ,r2c9 ,r2c10 ,r2c11 }, \
-    { XXX  ,XXX  ,XXX  ,XXX  ,r3c4 ,r3c5  ,r3c6 ,r3c7 ,XXX  ,XXX  ,XXX   ,XXX   }  \
-  }
-
-#define KEYMAP_STACKED(                                                            \
-      r0c0 ,r0c1 ,r0c2 ,r0c3 ,r0c4  ,r0c5                                          \
-     ,r1c0 ,r1c1 ,r1c2 ,r1c3 ,r1c4  ,r1c5                                          \
-     ,r2c0 ,r2c1 ,r2c2 ,r2c3 ,r2c4  ,r2c5                                          \
-                             ,r3c4  ,r3c5                                          \
                                                                                    \
-     ,r0c6 ,r0c7 ,r0c8 ,r0c9 ,r0c10 ,r0c11                                         \
-     ,r1c6 ,r1c7 ,r1c8 ,r1c9 ,r1c10 ,r1c11                                         \
-     ,r2c6 ,r2c7 ,r2c8 ,r2c9 ,r2c10 ,r2c11                                         \
-     ,r3c6 ,r3c7                                                                   \
-  )                                                                                \
-  {                                                                                \
-    { r0c0 ,r0c1 ,r0c2 ,r0c3 ,r0c4 ,r0c5 , r0c6 ,r0c7 ,r0c8 ,r0c9 ,r0c10 ,r0c11 }, \
-    { r1c0 ,r1c1 ,r1c2 ,r1c3 ,r1c4 ,r1c5 , r1c6 ,r1c7 ,r1c8 ,r1c9 ,r1c10 ,r1c11 }, \
-    { r2c0 ,r2c1 ,r2c2 ,r2c3 ,r2c4 ,r2c5 , r2c6 ,r2c7 ,r2c8 ,r2c9 ,r2c10 ,r2c11 }, \
-    { XXX  ,XXX  ,XXX  ,XXX  ,r3c4 ,r3c5  ,r3c6 ,r3c7 ,XXX  ,XXX  ,XXX   ,XXX   }  \
-  }
+      r0c0 ,r0c1 ,r0c2 ,r0c3 ,r0c4 ,r0c5 , r0c6 ,r0c7 ,r0c8 ,r0c9 ,r0c10 ,r0c11,   \
+      r1c0 ,r1c1 ,r1c2 ,r1c3 ,r1c4 ,r1c5 , r1c6 ,r1c7 ,r1c8 ,r1c9 ,r1c10 ,r1c11,   \
+      r2c0 ,r2c1 ,r2c2 ,r2c3 ,r2c4 ,r2c5 , r2c6 ,r2c7 ,r2c8 ,r2c9 ,r2c10 ,r2c11,   \
+      dflt ,dflt ,dflt ,dflt ,r3c4 ,r3c5  ,r3c6 ,r3c7 ,dflt ,dflt ,dflt  ,dflt
+
+#define KEYMAP_STACKED_GENERIC(dflt,                                           \
+      r0c0 ,r0c1 ,r0c2 ,r0c3 ,r0c4  ,r0c5                                      \
+     ,r1c0 ,r1c1 ,r1c2 ,r1c3 ,r1c4  ,r1c5                                      \
+     ,r2c0 ,r2c1 ,r2c2 ,r2c3 ,r2c4  ,r2c5                                      \
+                             ,r3c4  ,r3c5                                      \
+                                                                               \
+     ,r0c6 ,r0c7 ,r0c8 ,r0c9 ,r0c10 ,r0c11                                     \
+     ,r1c6 ,r1c7 ,r1c8 ,r1c9 ,r1c10 ,r1c11                                     \
+     ,r2c6 ,r2c7 ,r2c8 ,r2c9 ,r2c10 ,r2c11                                     \
+     ,r3c6 ,r3c7                                                               \
+  )                                                                            \
+    r0c0 ,r0c1 ,r0c2 ,r0c3 ,r0c4 ,r0c5 ,r0c6 ,r0c7 ,r0c8 ,r0c9 ,r0c10 ,r0c11,  \
+    r1c0 ,r1c1 ,r1c2 ,r1c3 ,r1c4 ,r1c5 ,r1c6 ,r1c7 ,r1c8 ,r1c9 ,r1c10 ,r1c11,  \
+    r2c0 ,r2c1 ,r2c2 ,r2c3 ,r2c4 ,r2c5 ,r2c6 ,r2c7 ,r2c8 ,r2c9 ,r2c10 ,r2c11,  \
+    dflt ,dflt ,dflt ,dflt ,r3c4 ,r3c5 ,r3c6 ,r3c7 ,dflt ,dflt ,dflt  ,dflt
 
 }
 }

--- a/src/kaleidoscope/hardware/technomancy/Atreus.h
+++ b/src/kaleidoscope/hardware/technomancy/Atreus.h
@@ -70,20 +70,19 @@ class Atreus: public kaleidoscope::hardware::ATMegaKeyboard {
  protected:
 };
 
-#define KEYMAP(                                                               \
+#define KEYMAP_GENERIC(dflt,                                                  \
     R0C0, R0C1, R0C2, R0C3, R0C4,             R0C7, R0C8, R0C9, R0C10, R0C11, \
     R1C0, R1C1, R1C2, R1C3, R1C4,             R1C7, R1C8, R1C9, R1C10, R1C11, \
     R2C0, R2C1, R2C2, R2C3, R2C4,             R2C7, R2C8, R2C9, R2C10, R2C11, \
     R3C0, R3C1, R3C2, R3C3, R3C4, R3C5, R3C6, R3C7, R3C8, R3C9, R3C10, R3C11  \
   )                                                                           \
-  {                                                                           \
-    { R0C0, R0C1, R0C2, R0C3, R0C4, XXX,    R0C7, R0C8, R0C9, R0C10, R0C11 }, \
-    { R1C0, R1C1, R1C2, R1C3, R1C4, XXX,    R1C7, R1C8, R1C9, R1C10, R1C11 }, \
-    { R2C0, R2C1, R2C2, R2C3, R2C4, R3C5,   R2C7, R2C8, R2C9, R2C10, R2C11 }, \
-    { R3C0, R3C1, R3C2, R3C3, R3C4, R3C6,   R3C7, R3C8, R3C9, R3C10, R3C11 }  \
-  }
+                                                                              \
+    R0C0, R0C1, R0C2, R0C3, R0C4, XXX,    R0C7, R0C8, R0C9, R0C10, R0C11,     \
+    R1C0, R1C1, R1C2, R1C3, R1C4, XXX,    R1C7, R1C8, R1C9, R1C10, R1C11,     \
+    R2C0, R2C1, R2C2, R2C3, R2C4, R3C5,   R2C7, R2C8, R2C9, R2C10, R2C11,     \
+    R3C0, R3C1, R3C2, R3C3, R3C4, R3C6,   R3C7, R3C8, R3C9, R3C10, R3C11
 
-#define KEYMAP_STACKED(                                                       \
+#define KEYMAP_STACKED_GENERIC(dflt,                                          \
     R0C0, R0C1, R0C2, R0C3, R0C4,                                             \
     R1C0, R1C1, R1C2, R1C3, R1C4,                                             \
     R2C0, R2C1, R2C2, R2C3, R2C4,                                             \
@@ -94,12 +93,10 @@ class Atreus: public kaleidoscope::hardware::ATMegaKeyboard {
           R2C7, R2C8, R2C9, R2C10, R2C11,                                     \
     R3C6, R3C7, R3C8, R3C9, R3C10, R3C11                                      \
   )                                                                           \
-  {                                                                           \
-    { R0C0, R0C1, R0C2, R0C3, R0C4, XXX,    R0C7, R0C8, R0C9, R0C10, R0C11 }, \
-    { R1C0, R1C1, R1C2, R1C3, R1C4, XXX,    R1C7, R1C8, R1C9, R1C10, R1C11 }, \
-    { R2C0, R2C1, R2C2, R2C3, R2C4, R3C5,   R2C7, R2C8, R2C9, R2C10, R2C11 }, \
-    { R3C0, R3C1, R3C2, R3C3, R3C4, R3C6,   R3C7, R3C8, R3C9, R3C10, R3C11 }  \
-  }
+    R0C0, R0C1, R0C2, R0C3, R0C4, dflt,   R0C7, R0C8, R0C9, R0C10, R0C11,     \
+    R1C0, R1C1, R1C2, R1C3, R1C4, dflt,   R1C7, R1C8, R1C9, R1C10, R1C11,     \
+    R2C0, R2C1, R2C2, R2C3, R2C4, R3C5,   R2C7, R2C8, R2C9, R2C10, R2C11,     \
+    R3C0, R3C1, R3C2, R3C3, R3C4, R3C6,   R3C7, R3C8, R3C9, R3C10, R3C11
 }
 }
 }

--- a/src/kaleidoscope/keymaps.h
+++ b/src/kaleidoscope/keymaps.h
@@ -1,0 +1,79 @@
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2018  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "kaleidoscope/key_defs.h"
+
+extern const Key keymaps_linear[][ROWS * COLS];
+
+namespace kaleidoscope {
+
+inline
+Key keyFromKeymap(uint8_t layer, uint8_t row, uint8_t col) {
+  return pgm_read_word(&keymaps_linear[layer][row * COLS + col]);
+}
+
+namespace internal {
+
+// This class mimics a three-dimensional array as formerly used to
+// store keymap arrays in progmem. It wraps the new one dimentional
+// keymap array.
+
+class Keymaps2DInterface {
+
+ public:
+
+  class KeymapLayer {
+
+    const Key * const keymap_layer_;
+
+   public:
+
+    KeymapLayer(const Key * const keymap_layer) : keymap_layer_(keymap_layer) {}
+
+    class KeymapRow {
+
+      const Key * const keymap_row_;
+
+     public:
+      KeymapRow(const Key * const keymap_row) : keymap_row_(keymap_row) {}
+
+      const Key &operator[](uint8_t col) {
+        return keymap_row_[col];
+      }
+    };
+
+    KeymapRow operator[](uint8_t row) {
+      return KeymapRow(keymap_layer_ + row * COLS);
+    }
+  };
+
+  KeymapLayer operator[](uint8_t layer) {
+    return KeymapLayer(keymaps_linear[layer]);
+  }
+};
+
+}
+}
+
+#define _DEPRECATED_MESSAGE_2D_KEYMAP_ARRAY                                    \
+  "Accessing the keymap array directly is deprecated. Please use the function "\
+  "keyFromKeymap() to access keys. The keymap array will be removed in future "\
+  "versions of the firmware"
+
+DEPRECATED(2D_KEYMAP_ARRAY)
+extern kaleidoscope::internal::Keymaps2DInterface keymaps;

--- a/src/kaleidoscope/layers.cpp
+++ b/src/kaleidoscope/layers.cpp
@@ -21,7 +21,7 @@
 // that should be enough for almost any layout.
 #define MAX_LAYERS sizeof(uint32_t) * 8;
 
-// The total number of defined layers in the firmware sketch keymaps[]
+// The total number of defined layers in the firmware sketch keymaps_linear[]
 // array. If the keymap wasn't defined using KEYMAPS(), set it to the
 // highest possible number of layers.
 uint8_t layer_count __attribute__((weak)) = MAX_LAYERS;
@@ -93,11 +93,7 @@ Key Layer_::eventHandler(Key mappedKey, byte row, byte col, uint8_t keyState) {
 }
 
 Key Layer_::getKeyFromPROGMEM(uint8_t layer, byte row, byte col) {
-  Key key;
-
-  key.raw = pgm_read_word(&(keymaps[layer][row][col]));
-
-  return key;
+  return keyFromKeymap(layer, row, col);
 }
 
 void Layer_::updateLiveCompositeKeymap(byte row, byte col) {

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -18,17 +18,21 @@
 
 #include <Arduino.h>
 #include "kaleidoscope/key_defs.h"
+#include "kaleidoscope/keymaps.h"
 #include KALEIDOSCOPE_HARDWARE_H
-
-extern const Key keymaps[][ROWS][COLS];
-
 
 // Macro for defining the keymap. This should be used in the sketch
 // file (*.ino) to define the keymap[] array that holds the user's
 // layers. It also computes the number of layers in that keymap.
-#define KEYMAPS(layers...)				\
-  const Key keymaps[][ROWS][COLS] PROGMEM = { layers };		\
-  uint8_t layer_count = sizeof(keymaps) / sizeof(*keymaps);
+#define KEYMAPS(layers...)				                                    __NL__ \
+  const Key keymaps_linear[][ROWS*COLS] PROGMEM = { layers };           __NL__ \
+  uint8_t layer_count                                                   __NL__ \
+     = sizeof(keymaps_linear) / sizeof(*keymaps_linear);                __NL__ \
+                                                                        __NL__ \
+  /* This deprecated compatibility wrapper is removed by the linker if  __NL__ \
+     it is not accessed nowhere.                                        __NL__ \
+  */                                                                    __NL__ \
+  kaleidoscope::internal::Keymaps2DInterface keymaps;
 
 extern uint8_t layer_count;
 


### PR DESCRIPTION
I am working on a plugin that provides extended keymap features:
https://github.com/CapeLeidokos/Kaleidoscope-XKeymaps

It's almost finished but to make it work, I need all keyboard hardware headers to define a macro that works similar to the existing `KEYMAP_STACKED` macro. The only difference is that the new macro generates a linear list of entities instead of a braced list. The new macro has an additional first macro parameter `dflt` (=default, name shortened to match row/col macro arguments as r0c0) that is used where the `KEYMAP_STACKED` macro would specify `XXX` for unused key matrix positions.

I rely on these macros with `Kaleidoscope-XKeymaps` to conveniently initialize keymap bitfields (keymasks) that are stored in PROGMEM (see the usage of `KEYMASK_STACKED_PROGMEM` in the example provided in the README.md of `Kaleidoscope-XKeymaps`). As a sidenote, the whole bitfield for the Model01 is really stored in 8 PROGMEM bytes and automatically initialized at compile time.

The newly introduced macros will possibly be useful in other places whenever information is supposed to be assigned to keys and this information is meant to be specified in a `KEYMAP_STACKED`-like fashion but passed as a linear list of entities, e.g. as arguments to a function or as an initialization list.