### PR TITLE
Introduced nextLowerLayer(layer) to support non stacked keymap implem…

### DIFF
--- a/src/kaleidoscope/layers.cpp
+++ b/src/kaleidoscope/layers.cpp
@@ -120,7 +120,7 @@ void Layer_::updateActiveLayers(void) {
             break;
           }
         }
-        layer--;
+        layer = nextLowerLayer(layer);
       }
     }
   }
@@ -202,6 +202,11 @@ void Layer_::activateNext(void) {
 
 void Layer_::deactivateTop(void) {
   deactivate(top_active_layer_);
+}
+
+__attribute__((weak))
+uint8_t nextLowerLayer(uint8_t layer) {
+  return layer - 1;
 }
 
 }

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -110,6 +110,8 @@ class Layer_ {
   static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState);
   static void updateTopActiveLayer(void);
 };
+
+extern uint8_t nextLowerLayer(uint8_t layer);
 }
 
 extern kaleidoscope::Layer_ Layer;


### PR DESCRIPTION
I am working on a plugin that provides extended keymap features:
https://github.com/CapeLeidokos/Kaleidoscope-XKeymaps

XKeymaps allows to replace Kaleidoscope's traditional layer stack with a layer tree. Every node in this tree is represented by an integer id. This means that when traversing the layers, the ids are not contiguously decaying towards zero but they form an arbitrary sequence of unsigned integers whose last member is zero.

The only thing that it requires to couple this approach with Kaleidoscope's existing layer class is to replace `--layer` with a call to a newly introduced function `nextLowerLayer(layer)`. 

The default implementation of `nextLowerLayer` still resembles `--layer`. Thus, this change is fully backward compatible.