### PR TITLE
Fix OneShot premature timeout

### DIFF
--- a/src/kaleidoscope/plugin/OneShot.cpp
+++ b/src/kaleidoscope/plugin/OneShot.cpp
@@ -173,7 +173,14 @@ EventHandlerResult OneShot::beforeReportingState() {
 }
 
 EventHandlerResult OneShot::afterEachCycle() {
-  if (hasTimedOut())
+  bool oneshot_active = false;
+  for (uint8_t i = 0; i < ONESHOT_KEY_COUNT; i++) {
+    if (state_[i].active) {
+      oneshot_active = true;
+      break;
+    }
+  }
+  if (oneshot_active && hasTimedOut())
     cancel();
 
   bool is_cancelled = false;


### PR DESCRIPTION
OneShot keys were failing to activate on the first press because of how the timeout was implemented. Most of the time, at the end of a cycle, `should_cancel_` was being set to `true` because the current time was being compared to the last time a OneShot key was activated, regardless of whether or not a OneShot key was active. As a result, OneShot keys that were pressed for the first time in a while would fail to register as OneShots.

This change prevents checking the timeout unless there is an active OneShot key.

Fixes #603.