### PR TITLE
ActiveModColor: Re-scan the keymap if no mods found

### DIFF
--- a/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -56,6 +56,10 @@ EventHandlerResult ActiveModColorEffect::onLayerChange() {
 }
 
 EventHandlerResult ActiveModColorEffect::beforeReportingState() {
+  if (mod_key_count_ == 0) {
+    onLayerChange();
+  }
+
   for (uint8_t i = 0; i < mod_key_count_; i++) {
     uint8_t coords = mod_keys_[i];
     byte c = coords % COLS;


### PR DESCRIPTION
If we found no modifiers on the current layer, force a re-scan. This way we'll scan the keymap without having to change layers first. We can't do the same thing at `onSetup()` time, because that's too early, so we do a check in `beforeReportingState()`.

Fixes #608.
