### PR TITLE
examples/EEPROM-Keymap: Stop using deprecated interfaces

### DIFF
--- a/examples/Features/EEPROM/EEPROM-Keymap/EEPROM-Keymap.ino
+++ b/examples/Features/EEPROM/EEPROM-Keymap/EEPROM-Keymap.ino
@@ -45,7 +45,7 @@ KALEIDOSCOPE_INIT_PLUGINS(EEPROMKeymap, Focus);
 void setup() {
   Kaleidoscope.setup();
 
-  EEPROMKeymap.setup(1, EEPROMKeymap.Mode::EXTEND);
+  EEPROMKeymap.setup(1);
 }
 
 void loop() {


### PR DESCRIPTION
This silences a warning, and gets us ready for the removal of said interface.