### PR TITLE
TopsyTurvy: Ensure active state toggles off

### DIFF
--- a/src/kaleidoscope/plugin/TopsyTurvy.cpp
+++ b/src/kaleidoscope/plugin/TopsyTurvy.cpp
@@ -42,6 +42,8 @@ EventHandlerResult TopsyTurvy::onKeyswitchEvent(Key &mapped_key, byte row, byte 
     return EventHandlerResult::OK;
   }
 
+  is_active_ = keyIsPressed(key_state);
+
   if (keyToggledOn(key_state)) {
     last_pressed_position_ = row * COLS + col;
   } else {
@@ -50,7 +52,6 @@ EventHandlerResult TopsyTurvy::onKeyswitchEvent(Key &mapped_key, byte row, byte 
     }
   }
 
-  is_active_ = keyIsPressed(key_state);
   mapped_key.raw = mapped_key.raw - ranges::TT_FIRST;
 
   // invert the shift state


### PR DESCRIPTION
Previously, if a Topsy key was pressed, then a non-Topsy key was pressed, then the Topsy key was released, we'd return the event consumed before toggling off the active state, leaving Shift keys consumed until a Topsy key got pressed again.

Toggle the active state before the early return for Topsy key events.