### PR TITLE
Fixed Kaleidoscope Builder for Arduino paths containing whitespaces

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -261,12 +261,12 @@ compile () {
     # SC2091: We do not care if quotes or backslashes are not respected.
     # SC2086: We want word splitting.
     # shellcheck disable=SC2086,SC2090
-    ${ARDUINO_BUILDER} \
+    "${ARDUINO_BUILDER}" \
         -compile \
 	      ${ARDUINO_PACKAGES} \
 	      -hardware "${ARDUINO_PATH}/hardware" \
 	      -hardware "${BOARD_HARDWARE_PATH}" \
-	      ${ARDUINO_TOOLS_PARAM} \
+	      ${ARDUINO_TOOLS_FLAG:+"${ARDUINO_TOOLS_FLAG}"} ${ARDUINO_TOOLS_PARAM:+"${ARDUINO_TOOLS_PARAM}"} \
 	      -tools "${ARDUINO_PATH}/tools-builder" \
 	      -fqbn "${FQBN}" \
         -libraries "." \

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -27,10 +27,10 @@ fi
 uname_S=$(uname -s 2>/dev/null || echo not)
 
 find_max_prog_size() {
-    VPIDS=$(${ARDUINO_BUILDER} \
+    VPIDS=$("${ARDUINO_BUILDER}" \
     -hardware "${ARDUINO_PATH}/hardware" \
     -hardware "${BOARD_HARDWARE_PATH}" \
-    ${ARDUINO_TOOLS_PARAM} \
+    ${ARDUINO_TOOLS_FLAG:+"${ARDUINO_TOOLS_FLAG}"} ${ARDUINO_TOOLS_PARAM:+"${ARDUINO_TOOLS_PARAM}"} \
     -tools "${ARDUINO_PATH}/tools-builder" \
     -fqbn "${FQBN}" \
     -dump-prefs | grep "upload\.maximum_size=")
@@ -38,10 +38,10 @@ find_max_prog_size() {
 }
 
 find_device_vid_pid() {
-    VPIDS=$(${ARDUINO_BUILDER} \
+    VPIDS=$("${ARDUINO_BUILDER}" \
 		-hardware "${ARDUINO_PATH}/hardware" \
 		-hardware "${BOARD_HARDWARE_PATH}" \
-		${ARDUINO_TOOLS_PARAM} \
+		${ARDUINO_TOOLS_FLAG:+"${ARDUINO_TOOLS_FLAG}"} ${ARDUINO_TOOLS_PARAM:+"${ARDUINO_TOOLS_PARAM}"} \
 		-tools "${ARDUINO_PATH}/tools-builder" \
 		-fqbn "${FQBN}" \
 		-dump-prefs | grep "\.[vp]id=")
@@ -166,7 +166,8 @@ BOARD_HARDWARE_PATH="${BOARD_HARDWARE_PATH:-${ARDUINO_LOCAL_LIB_PATH}/hardware}"
 BOOTLOADER_PATH="${BOOTLOADER_PATH:-${BOARD_HARDWARE_PATH}/keyboardio/avr/bootloaders/caterina/Caterina.hex}"
 
 if [ ! -z "${ARDUINO_TOOLS_PATH}" ]; then
-    ARDUINO_TOOLS_PARAM="-tools ${ARDUINO_TOOLS_PATH}"
+    ARDUINO_TOOLS_PARAM="${ARDUINO_TOOLS_PATH}"
+    ARDUINO_TOOLS_FLAG="-tools" 
 fi
 
 if [ ! -z "${AVR_GCC_PREFIX}" ]; then


### PR DESCRIPTION
This PR adds what is needed to build Kaleidoscope with msys2 when Arduino is installed in its Windows standard location that contains spaces "C:\Program Files (x86)\Arduino".

it basically adds missing quotes to variable evaluations. 