### PR TITLE
Make opposing mouse movement keys cancel each other

### DIFF
--- a/src/kaleidoscope/plugin/MouseKeys.cpp
+++ b/src/kaleidoscope/plugin/MouseKeys.cpp
@@ -92,14 +92,14 @@ EventHandlerResult MouseKeys_::beforeReportingState() {
   }
 
   if (mouseMoveIntent & KEY_MOUSE_UP)
-    moveY = -speed;
-  else if (mouseMoveIntent & KEY_MOUSE_DOWN)
-    moveY = speed;
+    moveY -= speed;
+  if (mouseMoveIntent & KEY_MOUSE_DOWN)
+    moveY += speed;
 
   if (mouseMoveIntent & KEY_MOUSE_LEFT)
-    moveX = -speed;
-  else if (mouseMoveIntent & KEY_MOUSE_RIGHT)
-    moveX = speed;
+    moveX -= speed;
+  if (mouseMoveIntent & KEY_MOUSE_RIGHT)
+    moveX += speed;
 
   MouseWrapper.move(moveX, moveY);
 


### PR DESCRIPTION
Instead of having `Key_mouseL` & `Key_mouseUp` override `Key_mouseR` & `Key_mouseDn`, respectively, stop mouse movement on a given axis when both keys are held simultaneously. Doing so will not reset acceleration, so when one of them is released, the mouse will resume movement at full speed immediately.

Closes #634.