### PR TITLE
Refactored LEDMode related classes

### DIFF
--- a/src/kaleidoscope/plugin/AccessTransientLEDMode.h
+++ b/src/kaleidoscope/plugin/AccessTransientLEDMode.h
@@ -1,4 +1,4 @@
-/* Kaleidoscope-LEDControl - LED control plugin for Kaleidoscope
+/*
  * Copyright (C) 2017-2018  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -14,17 +14,27 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#include <kaleidoscope/plugin/LEDMode.h>
-#include <kaleidoscope/plugin/LEDControl.h>
-#include <kaleidoscope/event_handler_result.h>
+#pragma once
 
 namespace kaleidoscope {
 namespace plugin {
 
-void LEDModeInterface::activate() {
-  LEDControl::activate(this);
-}
+class AccessTransientLEDMode {
+ public:
+
+  // This method is called when a plugin's LED mode is activated.
+  // Derived plugins may reimplement it to store the id of their
+  // exported LED mode. A plugin can thus check
+  // whether their LED mode is currently active.
+  //
+  void registerLEDModeActivated(uint8_t led_mode_id) {
+    led_mode_id_ = led_mode_id;
+  }
+
+ protected:
+
+  uint8_t led_mode_id_ = 255; /* 255 means uninitialized */
+};
 
 } // end namespace plugin
 } // end namespace kaleidoscope

--- a/src/kaleidoscope/plugin/LEDMode.h
+++ b/src/kaleidoscope/plugin/LEDMode.h
@@ -1,4 +1,4 @@
-/* Kaleidoscope-LEDControl - LED control plugin for Kaleidoscope
+/* Kaleidoscope-LEDMode - LED modes for Kaleidoscope
  * Copyright (C) 2017-2018  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -17,6 +17,8 @@
 #pragma once
 
 #include "kaleidoscope/plugin.h"
+#include "kaleidoscope/plugin/AccessTransientLEDMode.h"
+#include "kaleidoscope/plugin/LEDModeInterface.h"
 
 namespace kaleidoscope {
 
@@ -26,42 +28,6 @@ class LEDModeManager;
 } // end namespace internal
 
 namespace plugin {
-
-class LEDModeInterface {
- public:
-
-  void activate();
-
-  // This auxiliary class helps to generate a verbose error message
-  // in case that there is no TransientLEDMode typedef or nested
-  // class present in a derived class of LEDModeInterface.
-  //
-  struct _____LEDModeInterface_derived_class_is_missing_a_TransientLEDMode_typedef_or_nested_class_____ {};
-  typedef _____LEDModeInterface_derived_class_is_missing_a_TransientLEDMode_typedef_or_nested_class_____ NoLEDMode;
-
-  // By redefining TransientLEDMode, derived plugins export
-  // a LED mode that becomes part of the set of LED modes whose
-  // lifetime is handled dynamically.
-  //
-  typedef NoLEDMode DynamicLEDMode;
-};
-
-class AccessTransientLEDMode {
- public:
-
-  // This method is called when a plugin's LED mode is activated.
-  // Derived plugins may reimplement it to store the id of their
-  // exported LED mode. A plugin can thus check
-  // whether their LED mode is currently active.
-  //
-  void registerLEDModeActivated(uint8_t led_mode_id) {
-    led_mode_id_ = led_mode_id;
-  }
-
- protected:
-
-  uint8_t led_mode_id_ = 255; /* 255 means uninitialized */
-};
 
 /** Base class for LED modes.
 *

--- a/src/kaleidoscope/plugin/LEDModeInterface.cpp
+++ b/src/kaleidoscope/plugin/LEDModeInterface.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2017-2018  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <kaleidoscope/plugin/LEDModeInterface.h>
+#include <kaleidoscope/plugin/LEDControl.h>
+
+namespace kaleidoscope {
+namespace plugin {
+
+void LEDModeInterface::activate() {
+  LEDControl::activate(this);
+}
+
+} // end namespace plugin
+} // end namespace kaleidoscope

--- a/src/kaleidoscope/plugin/LEDModeInterface.h
+++ b/src/kaleidoscope/plugin/LEDModeInterface.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2017-2018  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace kaleidoscope {
+namespace plugin {
+
+class LEDModeInterface {
+ public:
+
+  void activate();
+
+  // This auxiliary class helps to generate a verbose error message
+  // in case that there is no TransientLEDMode typedef or nested
+  // class present in a derived class of LEDModeInterface.
+  //
+  struct _____LEDModeInterface_derived_class_is_missing_a_TransientLEDMode_typedef_or_nested_class_____ {};
+  typedef _____LEDModeInterface_derived_class_is_missing_a_TransientLEDMode_typedef_or_nested_class_____ NoLEDMode;
+
+  // By redefining TransientLEDMode, derived plugins export
+  // a LED mode that becomes part of the set of LED modes whose
+  // lifetime is handled dynamically.
+  //
+  typedef NoLEDMode DynamicLEDMode;
+};
+
+} // end namespace plugin
+} // end namespace kaleidoscope


### PR DESCRIPTION
This PR picks up the suggestion https://github.com/keyboardio/Kaleidoscope/pull/617#pullrequestreview-225975913 to refactor header `LEDMode.h`.

It does the following:

* factor out class AccessTransientLEDMode to an individual file
* factor out class LEDModeInterface to individual files
* fix the file header comment in LEDMode.h