### PR TITLE
Complete rewrite of Qukeys

### DIFF
--- a/examples/Keystrokes/Qukeys/Qukeys.ino
+++ b/examples/Keystrokes/Qukeys/Qukeys.ino
@@ -70,8 +70,8 @@ void setup() {
     kaleidoscope::plugin::Qukey(0, KeyAddr(2, 4), Key_LeftShift),    // F/shift
     kaleidoscope::plugin::Qukey(0, KeyAddr(3, 6), ShiftToLayer(1))   // Q/layer-shift (on `fn`)
   )
-  Qukeys.setTimeout(200);
-  Qukeys.setReleaseDelay(20);
+  Qukeys.setHoldTimeout(1000);
+  Qukeys.setOverlapThreshold(50);
 
   Kaleidoscope.setup();
 }

--- a/src/kaleidoscope/plugin/Qukeys.h
+++ b/src/kaleidoscope/plugin/Qukeys.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Qukeys -- Assign two keycodes to a single key
- * Copyright (C) 2017  Michael Richters
+ * Copyright (C) 2017-2019  Michael Richters
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,25 +20,9 @@
 
 #include <Kaleidoscope.h>
 #include <Kaleidoscope-Ranges.h>
+#include "kaleidoscope/plugin/Qukeys/KeyAddrEventQueue.h"
 
-// Maximum length of the pending queue
-#define QUKEYS_QUEUE_MAX 8
-
-// Boolean values for storing qukey state
-#define QUKEY_STATE_PRIMARY false
-#define QUKEY_STATE_ALTERNATE true
-
-// Initialization addr value for empty key_queue. This seems to be
-// unnecessary, because we rely on keeping track of the lenght of the
-// queue, anyway.
-#define QUKEY_UNKNOWN_ADDR 0xFF
-// Value to return when no match is found in Qukeys.dict. A successful
-// match returns an index in the array, so this must be negative. Also
-// used for failed search of the key_queue.
-#define QUKEY_NOT_FOUND -1
-// Wildcard value; this matches any layer
-#define QUKEY_ALL_LAYERS -1
-
+// DualUse Key definitions for Qukeys in the keymap
 #define MT(mod, key) Key(                                               \
     kaleidoscope::ranges::DUM_FIRST +                                   \
     (((Key_ ## mod).keyCode - Key_LeftControl.keyCode) << 8) +          \
@@ -51,90 +35,184 @@
 
 #define LT(layer, key) Key(kaleidoscope::ranges::DUL_FIRST + (layer << 8) + (Key_ ## key).keyCode)
 
+#define _DEPRECATED_MESSAGE_QUKEY_ROW_COL_CONSTRUCTOR                        \
+  "The `Qukey(layer, row, col, alternate_key)` constructor using separate\n" \
+  "`row` & `col` parameters has been deprecated. Please replace this\n"      \
+  "constructor with the new `KeyAddr` version:\n"                            \
+  "    `Qukey(layer, KeyAddr(row, col), alternate_key)`"
+
+#define _DEPRECATED_MESSAGE_QUKEYS_TIMEOUT                                  \
+  "The Qukeys.setTimeout() function has been renamed to setHoldTimeout()\n" \
+  "in order to distinguish it from the other timeouts more clearly."
+
+#define _DEPRECATED_MESSAGE_QUKEYS_RELEASEDELAY                               \
+  "The Qukeys.setReleaseDelay() is now obsolete. The rollover grace period\n" \
+  "for qukey release has been replaced with an improved version based on\n"   \
+  "the percentage of overlap between the qukey and the subsequent\n"          \
+  "key. Please use the setOverlapThreshold() function instead."
+
 namespace kaleidoscope {
 namespace plugin {
 
 // Data structure for an individual qukey
 struct Qukey {
- public:
-  Qukey(void) {}
-  Qukey(int8_t layer, KeyAddr key_addr, Key alt_keycode);
-  DEPRECATED(ROW_COL_FUNC) Qukey(int8_t layer, byte row, byte col, Key alt_keycode)
-    : Qukey(layer, KeyAddr(row, col), alt_keycode) {}
-
+  // The layer this qukey is mapped on.
   int8_t layer;
-  uint8_t addr;
-  Key alt_keycode;
+  // The keyswitch address of the qukey.
+  KeyAddr addr;
+  // The alternake Key value this qukey should use (when held).
+  Key alternate_key;
+
+  // This is the constructor that should be used when creating a Qukey object in
+  // the PROGMEM array that will be used by Qukeys (i.e. in the `QUKEYS()`
+  // macro).
+  constexpr
+  Qukey(int8_t layer, KeyAddr k, Key alternate_key)
+    : layer(layer), addr(k), alternate_key(alternate_key) {}
+  // This constructor is here so that we can create an empty Qukey object in RAM
+  // into which we can copy the values from a PROGMEM Qukey object.
+  Qukey() = default;
+
+  // Old-style Qukey constructor for backwards compatibility.
+  DEPRECATED(QUKEY_ROW_COL_CONSTRUCTOR)
+  constexpr
+  Qukey(int8_t layer, uint8_t row, uint8_t col, Key alternate_key)
+    : layer(layer), addr(KeyAddr(row, col)), alternate_key(alternate_key) {}
 };
 
-// Data structure for an entry in the key_queue
-struct QueueItem {
-  uint8_t addr;        // keyswitch coordinates
-  uint16_t start_time; // time a queued key was pressed
-};
 
-// The plugin itself
 class Qukeys : public kaleidoscope::Plugin {
-  // I could use a bitfield to get the state values, but then we'd
-  // have to check the key_queue (there are three states). Or use a
-  // second bitfield for the indeterminite state. Using a bitfield
-  // would enable storing the qukey list in PROGMEM, but I don't know
-  // if the added complexity is worth it.
- public:
-  Qukeys(void);
 
-  static void activate(void) {
+ public:
+  // Methods for turning the plugin on and off.
+  void activate() {
     active_ = true;
   }
-  static void deactivate(void) {
+  void deactivate() {
     active_ = false;
   }
-  static void toggle(void) {
+  void toggle() {
     active_ = !active_;
   }
-  static void setTimeout(uint16_t time_limit) {
-    time_limit_ = time_limit;
-  }
-  static void setReleaseDelay(uint8_t release_delay) {
-    release_delay_ = release_delay;
+
+  // Set the timeout (in milliseconds) for a held qukey. If a qukey is held at
+  // least this long, it will take on its alternate value (unless its primary
+  // value is a modifier -- i.e. a SpaceCadet type key).
+  void setHoldTimeout(uint16_t hold_timeout) {
+    hold_timeout_ = hold_timeout;
   }
 
-  static Qukey * qukeys;
-  static uint8_t qukeys_count;
+  // Set the percentage of the duration of a subsequent key's press that must
+  // overlap with the qukey preceding it above which the qukey will take on its
+  // alternate key value. In other words, if the user presses qukey `Q`, then
+  // key `K`, and the overlap of the two keys (`O`) is less than this
+  // percentage, the qukey will take on its primary value, but if it's greater
+  // (i.e. `K` spends a very small fraction of its time pressed after the `Q` is
+  // released), the qukey will take on its alternate value.
+  void setOverlapThreshold(uint8_t percentage) {
+    // Only percentages less than 100% are meaningful. 0% means to turn off the
+    // rollover grace period and rely solely on release order to determine the
+    // qukey's state.
+    if (percentage < 100) {
+      overlap_threshold_ = percentage;
+    } else {
+      overlap_threshold_ = 0;
+    }
+  }
 
-  EventHandlerResult onSetup();
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
+  // Function for defining the array of qukeys data (in PROGMEM). It's a
+  // template function that takes as its sole argument an array reference of
+  // size `_qukeys_count`, so there's no need to use `sizeof` to calculate the
+  // correct size, and pass it as a separate parameter.
+  template <uint8_t _qukeys_count>
+  void configureQukeys(Qukey const(&qukeys)[_qukeys_count]) {
+    qukeys_ = qukeys;
+    qukeys_count_ = _qukeys_count;
+  }
+
+  // Obsolete configuration functions.
+  DEPRECATED(QUKEYS_TIMEOUT)
+  void setTimeout(uint16_t time_limit) {
+    setHoldTimeout(time_limit);
+  }
+  DEPRECATED(QUKEYS_RELEASEDELAY)
+  void setReleaseDelay(uint8_t release_delay) {
+    if (release_delay == 0) {
+      overlap_threshold_ = 0;
+    } else {
+      overlap_threshold_ = 60;
+    }
+  }
+
+  // A wildcard value for a qukey that exists on every layer.
+  static constexpr int8_t layer_wildcard{-1};
+
+  // Kaleidoscope hook functions.
+  EventHandlerResult onKeyswitchEvent(Key &mapped_key,
+                                      KeyAddr key_addr,
+                                      uint8_t key_state);
   EventHandlerResult beforeReportingState();
 
  private:
-  static bool active_;
-  static uint16_t time_limit_;
-  static uint8_t release_delay_;
-  static QueueItem key_queue_[QUKEYS_QUEUE_MAX];
-  static uint8_t key_queue_length_;
-  static bool flushing_queue_;
+  // An array of Qukey objects in PROGMEM.
+  Qukey const * qukeys_{nullptr};
+  uint8_t qukeys_count_{0};
 
-  static uint8_t delayed_qukey_addr_;
-  static int16_t delayed_qukey_start_time_;
+  // The maximum number of events in the queue at a time.
+  static constexpr uint8_t queue_capacity_{8};
 
-  static int8_t lookupQukey(uint8_t key_addr);
-  static void enqueue(uint8_t key_addr);
-  static int8_t searchQueue(uint8_t key_addr);
-  static bool flushKey(bool qukey_state, uint8_t keyswitch_state);
-  static void flushQueue(int8_t index);
-  static void flushQueue(void);
-  static bool isQukey(uint8_t addr);
+  // The event queue stores a series of press and release events.
+  KeyAddrEventQueue<queue_capacity_> event_queue_;
+
+  // This determines whether the plugin is on or off.
+  bool active_{true};
+
+  // This variable stores the percentage number between 0 and 99 that determines
+  // how forgiving the plugin is of rollover from a qukey to a modified key.
+  uint8_t overlap_threshold_{80};
+
+  // The number of milliseconds until a qukey held on its own will take on its
+  // alternate state (or primary state, in the case of a SpaceCadet-type qukey).
+  uint16_t hold_timeout_{250};
+
+  // This is a guard against re-processing events when qukeys flushes them from
+  // its event queue. We can't just use an "injected" key state flag, because
+  // that would cause other plugins to also ignore the event.
+  bool flushing_queue_{false};
+
+  // A cache of the current qukey's primary and alternate key values, so we
+  // don't have to keep looking them up from PROGMEM.
+  struct {
+    Key primary_key{Key_Transparent};
+    Key alternate_key{Key_Transparent};
+  } queue_head_;
+
+  // Internal helper methods.
+  bool processQueue();
+  void flushEvent(Key event_key);
+  bool isQukey(KeyAddr k);
+  bool isDualUseKey(Key key);
+  bool releaseDelayed(uint16_t overlap_start, uint16_t overlap_end) const;
+  bool isKeyAddrInQueueBeforeIndex(KeyAddr k, uint8_t index) const;
 };
 
-} // namespace plugin {
+// This function returns true for any key that we expect to be used chorded with
+// a "modified" key. This includes actual keyboard modifiers, but also layer
+// shift keys. Used for determining if a qukey is a SpaceCadet-type key.
+bool isModifierKey(Key key);
 
+} // namespace plugin {
 } // namespace kaleidoscope {
 
 extern kaleidoscope::plugin::Qukeys Qukeys;
 
-// macro for use in sketch file to simplify definition of qukeys
-#define QUKEYS(qukey_defs...) {						\
-  static kaleidoscope::plugin::Qukey qk_table[] = { qukey_defs }; \
-  Qukeys.qukeys = qk_table;						\
-  Qukeys.qukeys_count = sizeof(qk_table) / sizeof(kaleidoscope::plugin::Qukey); \
+// Macro for use in sketch file to simplify definition of the qukeys array and
+// guarantee that the count is set correctly. This is considerably less
+// important than it used to be, with the `configureQukeys()` function taking
+// care of guaranteeing the correct count setting.
+#define QUKEYS(qukey_defs...) {                                         \
+    static kaleidoscope::plugin::Qukey const qk_table[] PROGMEM = {     \
+      qukey_defs                                                        \
+    };                                                                  \
+    Qukeys.configureQukeys(qk_table);                                   \
 }

--- a/src/kaleidoscope/plugin/Qukeys/KeyAddrEventQueue.h
+++ b/src/kaleidoscope/plugin/Qukeys/KeyAddrEventQueue.h
@@ -1,0 +1,115 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <Arduino.h>
+//#include <assert.h>
+
+#include "kaleidoscope/Kaleidoscope.h"
+#include "kaleidoscope/KeyAddr.h"
+
+namespace kaleidoscope {
+namespace plugin {
+
+// This class defines a keyswitch event queue that stores both press and release
+// events, recording the key address, a timestamp, and the keyswitch state
+// (press or release). It is optimized for random access to the queue entries,
+// so that each property of each entry can be retrieved without fetching any
+// other data, in order to best serve the specific needs of the Qukeys
+// plugin. Its performance is better for a queue that needs to be searched much
+// more frequently than entries are added or removed.
+template <uint8_t _capacity,
+          typename _Bitfield  = uint8_t,
+          typename _Timestamp = uint16_t>
+class KeyAddrEventQueue {
+
+  static_assert(_capacity <= (sizeof(_Bitfield) * 8),
+                "EventQueue error: _Bitfield type too small for _capacity!");
+
+ private:
+  uint8_t    length_{0};
+  KeyAddr    addrs_[_capacity];
+  _Timestamp timestamps_[_capacity];
+  _Bitfield  release_event_bits_;
+
+ public:
+  uint8_t length() const {
+    return length_;
+  }
+  bool isEmpty() const {
+    return (length_ == 0);
+  }
+  bool isFull() const {
+    return (length_ == _capacity);
+  }
+
+  // Queue entry access methods. Note: the caller is responsible for bounds
+  // checking, because it's expected that a for loop will be used when searching
+  // the queue, which will terminate when `index >= queue.length()`.
+  KeyAddr addr(uint8_t index) const {
+    // assert(index < length_);
+    return addrs_[index];
+  }
+
+  _Timestamp timestamp(uint8_t index) const {
+    // assert(index < length_);
+    return timestamps_[index];
+  }
+
+  bool isRelease(uint8_t index) const {
+    // assert(index < length_);
+    return bitRead(release_event_bits_, index);
+  }
+  bool isPress(uint8_t index) const {
+    // assert(index < length_);
+    return !isRelease(index);
+  }
+
+  // Append a new event on the end of the queue. Note: the caller is responsible
+  // for bounds checking; we don't guard against it here.
+  void append(KeyAddr k, uint8_t keyswitch_state) {
+    // assert(length_ < _capacity);
+    addrs_[length_]      = k;
+    timestamps_[length_] = Kaleidoscope.millisAtCycleStart();
+    bitWrite(release_event_bits_, length_, keyToggledOff(keyswitch_state));
+    ++length_;
+  }
+
+  // Remove the first event from the head of the queue, shifting the
+  // others. This function actually shifts the queue by copying element values,
+  // rather than using a ring buffer because we expect it will be called much
+  // less often than the queue is searched via a for loop.
+  void shift() {
+    // assert(length > 0);
+    --length_;
+    for (uint8_t i{0}; i < length_; ++i) {
+      addrs_[i]      = addrs_[i + 1];
+      timestamps_[i] = timestamps_[i + 1];
+    }
+    release_event_bits_ >>= 1;
+  }
+
+  // Empty the queue entirely.
+  void clear() {
+    length_             = 0;
+    release_event_bits_ = 0;
+  }
+};
+
+}  // namespace plugin
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/progmem_helpers.h
+++ b/src/kaleidoscope/progmem_helpers.h
@@ -1,0 +1,35 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// Load any intrinsic data type or trivial class stored in PROGMEM into an
+// object of that type in memory.
+template <typename _Type>
+void loadFromProgmem(_Type const& pgm_object, _Type& object) {
+  memcpy_P(&object, &pgm_object, sizeof(object));
+}
+
+// Copy an object from PROGMEM to RAM. This works as long as the type has a
+// suitable constructor that does not require arguments (i.e. "trivial classes")
+// or if `_Type` is an intrinsic data type.
+template <typename _Type>
+_Type cloneFromProgmem(_Type const& pgm_object) {
+  _Type object;
+  memcpy_P(&object, &pgm_object, sizeof(object));
+  return object;
+}


### PR DESCRIPTION
This is a complete rewrite of Qukeys, built on top of #621, in order to implement several improvements and new features:

- A new EventQueue class has been introduced, in order to store both key press and release events in the queue.
- The direct dependence on KeyboardioHID is removed by only flushing one event from the queue per cycle.
- The array of Qukey objects is now stored in PROGMEM instead of SRAM.
- There is a new algorithm for determining which state a qukey will collapse into in the case of rollover from qukey to another key, which should reduce the rate of errors for "sloppy" typists.
- A Qukey with a primary key value that is a modifier (including layer shift keys) is treated like a SpaceCadet key, with different semantics. The alternate (non-modifier) key value is only used if the SpaceCadet key is pressed and released on its own, without rolling over to any other key.
- The code is generally simpler and easier to understand, with better inline comments explaining how it all works.

This pull request supersedes #637 (and functionally includes those changes, though not the actual commits).