### PR TITLE
Standardize plugin timers

### DIFF
--- a/src/kaleidoscope/plugin/CycleTimeReport.cpp
+++ b/src/kaleidoscope/plugin/CycleTimeReport.cpp
@@ -20,12 +20,12 @@
 
 namespace kaleidoscope {
 namespace plugin {
-uint32_t CycleTimeReport::next_report_time_;
+uint16_t CycleTimeReport::last_report_time_;
 uint32_t CycleTimeReport::loop_start_time_;
 uint32_t CycleTimeReport::average_loop_time;
 
 EventHandlerResult CycleTimeReport::onSetup() {
-  next_report_time_ = millis() + 1000;
+  last_report_time_ = Kaleidoscope.millisAtCycleStart();
   return EventHandlerResult::OK;
 }
 
@@ -42,11 +42,11 @@ EventHandlerResult CycleTimeReport::afterEachCycle() {
   else
     average_loop_time = loop_time;
 
-  if (millis() >= next_report_time_) {
+  if (Kaleidoscope.hasTimeExpired(last_report_time_, uint16_t(1000))) {
     cycleTimeReport();
 
     average_loop_time = 0;
-    next_report_time_ = millis() + 1000;
+    last_report_time_ = Kaleidoscope.millisAtCycleStart();
   }
 
   return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/CycleTimeReport.h
+++ b/src/kaleidoscope/plugin/CycleTimeReport.h
@@ -32,7 +32,7 @@ class CycleTimeReport : public kaleidoscope::Plugin {
   static uint32_t average_loop_time;
 
  private:
-  static uint32_t next_report_time_;
+  static uint16_t last_report_time_;
   static uint32_t loop_start_time_;
 };
 }

--- a/src/kaleidoscope/plugin/GhostInTheFirmware.cpp
+++ b/src/kaleidoscope/plugin/GhostInTheFirmware.cpp
@@ -46,11 +46,11 @@ EventHandlerResult GhostInTheFirmware::beforeReportingState() {
       return EventHandlerResult::OK;
     }
     is_pressed_ = true;
-    start_time_ = millis();
+    start_time_ = Kaleidoscope.millisAtCycleStart();
   } else {
-    if (is_pressed_ && ((millis() - start_time_) > press_timeout_)) {
+    if (is_pressed_ && Kaleidoscope.hasTimeExpired(start_time_, press_timeout_)) {
       is_pressed_ = false;
-      start_time_ = millis();
+      start_time_ = Kaleidoscope.millisAtCycleStart();
 
       byte row = pgm_read_byte(&(ghost_keys[current_pos_].row));
       byte col = pgm_read_byte(&(ghost_keys[current_pos_].col));
@@ -61,7 +61,7 @@ EventHandlerResult GhostInTheFirmware::beforeReportingState() {
       byte col = pgm_read_byte(&(ghost_keys[current_pos_].col));
 
       handleKeyswitchEvent(Key_NoKey, row, col, IS_PRESSED);
-    } else if ((millis() - start_time_) > delay_timeout_) {
+    } else if (Kaleidoscope.hasTimeExpired(start_time_, delay_timeout_)) {
       current_pos_++;
       press_timeout_ = 0;
     }

--- a/src/kaleidoscope/plugin/Heatmap.cpp
+++ b/src/kaleidoscope/plugin/Heatmap.cpp
@@ -38,8 +38,8 @@ Heatmap::TransientLEDMode::TransientLEDMode(const Heatmap *parent)
     heatmap_{},
     // max of heatmap_ (we divide by it so we start at 1)
     highest_(1),
-    // next heatmap computation time
-    next_heatmap_comp_time_(0)
+    // last heatmap computation time
+    last_heatmap_comp_time_(Kaleidoscope.millisAtCycleStart())
 {}
 
 cRGB Heatmap::TransientLEDMode::computeColor(float v) {
@@ -211,14 +211,14 @@ void Heatmap::TransientLEDMode::update(void) {
 
   // this methode is called frequently by the LEDControl::loopHook
 
-  // do nothing if we didn't reach next_heatmap_comp_time_ yet
-  if (next_heatmap_comp_time_ && (millis() < next_heatmap_comp_time_))
+  // do nothing if the update interval hasn't elapsed since the previous update
+  if (!Kaleidoscope.hasTimeExpired(last_heatmap_comp_time_, update_delay))
     return;
   // do the heatmap computing
-  // (we reach next_heatmap_comp_time_ or next_heatmap_comp_time_ was never scheduled)
+  // (update_delay milliseconds elapsed since last_heatmap_comp_time)
 
   // schedule the next heatmap computing
-  next_heatmap_comp_time_ = millis() + update_delay;
+  last_heatmap_comp_time_ = Kaleidoscope.millisAtCycleStart();
 
   // for each key
   for (uint8_t r = 0; r < ROWS; r++) {

--- a/src/kaleidoscope/plugin/Heatmap.h
+++ b/src/kaleidoscope/plugin/Heatmap.h
@@ -61,7 +61,7 @@ class Heatmap : public Plugin,
 
     uint16_t heatmap_[ROWS][COLS];
     uint16_t highest_;
-    uint32_t next_heatmap_comp_time_;
+    uint16_t last_heatmap_comp_time_;
 
     void shiftStats(void);
     cRGB computeColor(float v);

--- a/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -22,11 +22,11 @@ namespace kaleidoscope {
 namespace plugin {
 
 uint16_t IdleLEDs::idle_time_limit = 600; // 10 minutes
-uint32_t IdleLEDs::end_time_;
+uint32_t IdleLEDs::start_time_ = 0;
 
 EventHandlerResult IdleLEDs::beforeEachCycle() {
   if (!::LEDControl.paused &&
-      (Kaleidoscope.millisAtCycleStart() >= end_time_)) {
+      Kaleidoscope.hasTimeExpired(start_time_, uint32_t(idle_time_limit * 1000))) {
     ::LEDControl.set_all_leds_to(CRGB(0, 0, 0));
     ::LEDControl.syncLeds();
 
@@ -43,7 +43,7 @@ EventHandlerResult IdleLEDs::onKeyswitchEvent(Key &mapped_key, byte row, byte co
     ::LEDControl.refreshAll();
   }
 
-  end_time_ = Kaleidoscope.millisAtCycleStart() + (uint32_t)idle_time_limit * 1000;
+  start_time_ = Kaleidoscope.millisAtCycleStart();
 
   return EventHandlerResult::OK;
 }

--- a/src/kaleidoscope/plugin/IdleLEDs.h
+++ b/src/kaleidoscope/plugin/IdleLEDs.h
@@ -28,15 +28,11 @@ class IdleLEDs: public kaleidoscope::Plugin {
 
   static uint16_t idle_time_limit;
 
-  EventHandlerResult onSetup() {
-    end_time_ = millis() + idle_time_limit * 1000;
-    return EventHandlerResult::OK;
-  }
   EventHandlerResult beforeEachCycle();
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
 
  private:
-  static uint32_t end_time_;
+  static uint32_t start_time_;
 };
 }
 }

--- a/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
@@ -43,7 +43,7 @@ class AlphaSquareEffect : public Plugin,
     void refreshAt(byte row, byte col) final;
 
    private:
-    uint32_t end_time_left_, end_time_right_;
+    uint16_t start_time_left_, start_time_right_;
     Key last_key_left_, last_key_right_;
 
     friend class AlphaSquareEffect;

--- a/src/kaleidoscope/plugin/LED-Stalker.cpp
+++ b/src/kaleidoscope/plugin/LED-Stalker.cpp
@@ -57,8 +57,7 @@ void StalkerEffect::TransientLEDMode::update(void) {
   if (!parent_->variant)
     return;
 
-  uint16_t elapsed = Kaleidoscope.millisAtCycleStart() - step_start_time_;
-  if (elapsed < parent_->step_length)
+  if (!Kaleidoscope.hasTimeExpired(step_start_time_, parent_->step_length))
     return;
 
   for (byte r = 0; r < ROWS; r++) {

--- a/src/kaleidoscope/plugin/LED-Wavepool.cpp
+++ b/src/kaleidoscope/plugin/LED-Wavepool.cpp
@@ -81,14 +81,14 @@ void WavepoolEffect::TransientLEDMode::raindrop(uint8_t x, uint8_t y, int8_t *pa
 uint8_t WavepoolEffect::TransientLEDMode::wp_rand() {
   static uint16_t offset = 0x400;
   offset = ((offset + 1) & 0x4fff) | 0x400;
-  return (millis() / MS_PER_FRAME) + pgm_read_byte(offset);
+  return (Kaleidoscope.millisAtCycleStart() / MS_PER_FRAME) + pgm_read_byte(offset);
 }
 
 void WavepoolEffect::TransientLEDMode::update(void) {
 
   // limit the frame rate; one frame every 64 ms
   static uint8_t prev_time = 0;
-  uint8_t now = millis() / MS_PER_FRAME;
+  uint8_t now = Kaleidoscope.millisAtCycleStart() / MS_PER_FRAME;
   if (now != prev_time) {
     prev_time = now;
   } else {

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -95,7 +95,7 @@ class LEDControl : public kaleidoscope::Plugin {
   //
   static void activate(LEDModeInterface *plugin);
 
-  static uint16_t syncDelay;
+  static uint8_t syncDelay;
   static bool paused;
 
   kaleidoscope::EventHandlerResult onSetup();

--- a/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
@@ -40,7 +40,6 @@ const uint8_t BootAnimationEffect::greeting_[11] PROGMEM = {
 };
 
 EventHandlerResult BootAnimationEffect::onSetup() {
-  start_time_ = Kaleidoscope.millisAtCycleStart();
   return EventHandlerResult::OK;
 }
 
@@ -70,12 +69,12 @@ EventHandlerResult BootAnimationEffect::afterEachCycle() {
     }
   }
 
-  if ((Kaleidoscope.millisAtCycleStart() - start_time_) > timeout) {
+  if (Kaleidoscope.hasTimeExpired(start_time_, timeout)) {
     current_index_++;
     if (current_index_ == sizeof(greeting_))
       done_ = true;
 
-    start_time_ = Kaleidoscope.millisAtCycleStart();
+    start_time_ += timeout;
     if (row != 255 && col != 255)
       ::LEDControl.refreshAt(row, col);
     return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
@@ -60,6 +60,11 @@ void BootGreetingEffect::findLed(void) {
   done_ = true;
 }
 
+EventHandlerResult BootGreetingEffect::onSetup() {
+  findLed();
+  return EventHandlerResult::OK;
+}
+
 EventHandlerResult BootGreetingEffect::afterEachCycle() {
   if (!Kaleidoscope.has_leds)
     return EventHandlerResult::OK;
@@ -69,17 +74,8 @@ EventHandlerResult BootGreetingEffect::afterEachCycle() {
     return EventHandlerResult::OK;
   }
 
-  //If the start time isn't set, set the start time and
-  //find the LEDs.
-  if (start_time == 0) {
-    start_time = millis();
-    findLed();
-    //the first time, don't do anything.
-    return EventHandlerResult::OK;
-  }
-
   //Only run for 'timeout' milliseconds
-  if ((millis() - start_time) > timeout) {
+  if (Kaleidoscope.hasTimeExpired(start_time, timeout)) {
     done_ = true;
     ::LEDControl.refreshAt(row_, col_);
     return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/LEDEffect-BootGreeting.h
+++ b/src/kaleidoscope/plugin/LEDEffect-BootGreeting.h
@@ -32,6 +32,7 @@ class BootGreetingEffect : public kaleidoscope::Plugin {
   static uint8_t hue;
   static uint16_t timeout;
 
+  EventHandlerResult onSetup();
   EventHandlerResult afterEachCycle();
 
  private:

--- a/src/kaleidoscope/plugin/LEDEffect-Breathe.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Breathe.cpp
@@ -16,18 +16,15 @@
 
 #include "Kaleidoscope-LEDEffect-Breathe.h"
 
-#define UPDATE_INTERVAL 50  // milliseconds between two LED updates to avoid overloading; 20 fps
-
 namespace kaleidoscope {
 namespace plugin {
 void LEDBreatheEffect::TransientLEDMode::update(void) {
   if (!Kaleidoscope.has_leds)
     return;
 
-  uint16_t now = Kaleidoscope.millisAtCycleStart();
-  if ((now - last_update_) < UPDATE_INTERVAL)
+  if (!Kaleidoscope.hasTimeExpired(last_update_, update_interval_))
     return;
-  last_update_ = now;
+  last_update_ += update_interval_;
 
   cRGB color = breath_compute(parent_->hue, parent_->saturation);
   ::LEDControl.set_all_leds_to(color);

--- a/src/kaleidoscope/plugin/LEDEffect-Breathe.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Breathe.h
@@ -46,7 +46,9 @@ class LEDBreatheEffect : public Plugin,
    private:
 
     const LEDBreatheEffect *parent_;
-    uint16_t last_update_ = 0;
+
+    static constexpr uint8_t update_interval_ = 50;
+    uint8_t last_update_ = 0;
   };
 };
 }

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
@@ -23,11 +23,10 @@ void LEDChaseEffect::TransientLEDMode::update(void) {
   if (!Kaleidoscope.has_leds)
     return;
 
-  uint16_t now = Kaleidoscope.millisAtCycleStart();
-  if ((now - last_update_) < parent_->update_delay_) {
+  if (!Kaleidoscope.hasTimeExpired(last_update_, parent_->update_delay_)) {
     return;
   }
-  last_update_ = now;
+  last_update_ += parent_->update_delay_;
 
   // The red LED is at `pos_`; the blue one follows behind. `direction_` is
   // either +1 or -1; `distance_` is the gap between them.

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.h
@@ -25,10 +25,10 @@ class LEDChaseEffect : public Plugin,
  public:
   LEDChaseEffect(void) {}
 
-  uint16_t update_delay() {
+  uint8_t update_delay() {
     return update_delay_;
   }
-  void update_delay(uint16_t delay) {
+  void update_delay(uint8_t delay) {
     update_delay_ = delay;
   }
   uint8_t distance() {
@@ -48,7 +48,7 @@ class LEDChaseEffect : public Plugin,
     // members of their parent class. Most LED modes can do without.
     //
     TransientLEDMode(const LEDChaseEffect *parent)
-      : parent_(parent) {}
+      : parent_(parent), last_update_(Kaleidoscope.millisAtCycleStart()) {}
 
    protected:
 
@@ -60,12 +60,12 @@ class LEDChaseEffect : public Plugin,
 
     int8_t pos_ = 0;
     int8_t direction_ = 1;
-    uint16_t last_update_ = 0;
+    uint16_t last_update_;
   };
 
  private:
   uint8_t distance_ = 5;
-  uint16_t update_delay_ = 150;
+  uint8_t update_delay_ = 150;
 };
 }
 }

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
@@ -23,11 +23,11 @@ void LEDRainbowEffect::TransientLEDMode::update(void) {
   if (!Kaleidoscope.has_leds)
     return;
 
-  uint16_t now = millis();
-  if ((now - rainbow_last_update) < parent_->rainbow_update_delay) {
+  if (!Kaleidoscope.hasTimeExpired(rainbow_last_update,
+                                   parent_->rainbow_update_delay)) {
     return;
   } else {
-    rainbow_last_update = now;
+    rainbow_last_update += parent_->rainbow_update_delay;
   }
 
   cRGB rainbow = hsvToRgb(rainbow_hue, rainbow_saturation, parent_->rainbow_value);
@@ -54,11 +54,11 @@ void LEDRainbowWaveEffect::TransientLEDMode::update(void) {
   if (!Kaleidoscope.has_leds)
     return;
 
-  uint16_t now = millis();
-  if ((now - rainbow_last_update) < parent_->rainbow_update_delay) {
+  if (!Kaleidoscope.hasTimeExpired(rainbow_last_update,
+                                   parent_->rainbow_update_delay)) {
     return;
   } else {
-    rainbow_last_update = now;
+    rainbow_last_update += parent_->rainbow_update_delay;
   }
 
   for (int8_t i = 0; i < LED_COUNT; i++) {

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
@@ -55,13 +55,13 @@ class LEDRainbowEffect : public Plugin,
     uint16_t rainbow_hue = 0;   //  stores 0 to 614
 
     uint8_t rainbow_steps = 1;  //  number of hues we skip in a 360 range per update
-    uint16_t rainbow_last_update = 0;
+    uint8_t rainbow_last_update = 0;
 
     byte rainbow_saturation = 255;
   };
 
  private:
-  uint16_t rainbow_update_delay = 40; // delay between updates (ms)
+  uint8_t rainbow_update_delay = 40; // delay between updates (ms)
   byte rainbow_value = 50;
 };
 
@@ -100,12 +100,12 @@ class LEDRainbowWaveEffect : public Plugin, public LEDModeInterface {
     uint16_t rainbow_hue = 0;  //  stores 0 to 614
 
     uint8_t rainbow_wave_steps = 1;  //  number of hues we skip in a 360 range per update
-    uint16_t rainbow_last_update = 0;
+    uint8_t rainbow_last_update = 0;
 
     byte rainbow_saturation = 255;
   };
 
-  uint16_t rainbow_update_delay = 40; // delay between updates (ms)
+  uint8_t rainbow_update_delay = 40; // delay between updates (ms)
   byte rainbow_value = 50;
 };
 }

--- a/src/kaleidoscope/plugin/Leader.cpp
+++ b/src/kaleidoscope/plugin/Leader.cpp
@@ -23,7 +23,7 @@ namespace plugin {
 // --- state ---
 Key Leader::sequence_[LEADER_MAX_SEQUENCE_LENGTH + 1];
 uint8_t Leader::sequence_pos_;
-uint32_t Leader::end_time_;
+uint16_t Leader::start_time_ = 0;
 uint16_t Leader::time_out = 1000;
 const Leader::dictionary_t *Leader::dictionary;
 
@@ -93,7 +93,7 @@ EventHandlerResult Leader::onKeyswitchEvent(Key &mapped_key, byte row, byte col,
 
     if (keyToggledOff(keyState)) {
       // not active, but a leader key = start the sequence on key release!
-      end_time_ = millis() + time_out;
+      start_time_ = Kaleidoscope.millisAtCycleStart();
       sequence_pos_ = 0;
       sequence_[sequence_pos_].raw = mapped_key.raw;
     }
@@ -112,7 +112,7 @@ EventHandlerResult Leader::onKeyswitchEvent(Key &mapped_key, byte row, byte col,
       return EventHandlerResult::OK;
     }
 
-    end_time_ = millis() + time_out;
+    start_time_ = Kaleidoscope.millisAtCycleStart();
     sequence_[sequence_pos_].raw = mapped_key.raw;
     action_index = lookup();
 
@@ -142,7 +142,7 @@ EventHandlerResult Leader::afterEachCycle() {
   if (!isActive())
     return EventHandlerResult::OK;
 
-  if (millis() >= end_time_)
+  if (Kaleidoscope.hasTimeExpired(start_time_, time_out))
     reset();
 
   return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/Leader.h
+++ b/src/kaleidoscope/plugin/Leader.h
@@ -52,7 +52,7 @@ class Leader : public kaleidoscope::Plugin {
  private:
   static Key sequence_[LEADER_MAX_SEQUENCE_LENGTH + 1];
   static uint8_t sequence_pos_;
-  static uint32_t end_time_;
+  static uint16_t start_time_;
 
   static int8_t lookup(void);
 };

--- a/src/kaleidoscope/plugin/MagicCombo.cpp
+++ b/src/kaleidoscope/plugin/MagicCombo.cpp
@@ -21,7 +21,7 @@ namespace kaleidoscope {
 namespace plugin {
 
 uint16_t MagicCombo::min_interval = 500;
-uint32_t MagicCombo::end_time_;
+uint16_t MagicCombo::start_time_ = 0;
 
 EventHandlerResult MagicCombo::beforeReportingState() {
   for (byte i = 0; i < magiccombo::combos_length; i++) {
@@ -42,11 +42,11 @@ EventHandlerResult MagicCombo::beforeReportingState() {
     if (j != KeyboardHardware.pressedKeyswitchCount())
       match = false;
 
-    if (match && (millis() >= end_time_)) {
+    if (match && Kaleidoscope.hasTimeExpired(start_time_, min_interval)) {
       ComboAction action = (ComboAction) pgm_read_ptr(&(magiccombo::combos[i].action));
 
       (*action)(i);
-      end_time_ = millis() + min_interval;
+      start_time_ = Kaleidoscope.millisAtCycleStart();
     }
   }
 

--- a/src/kaleidoscope/plugin/MagicCombo.h
+++ b/src/kaleidoscope/plugin/MagicCombo.h
@@ -51,7 +51,7 @@ class MagicCombo : public kaleidoscope::Plugin {
   EventHandlerResult beforeReportingState();
 
  private:
-  static uint32_t end_time_;
+  static uint16_t start_time_;
 };
 
 namespace magiccombo {

--- a/src/kaleidoscope/plugin/MouseKeys.h
+++ b/src/kaleidoscope/plugin/MouseKeys.h
@@ -44,9 +44,9 @@ class MouseKeys_ : public kaleidoscope::Plugin {
 
  private:
   static uint8_t mouseMoveIntent;
-  static uint32_t endTime;
-  static uint32_t accelEndTime;
-  static uint32_t wheelEndTime;
+  static uint16_t move_start_time_;
+  static uint16_t accel_start_time_;
+  static uint16_t wheel_start_time_;
 
   static void scrollWheel(uint8_t keyCode);
 };

--- a/src/kaleidoscope/plugin/OneShot.cpp
+++ b/src/kaleidoscope/plugin/OneShot.cpp
@@ -22,7 +22,7 @@ namespace plugin {
 
 // ---- state ---------
 
-uint32_t OneShot::start_time_ = 0;
+uint16_t OneShot::start_time_ = 0;
 uint16_t OneShot::time_out = 2500;
 uint16_t OneShot::hold_time_out = 250;
 int16_t OneShot::double_tap_time_out = -1;
@@ -113,7 +113,7 @@ EventHandlerResult OneShot::onKeyswitchEvent(Key &mapped_key, byte row, byte col
     } else {
       if (keyToggledOff(keyState)) {
         state_[idx].pressed = false;
-        if ((Kaleidoscope.millisAtCycleStart() - start_time_) >= hold_time_out) {
+        if (Kaleidoscope.hasTimeExpired(start_time_, hold_time_out)) {
           cancelOneShot(idx);
           should_cancel_ = false;
         }
@@ -123,8 +123,8 @@ EventHandlerResult OneShot::onKeyswitchEvent(Key &mapped_key, byte row, byte col
         state_[idx].pressed = true;
 
         if (prev_key_ == mapped_key && isStickable(mapped_key)) {
-          if ((Kaleidoscope.millisAtCycleStart() - start_time_) <=
-              uint16_t((double_tap_time_out == -1) ? time_out : double_tap_time_out)) {
+          uint16_t dtto = (double_tap_time_out == -1) ? time_out : double_tap_time_out;
+          if (!Kaleidoscope.hasTimeExpired(start_time_, dtto)) {
             state_[idx].sticky = true;
             prev_key_ = mapped_key;
           }

--- a/src/kaleidoscope/plugin/OneShot.h
+++ b/src/kaleidoscope/plugin/OneShot.h
@@ -90,7 +90,7 @@ class OneShot : public kaleidoscope::Plugin {
   } key_state_t;
   static key_state_t state_[ONESHOT_KEY_COUNT];
 
-  static uint32_t start_time_;
+  static uint16_t start_time_;
   static Key prev_key_;
   static bool should_cancel_;
   static bool should_cancel_stickies_;
@@ -103,7 +103,7 @@ class OneShot : public kaleidoscope::Plugin {
     return key.raw >= ranges::OS_FIRST && key.raw <= ranges::OS_LAST;
   }
   static bool hasTimedOut() {
-    return Kaleidoscope.millisAtCycleStart() - start_time_ >= time_out;
+    return Kaleidoscope.hasTimeExpired(start_time_, time_out);
   }
 };
 }

--- a/src/kaleidoscope/plugin/SpaceCadet.cpp
+++ b/src/kaleidoscope/plugin/SpaceCadet.cpp
@@ -119,7 +119,7 @@ EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, byte row, byte 
       if (mapped_key.raw == map[i].input.raw) {
         //The keypress was valid and a match. Mark it as flagged and reset the counter
         map[i].flagged = true;
-        map[i].start_time = millis();
+        map[i].start_time = Kaleidoscope.millisAtCycleStart();
 
         //yes, we found a valid key
         valid_key = true;
@@ -199,7 +199,7 @@ EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, byte row, byte 
   }
 
   //Check to determine if we have surpassed our timeout for holding this key
-  if ((millis() - map[index].start_time) >= current_timeout) {
+  if (Kaleidoscope.hasTimeExpired(map[index].start_time, current_timeout)) {
     // if we timed out, that means we need to keep pressing the mapped
     // key, but we won't need to send the alternative key in the end
     map[index].flagged = false;

--- a/src/kaleidoscope/plugin/SpaceCadet.h
+++ b/src/kaleidoscope/plugin/SpaceCadet.h
@@ -52,7 +52,7 @@ class SpaceCadet : public kaleidoscope::Plugin {
     //The flag (set to 0)
     bool flagged = false;
     //the start time for this key press
-    uint32_t start_time = 0;
+    uint16_t start_time = 0;
   };
 
   SpaceCadet(void);

--- a/src/kaleidoscope/plugin/TapDance.h
+++ b/src/kaleidoscope/plugin/TapDance.h
@@ -59,7 +59,7 @@ class TapDance : public kaleidoscope::Plugin {
   };
   static TapDanceState state_[TAPDANCE_KEY_COUNT];
 
-  static uint32_t end_time_;
+  static uint16_t start_time_;
   static Key last_tap_dance_key_;
   static byte last_tap_dance_row_;
   static byte last_tap_dance_col_;

--- a/src/kaleidoscope/plugin/TypingBreaks.h
+++ b/src/kaleidoscope/plugin/TypingBreaks.h
@@ -41,6 +41,7 @@ class TypingBreaks : public kaleidoscope::Plugin {
   EventHandlerResult onSetup();
 
  private:
+  static bool keyboard_locked_;
   static uint32_t session_start_time_;
   static uint32_t lock_start_time_;
   static uint32_t last_key_time_;


### PR DESCRIPTION
This PR is built on #641, and makes use of it to provide consistency and reliability of timers in the core Kaleidoscope plugins. It also substantially reduces PROGMEM usage, in part by reducing the number of bytes needed to store timestamps where possible.

Each plugin's changes are in a separate commit, mainly to make debugging easier. I have not yet thoroughly tested them all to make sure that I didn't make any errors.

### Plugin testing status
- [x] LEDControl
- [x] LED-AlphaSquare
- [x] LED-Stalker
- [x] LED-Wavepool
- [x] LED-BootAnimation
- [x] LED-BootGreeting
- [x] LEDEffect-Breathe
- [x] LEDEffect-Chase
- [x] LEDEffect-Rainbow
- [x] IdleLEDs
- [x] CycleTimeReport
- [x] GhostInTheFirmware
- [x] Heatmap
- [x] Leader
- [x] MagicCombo
- [x] MouseKeys
- [x] OneShot
- [x] SpaceCadet
- [x] TapDance
- [x] TypingBreaks
