### PR TITLE
Removed a hacky statement that became useless

### DIFF
--- a/src/kaleidoscope/Kaleidoscope.cpp
+++ b/src/kaleidoscope/Kaleidoscope.cpp
@@ -44,11 +44,6 @@ Kaleidoscope_::setup(void) {
   kaleidoscope::hid::initializeConsumerControl();
   kaleidoscope::hid::initializeSystemControl();
 
-  // A workaround, so that the compiler does not optimize handleKeyswitchEvent out...
-  // This is a no-op, but tricks the compiler into not being too helpful
-  // TODO(anyone): figure out how to hint the compiler in a more reasonable way
-  handleKeyswitchEvent(Key_NoKey, 255, 255, 0);
-
   // Update the keymap cache, so we start with a non-empty state.
   Layer.updateActiveLayers();
   for (byte row = 0; row < ROWS; row++) {

--- a/src/kaleidoscope/plugin/LEDMode.h
+++ b/src/kaleidoscope/plugin/LEDMode.h
@@ -46,6 +46,7 @@ class LEDMode : public kaleidoscope::Plugin,
   friend class LEDControl;
   friend class kaleidoscope::internal::LEDModeManager;
  protected:
+
   // These methods should only be called by LEDControl.
 
   /** One-time setup, called at keyboard boot.


### PR DESCRIPTION
**Important:** Only merge this after https://github.com/keyboardio/Kaleidoscope-Bundle-Keyboardio/pull/15 has been merged.

After changing the linker command line in platform.txt
in a way that linker error problems are fixed, this
statement is no more needed.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>