### PR TITLE
Wrong type of PROGMEM read function fixed

### DIFF
--- a/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
@@ -60,7 +60,7 @@ EventHandlerResult BootAnimationEffect::afterEachCycle() {
       Key k = Layer.lookupOnActiveLayer(r, c);
       Key g;
       g.flags = 0;
-      g.keyCode = pgm_read_word(&greeting_[current_index_]);
+      g.keyCode = pgm_read_byte(&greeting_[current_index_]);
 
       if (k.raw == g.raw) {
         row = r;


### PR DESCRIPTION
Reading a word and then assigning to a byte does not make sense.
Changed to reading a byte instead.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>