### PR TITLE
Calculate idle time when set instead of every cycle

### DIFF
--- a/doc/plugin/IdleLEDs.md
+++ b/doc/plugin/IdleLEDs.md
@@ -34,17 +34,22 @@ Because the plugin needs to know about key events, it is best to make it one of
 the first plugins, so it can catch all of them, before any other plugin would
 have a chance to consume key events.
 
-## Plugin properties
+## Plugin Methods
 
 The plugin provides a single object, `IdleLEDs`, with the following
-properties. All times are in seconds.
+methods. All times are in seconds.
 
-### `idle_time_limit`
+### `.idle_time_limit()`
 
-> The amount of time that can pass without a single key being pressed, before
-> the plugin considers the keyboard idle, and turns the LEDs off.
+> The amount of time that can pass without a single key being pressed before
+> the plugin considers the keyboard idle and turns off the LEDs.
 >
 > Defaults to 600 seconds (10 minutes).
+
+### `.set_idle_time_limit(uint16_t new_limit)`
+
+> Sets the amount of time that can pass without a single key being pressed
+> before the plugin considers the keyboard idle and turns off the LEDs.
 
 ## Dependencies
 

--- a/doc/plugin/IdleLEDs.md
+++ b/doc/plugin/IdleLEDs.md
@@ -34,22 +34,32 @@ Because the plugin needs to know about key events, it is best to make it one of
 the first plugins, so it can catch all of them, before any other plugin would
 have a chance to consume key events.
 
-## Plugin Methods
+## Plugin Properties
 
-The plugin provides a single object, `IdleLEDs`, with the following
-methods. All times are in seconds.
+The plugin provides a single object, `IdleLEDs`, with the following properties
+and methods.
 
-### `.idle_time_limit()`
+### `.idle_time_limit`
 
-> The amount of time that can pass without a single key being pressed before
-> the plugin considers the keyboard idle and turns off the LEDs.
->
-> Defaults to 600 seconds (10 minutes).
+> Property storing the amount of time that can pass without a single key being
+> pressed before the plugin considers the keyboard idle and turns off the LEDs.
+> Value is expressed in milliseconds.
 
-### `.set_idle_time_limit(uint16_t new_limit)`
+> Defaults to 600000 milliseconds (10 minutes).
 
-> Sets the amount of time that can pass without a single key being pressed
-> before the plugin considers the keyboard idle and turns off the LEDs.
+> Provided for compatibility reasons. It is recommended to use one of the
+> methods below instead of setting this property directly.
+
+### `.idleTimeoutSeconds()`
+
+> Returns the amount of time (in seconds) that can pass without a single key
+> being pressed before the plugin considers the keyboard idle and turns off the
+> LEDs.
+
+### `.setIdleTimeoutSeconds(uint32_t new_limit)`
+
+> Sets the amount of time (in seconds) that can pass without a single key being
+> pressed before the plugin considers the keyboard idle and turns off the LEDs.
 
 ## Dependencies
 

--- a/examples/LEDs/IdleLEDs/IdleLEDs.ino
+++ b/examples/LEDs/IdleLEDs/IdleLEDs.ino
@@ -50,7 +50,7 @@ KALEIDOSCOPE_INIT_PLUGINS(LEDControl,
 void setup() {
   Kaleidoscope.setup();
 
-  IdleLEDs.set_idle_time_limit(300); // 5 minutes
+  IdleLEDs.setIdleTimeoutSeconds(300); // 5 minutes
 
   LEDRainbowWaveEffect.activate();
 }

--- a/examples/LEDs/IdleLEDs/IdleLEDs.ino
+++ b/examples/LEDs/IdleLEDs/IdleLEDs.ino
@@ -50,7 +50,7 @@ KALEIDOSCOPE_INIT_PLUGINS(LEDControl,
 void setup() {
   Kaleidoscope.setup();
 
-  IdleLEDs.idle_time_limit = 300; // 5 minutes
+  IdleLEDs.set_idle_time_limit(300); // 5 minutes
 
   LEDRainbowWaveEffect.activate();
 }

--- a/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -21,20 +21,20 @@
 namespace kaleidoscope {
 namespace plugin {
 
-uint32_t IdleLEDs::idle_time_limit_ = 600000; // 10 minutes
-uint32_t IdleLEDs::start_time_ = 0;
+uint32_t IdleLEDs::idle_time_limit = 600000; // 10 minutes
+uint32_t IdleLEDs::start_time_     = 0;
 
-uint16_t IdleLEDs::idle_time_limit() {
-  return uint16_t(idle_time_limit_ / 1000);
+uint32_t IdleLEDs::idleTimeoutSeconds() {
+  return idle_time_limit / 1000;
 }
 
-void IdleLEDs::set_idle_time_limit(uint16_t new_limit) {
-  idle_time_limit_ = (uint32_t)new_limit * 1000;
+void IdleLEDs::setIdleTimeoutSeconds(uint32_t new_limit) {
+  idle_time_limit = new_limit * 1000;
 }
 
 EventHandlerResult IdleLEDs::beforeEachCycle() {
   if (!::LEDControl.paused &&
-      Kaleidoscope.hasTimeExpired(start_time_, idle_time_limit_)) {
+      Kaleidoscope.hasTimeExpired(start_time_, idle_time_limit)) {
     ::LEDControl.set_all_leds_to(CRGB(0, 0, 0));
     ::LEDControl.syncLeds();
 

--- a/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -21,12 +21,20 @@
 namespace kaleidoscope {
 namespace plugin {
 
-uint16_t IdleLEDs::idle_time_limit = 600; // 10 minutes
+uint32_t IdleLEDs::idle_time_limit_ = 600000; // 10 minutes
 uint32_t IdleLEDs::start_time_ = 0;
+
+uint16_t IdleLEDs::idle_time_limit() {
+  return uint16_t(idle_time_limit_ / 1000);
+}
+
+void IdleLEDs::set_idle_time_limit(uint16_t new_limit) {
+  idle_time_limit_ = (uint32_t)new_limit * 1000;
+}
 
 EventHandlerResult IdleLEDs::beforeEachCycle() {
   if (!::LEDControl.paused &&
-      Kaleidoscope.hasTimeExpired(start_time_, uint32_t(idle_time_limit * 1000))) {
+      Kaleidoscope.hasTimeExpired(start_time_, idle_time_limit_)) {
     ::LEDControl.set_all_leds_to(CRGB(0, 0, 0));
     ::LEDControl.syncLeds();
 

--- a/src/kaleidoscope/plugin/IdleLEDs.h
+++ b/src/kaleidoscope/plugin/IdleLEDs.h
@@ -26,12 +26,14 @@ class IdleLEDs: public kaleidoscope::Plugin {
  public:
   IdleLEDs(void) {}
 
-  static uint16_t idle_time_limit;
+  static uint16_t idle_time_limit();
+  static void set_idle_time_limit(uint16_t new_limit);
 
   EventHandlerResult beforeEachCycle();
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 
  private:
+  static uint32_t idle_time_limit_;
   static uint32_t start_time_;
 };
 }

--- a/src/kaleidoscope/plugin/IdleLEDs.h
+++ b/src/kaleidoscope/plugin/IdleLEDs.h
@@ -26,14 +26,15 @@ class IdleLEDs: public kaleidoscope::Plugin {
  public:
   IdleLEDs(void) {}
 
-  static uint16_t idle_time_limit();
-  static void set_idle_time_limit(uint16_t new_limit);
+  static uint32_t idle_time_limit;
+
+  static uint32_t idleTimeoutSeconds();
+  static void setIdleTimeoutSeconds(uint32_t new_limit);
 
   EventHandlerResult beforeEachCycle();
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 
  private:
-  static uint32_t idle_time_limit_;
   static uint32_t start_time_;
 };
 }


### PR DESCRIPTION
Wrap the `idle_time_limit` property in a getter and setter that automatically converts to milliseconds. This way, we avoid converting inside `beforeEachCycle()`, slightly increasing efficiency.

Also fixes #667.

Signed-off-by: tiltowait <tiltowaitt+github@icloud.com>