### PR TITLE
ActiveModColor: Cache the list of modifiers at setup time too

### DIFF
--- a/src/kaleidoscope/plugin/LED-ActiveModColor.h
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.h
@@ -37,6 +37,9 @@ class ActiveModColorEffect : public kaleidoscope::Plugin {
 
   EventHandlerResult beforeReportingState();
   EventHandlerResult onLayerChange();
+  EventHandlerResult onSetup() {
+    return onLayerChange();
+  }
 
  private:
   static bool highlight_normal_modifiers_;


### PR DESCRIPTION
In order for the plugin to work without having to switch layers once, it needs to scan the keymap for modifiers at setup time too. We do this by calling `onLayerChange()`, which already does that.

Fixes #670.
