### PR TITLE
LEDPaletteTheme: Fix the key address refreshAt() uses

### DIFF
--- a/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -51,7 +51,7 @@ void LEDPaletteTheme::refreshAt(uint16_t theme_base, uint8_t theme, KeyAddr key_
   uint8_t pos = KeyboardHardware.getLedIndex(key_addr);
 
   cRGB color = lookupColorAtPosition(map_base, pos);
-  ::LEDControl.setCrgbAt(KeyAddr(pos), color);
+  ::LEDControl.setCrgbAt(key_addr, color);
 }
 
 


### PR DESCRIPTION
In `refreshAt()`, we want to use the key address, instead of the LED address. `LEDControl` will turn the key address into a LED address itself anyway. This not only makes the code a tiny bit more efficient, but it also fixes `refreshAt()`, which was refreshing the wrong key since the conversion to `KeyAddr`.
