### PR TITLE
Prevent rollover to a qukey from causing unintended repeats

### DIFF
--- a/src/kaleidoscope/plugin/Qukeys.cpp
+++ b/src/kaleidoscope/plugin/Qukeys.cpp
@@ -51,6 +51,14 @@ EventHandlerResult Qukeys::onKeyswitchEvent(Key& key, KeyAddr k, uint8_t key_sta
 
   // Deal with keyswitch state changes.
   if (keyToggledOn(key_state) || keyToggledOff(key_state)) {
+    // If the user rolled over from a non-modifier key to a qukey, let the
+    // release event for that key skip the queue. This prevents unintended
+    // repeat characters for the tapped key, which would otherwise have its
+    // release event delayed.
+    if (keyToggledOff(key_state) && event_queue_.length() == 1 &&
+        k != event_queue_.addr(0) && !isModifierKey(key)) {
+      return EventHandlerResult::OK;
+    }
     // If we can't trivially ignore the event, just add it to the queue.
     event_queue_.append(k, key_state);
     // In order to prevent overflowing the queue, process it now.


### PR DESCRIPTION
When rollover occurs from a non-modifier key to a qukey, if we delay the release event of that key until after the qukey's state is resolved, and if the hold timeout is set to a fairly large value (on the order of 500ms), unintended repeats would occur for a key that was actually only tapped. To prevent this, if there's only one event in the queue (the press of the qukey), and we see a release of a non-modifier key that's not the qukey, it's okay to allow that release event to skip the queue and simply proceed as if it had been released before the qukey was pressed.

This might fix #682, but I doubt it. @neh, please give it a try and see if it helps.