### PR TITLE
Force explicit type conversion for MatrixAddr

### DIFF
--- a/src/kaleidoscope/MatrixAddr.h
+++ b/src/kaleidoscope/MatrixAddr.h
@@ -66,8 +66,15 @@ class MatrixAddr {
   ThisType &operator=(ThisType &&) = default;
 
   template<typename MatrixAddr__>
+  explicit
   constexpr MatrixAddr(const MatrixAddr__ &other)
-    : MatrixAddr(other.row(), other.col()) {}
+    : MatrixAddr(other.row(), other.col()) 
+  {
+     static_assert(MatrixAddr__::rows <= ThisType::rows,
+        "Matrix type conversion failed. Source type must not have greater row size than target type");
+     static_assert(MatrixAddr__::cols <= ThisType::cols,
+        "Matrix type conversion failed. Source type must not have greater col size than target type");
+  }
 
   constexpr uint8_t row() const {
     return offset_ / cols;


### PR DESCRIPTION
**Caution: This PR if merged will cause build errors for all keyboards that are based on AtmegaKeyboard. The reason for this is that the design of the inheritance of keyboard hardware from AtmegaKeyboard is fundamentally broken in a sense that the class `AtmegaKeyboard` defines methods (e.g. `AtmegaKeyboard::isKeyMasked`) with an `KeyAddr` argument. This type is inherited from `kaleidoscope::Hardware` and evaluates to `MatrixAddr<0, 0>`. The actually correct template instantiation of `MatrixAddr<ROWS, COLS>` is only known to the derived hardware classes, e.g. `Atreus`, etc.**

**The changes in this PR reveal this problem. To fix it, a redesign of the hardware stuff is probably inevitable. After those problems have been fixed, this PR can safely be merged.**

---

By forcing an explicit type conversion between
two template class instances of template
MatrixAddr<...>, we prevent undesired implicit
construction of the wrong MatrixAddr types.

Before this change, the following would have been possible

```cpp
typedef MatrixAddr<5, 5> KeyAddr;

void f(KeyAddr k) {} // uses MatrixAddr<5, 5>

void g() {
   typedef MatrixAddr<0, 0> KeyAddr; // Stupid but possible
   f(KeyAddr(1, 12)); // Would instantiate MatrixAddr<0, 0> and
                      // implicitly convert it to MatrixAddr<5, 5>
}
```

With this commit, the compiler will emit an error and explicit type
conversion is required.

```cpp
typedef MatrixAddr<5, 5> KeyAddr1;
typedef MatrixAddr<2, 2> KeyAddr2;

void f(KeyAddr1 k) {} // uses MatrixAddr<5, 5>

void g() {
   f(KeyAddr1(KeyAddr2(1, 1)); // Now an explicit type conversion is
                               // required.
}
```

This commit also introduces a compile time check that prevents
conversion from a matrix type with greater extension to one with
smaller extension.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>