### PR TITLE
Fixes problems with ATMegaKeyboard and KeyAddr

### DIFF
--- a/src/kaleidoscope/Hardware.h
+++ b/src/kaleidoscope/Hardware.h
@@ -46,13 +46,20 @@ namespace kaleidoscope {
 /** Kaleidoscope Hardware base class.
  * Essential methods all hardware libraries must implement.
  */
+
+struct NoopKeyAddr {
+  NoopKeyAddr() {}
+  template<typename T_>
+  NoopKeyAddr(T_) {}
+};
+
 class Hardware {
  public:
 
   // To satisfy the interface of those methods that allow
-  // for matrix addressing we define default key and led address classes.
-  // Those typedefs are supposed to overridden by derived hardware classes.
-  typedef MatrixAddr<0, 0> KeyAddr;
+  // for matrix addressing we define a default key address class.
+  // This typedef is supposed to overridden by derived hardware classes.
+  typedef NoopKeyAddr KeyAddr;
 
   /**
    * @defgroup kaleidoscope_hardware_leds Kaleidoscope::Hardware/LEDs

--- a/src/kaleidoscope/hardware/ATMegaKeyboard.cpp
+++ b/src/kaleidoscope/hardware/ATMegaKeyboard.cpp
@@ -74,16 +74,6 @@ uint8_t ATMegaKeyboard::pressedKeyswitchCount() {
   return count;
 }
 
-bool ATMegaKeyboard::isKeyswitchPressed(KeyAddr key_addr) {
-  return (bitRead(KeyboardHardware.keyState_[key_addr.row()], key_addr.col()) != 0);
-}
-
-bool ATMegaKeyboard::isKeyswitchPressed(uint8_t keyIndex) {
-  keyIndex--;
-  return isKeyswitchPressed(::KeyAddr(keyIndex));
-}
-
-
 uint8_t ATMegaKeyboard::previousPressedKeyswitchCount() {
   uint8_t count = 0;
 
@@ -92,17 +82,6 @@ uint8_t ATMegaKeyboard::previousPressedKeyswitchCount() {
   }
   return count;
 }
-
-bool ATMegaKeyboard::wasKeyswitchPressed(KeyAddr key_addr) {
-  return (bitRead(KeyboardHardware.previousKeyState_[key_addr.row()], key_addr.col()) != 0);
-
-}
-
-bool ATMegaKeyboard::wasKeyswitchPressed(uint8_t keyIndex) {
-  keyIndex--;
-  return wasKeyswitchPressed(::KeyAddr(keyIndex));
-}
-
 
 void __attribute__((optimize(3))) ATMegaKeyboard::actOnMatrixScan() {
   for (byte row = 0; row < KeyboardHardware.matrix_rows; row++) {
@@ -125,27 +104,6 @@ void ATMegaKeyboard::scanMatrix() {
   }
   // We ALWAYS want to tell Kaleidoscope about the state of the matrix
   KeyboardHardware.actOnMatrixScan();
-}
-
-void ATMegaKeyboard::maskKey(KeyAddr key_addr) {
-  if (!key_addr.isValid())
-    return;
-
-  bitWrite(KeyboardHardware.masks_[key_addr.row()], key_addr.col(), 1);
-}
-
-void ATMegaKeyboard::unMaskKey(KeyAddr key_addr) {
-  if (!key_addr.isValid())
-    return;
-
-  bitWrite(KeyboardHardware.masks_[key_addr.row()], key_addr.col(), 0);
-}
-
-bool ATMegaKeyboard::isKeyMasked(KeyAddr key_addr) {
-  if (!key_addr.isValid())
-    return false;
-
-  return bitRead(KeyboardHardware.masks_[key_addr.row()], key_addr.col());
 }
 
 /*


### PR DESCRIPTION
This PR fixes the problems discussed in https://github.com/keyboardio/Kaleidoscope/pull/689 and https://github.com/keyboardio/Kaleidoscope/commit/ebeb173cb8fe7f3f0572a68be7557d5e621e985d.

Don't forget to merge https://github.com/keyboardio/Kaleidoscope/pull/689 to prevent future problems with implicit conversions to `MatrixAddr<0, 0>`. It can be safely merged on top of this PR.

---

The correct KeyAddr type is not known to class ATMegaKeyboard
as key matrix dimentions (matrix_rows/matrix_columns) and
type KeyAddr are only defined in derived hardware classes. To deal with
this problem, some of the KeyAddr related methods are moved to
derived hardware classes.

The necessary boilerplate code is synthesized through a macro
ATMEGA_KEYBOARD_MATRIX_ACCESS_METHODS that is automatically included
by all derived classes of class ATMegaKeyboard through the already used
macro ATMEGA_KEYBOARD_CONFIG.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>