### PR TITLE
Arduino 1.8.10 broke the build

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -300,6 +300,7 @@ compile () {
 	      -build-cache "${CORE_CACHE_PATH}" \
 	      -build-path "${BUILD_PATH}" \
 	      -ide-version "${ARDUINO_IDE_VERSION}" \
+	      -built-in-libraries "${ARDUINO_PATH}/libraries" \
 	      -prefs "compiler.cpp.extra_flags=-std=c++11 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
 	      $CCACHE_ENABLE \
 	      -warnings all \

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -42,25 +42,32 @@ fi
 # Shamelessly stolen from git's Makefile
 uname_S=$(uname -s 2>/dev/null || echo not)
 
+
 find_max_prog_size() {
+# SKETCH and -build-path in this command are here because of a bug introduced in Arduino 1.8.10
+# https://github.com/arduino/arduino-builder/issues/341
     VPIDS=$("${ARDUINO_BUILDER}" \
     -hardware "${ARDUINO_PATH}/hardware" \
     -hardware "${BOARD_HARDWARE_PATH}" \
     ${ARDUINO_TOOLS_FLAG:+"${ARDUINO_TOOLS_FLAG}"} ${ARDUINO_TOOLS_PARAM:+"${ARDUINO_TOOLS_PARAM}"} \
     -tools "${ARDUINO_PATH}/tools-builder" \
     -fqbn "${FQBN}" \
-    -dump-prefs | grep "upload\.maximum_size=")
+    -build-path ${ARDUINO_PATH} \
+    -dump-prefs "${SKETCH_DIR}/${SKETCH}.ino" | grep "upload\.maximum_size=")
     MAX_PROG_SIZE=${MAX_PROG_SIZE:-$(echo "${VPIDS}" | grep upload.maximum_size | head -n 1 | cut -d= -f2)}
 }
 
 find_device_vid_pid() {
+# SKETCH and -build-path in this command are here because of a bug introduced in Arduino 1.8.10
+# https://github.com/arduino/arduino-builder/issues/341
     VPIDS=$("${ARDUINO_BUILDER}" \
 		-hardware "${ARDUINO_PATH}/hardware" \
 		-hardware "${BOARD_HARDWARE_PATH}" \
 		${ARDUINO_TOOLS_FLAG:+"${ARDUINO_TOOLS_FLAG}"} ${ARDUINO_TOOLS_PARAM:+"${ARDUINO_TOOLS_PARAM}"} \
 		-tools "${ARDUINO_PATH}/tools-builder" \
 		-fqbn "${FQBN}" \
-		-dump-prefs | grep "\.[vp]id=")
+	 	-build-path ${ARDUINO_PATH} \
+   		-dump-prefs  "${SKETCH_DIR}/${SKETCH}.ino" || grep "\.[vp]id=")
     VID=${VID:-$(echo "${VPIDS}" | grep build.vid= | cut -dx -f2)}
     SKETCH_PID=${SKETCH_PID:-$(echo "${VPIDS}" | grep build.pid= | cut -dx -f2)}
     BOOTLOADER_PID=${BOOTLOADER_PID:-$(echo "${VPIDS}" | grep bootloader.pid= | cut -dx -f2)}


### PR DESCRIPTION
arduino-builder changed in 1.8.10, which caused our build to break. these two changes work around the failures. Building with 1.8.9 still works