### PR TITLE
Storage & Serial abstraction

### DIFF
--- a/doc/plugin/CycleTimeReport.md
+++ b/doc/plugin/CycleTimeReport.md
@@ -17,7 +17,7 @@ the box, without any further configuration:
 KALEIDOSCOPE_INIT_PLUGINS(CycleTimeReport);
 
 void setup (void) {
-  Serial.begin(9600);
+  KeyboardHardware.serialPort().begin(9600);
   Kaleidoscope.setup ();
 }
 ```

--- a/doc/plugin/EEPROM-Settings.md
+++ b/doc/plugin/EEPROM-Settings.md
@@ -43,7 +43,7 @@ void setup () {
     return;
   }
 
-  EEPROM.get(settingsBase, testSettings);
+  KeyboardHardware.storage().get(settingsBase, testSettings);
 }
 ```
 

--- a/doc/plugin/Leader.md
+++ b/doc/plugin/Leader.md
@@ -32,11 +32,11 @@ dictionary:
 #include <Kaleidoscope-Leader.h>
 
 static void leaderA(uint8_t seq_index) {
-  Serial.println("leaderA");
+  KeyboardHardware.serialPort().println("leaderA");
 }
 
 static void leaderTX(uint8_t seq_index) {
-  Serial.println("leaderTX");
+  KeyboardHardware.serialPort().println("leaderTX");
 }
 
 static const kaleidoscope::Leader::dictionary_t leader_dictionary[] PROGMEM =
@@ -46,7 +46,7 @@ static const kaleidoscope::Leader::dictionary_t leader_dictionary[] PROGMEM =
 KALEIDOSCOPE_INIT_PLUGINS(Leader);
 
 void setup() {
-  Serial.begin(9600);
+  KeyboardHardware.serialPort().begin(9600);
 
   Kaleidoscope.setup();
 

--- a/doc/plugin/Syster.md
+++ b/doc/plugin/Syster.md
@@ -34,8 +34,8 @@ void systerAction(kaleidoscope::plugin::Syster::action_t action, const char *sym
     kaleidoscope::hid::sendKeyboardReport ();
     break;
   case kaleidoscope::plugin::Syster::SymbolAction:
-    Serial.print ("systerAction: symbol=");
-    Serial.println (symbol);
+    KeyboardHardware.serialPort().print ("systerAction: symbol=");
+    KeyboardHardware.serialPort().println (symbol);
     if (strcmp (symbol, "coffee") == 0) {
       Unicode.type (0x2615);
     }
@@ -46,7 +46,7 @@ void systerAction(kaleidoscope::plugin::Syster::action_t action, const char *sym
 KALEIDOSCOPE_INIT_PLUGINS(EEPROMSettings, HostOS, Unicode, Syster);
 
 void setup() {
-  Serial.begin(9600);
+  KeyboardHardware.serialPort().begin(9600);
   Kaleidoscope.setup ();
 }
 ```

--- a/examples/Devices/Keyboardio/Model01/Model01.ino
+++ b/examples/Devices/Keyboardio/Model01/Model01.ino
@@ -86,7 +86,7 @@ static kaleidoscope::plugin::LEDSolidColor solidViolet(70, 0, 60);
 
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
   if (macroIndex == 1 && keyToggledOn(keyState)) {
-    Serial.print("Keyboard.IO keyboard driver v0.00");
+    KeyboardHardware.serialPort().print("Keyboard.IO keyboard driver v0.00");
     return MACRO(I(25),
                  D(LeftShift), T(M), U(LeftShift), T(O), T(D), T(E), T(L),
                  T(Spacebar),

--- a/examples/Devices/OLKB/Planck/Planck.ino
+++ b/examples/Devices/OLKB/Planck/Planck.ino
@@ -167,7 +167,7 @@ KALEIDOSCOPE_INIT_PLUGINS(Macros);
 
 void setup() {
   Kaleidoscope.setup();
-  Serial.begin(9600);
+  KeyboardHardware.serialPort().begin(9600);
 }
 
 void loop() {

--- a/examples/Devices/SOFTHRUF/Splitography/Splitography.ino
+++ b/examples/Devices/SOFTHRUF/Splitography/Splitography.ino
@@ -50,7 +50,7 @@ KEYMAPS(
 KALEIDOSCOPE_INIT_PLUGINS(GeminiPR);
 
 void setup() {
-  Serial.begin(9600);
+  KeyboardHardware.serialPort().begin(9600);
   Kaleidoscope.setup();
 }
 

--- a/examples/Features/CycleTimeReport/CycleTimeReport.ino
+++ b/examples/Features/CycleTimeReport/CycleTimeReport.ino
@@ -43,7 +43,7 @@ KEYMAPS(
 KALEIDOSCOPE_INIT_PLUGINS(CycleTimeReport);
 
 void setup() {
-  Serial.begin(9600);
+  KeyboardHardware.serialPort().begin(9600);
   Kaleidoscope.setup();
 }
 

--- a/examples/Features/EEPROM/EEPROM-Keymap-Programmer/EEPROM-Keymap-Programmer.ino
+++ b/examples/Features/EEPROM/EEPROM-Keymap-Programmer/EEPROM-Keymap-Programmer.ino
@@ -56,7 +56,7 @@ KALEIDOSCOPE_INIT_PLUGINS(EEPROMSettings,
                           Macros);
 
 void setup() {
-  Serial.begin(9600);
+  KeyboardHardware.serialPort().begin(9600);
 
   Kaleidoscope.setup();
 

--- a/examples/Features/EEPROM/EEPROM-Settings/EEPROM-Settings.ino
+++ b/examples/Features/EEPROM/EEPROM-Settings/EEPROM-Settings.ino
@@ -42,16 +42,16 @@ KEYMAPS(
 KALEIDOSCOPE_INIT_PLUGINS(EEPROMSettings);
 
 void setup() {
-  Serial.begin(9600);
+  KeyboardHardware.serialPort().begin(9600);
 
   Kaleidoscope.setup();
 
-  while (!Serial) {
+  while (!KeyboardHardware.serialPort()) {
   }
 
-  Serial.println(EEPROMSettings.isValid() ? F("valid EEPROM settings") : F("invalid EEPROM settings"));
-  Serial.println(EEPROMSettings.crc(), HEX);
-  Serial.println(EEPROMSettings.version());
+  KeyboardHardware.serialPort().println(EEPROMSettings.isValid() ? F("valid EEPROM settings") : F("invalid EEPROM settings"));
+  KeyboardHardware.serialPort().println(EEPROMSettings.crc(), HEX);
+  KeyboardHardware.serialPort().println(EEPROMSettings.version());
 }
 
 void loop() {

--- a/examples/Features/HostOS/HostOS.ino
+++ b/examples/Features/HostOS/HostOS.ino
@@ -43,12 +43,12 @@ KEYMAPS(
 KALEIDOSCOPE_INIT_PLUGINS(EEPROMSettings, HostOS);
 
 void setup() {
-  Serial.begin(9600);
+  KeyboardHardware.serialPort().begin(9600);
 
   Kaleidoscope.setup();
 
-  Serial.print("Host OS id is: ");
-  Serial.println(HostOS.os(), DEC);
+  KeyboardHardware.serialPort().print("Host OS id is: ");
+  KeyboardHardware.serialPort().println(HostOS.os(), DEC);
 }
 
 void loop() {

--- a/examples/Features/Steno/Steno.ino
+++ b/examples/Features/Steno/Steno.ino
@@ -61,7 +61,7 @@ KEYMAPS(
 KALEIDOSCOPE_INIT_PLUGINS(GeminiPR);
 
 void setup() {
-  Serial.begin(9600);
+  KeyboardHardware.serialPort().begin(9600);
   Kaleidoscope.setup();
 }
 

--- a/examples/Keystrokes/Leader/Leader.ino
+++ b/examples/Keystrokes/Leader/Leader.ino
@@ -40,11 +40,11 @@ KEYMAPS(
 // *INDENT-ON*
 
 static void leaderTestA(uint8_t seq_index) {
-  Serial.println(F("leaderTestA"));
+  KeyboardHardware.serialPort().println(F("leaderTestA"));
 }
 
 static void leaderTestAA(uint8_t seq_index) {
-  Serial.println(F("leaderTestAA"));
+  KeyboardHardware.serialPort().println(F("leaderTestAA"));
 }
 
 static const kaleidoscope::plugin::Leader::dictionary_t leader_dictionary[] PROGMEM =

--- a/examples/Keystrokes/Syster/Syster.ino
+++ b/examples/Keystrokes/Syster/Syster.ino
@@ -56,8 +56,8 @@ void systerAction(kaleidoscope::plugin::Syster::action_t action, const char *sym
     kaleidoscope::hid::sendKeyboardReport();
     break;
   case kaleidoscope::plugin::Syster::SymbolAction:
-    Serial.print("systerAction: symbol=");
-    Serial.println(symbol);
+    KeyboardHardware.serialPort().print("systerAction: symbol=");
+    KeyboardHardware.serialPort().println(symbol);
     if (strcmp(symbol, "coffee") == 0) {
       Unicode.type(0x2615);
     }

--- a/src/kaleidoscope/Hardware.h
+++ b/src/kaleidoscope/Hardware.h
@@ -394,6 +394,13 @@ class Hardware {
     return EEPROM;
   }
 
+  /**
+   * Method to return the serial port object used by the hardware.
+   */
+  auto serialPort() -> decltype(Serial) & {
+    return Serial;
+  }
+
   /** @} */
 };
 }

--- a/src/kaleidoscope/Hardware.h
+++ b/src/kaleidoscope/Hardware.h
@@ -24,6 +24,8 @@
 #include "kaleidoscope/MatrixAddr.h"
 #include "kaleidoscope_internal/deprecations.h"
 
+#include "EEPROM.h"
+
 #ifndef CRGB
 #error cRGB and CRGB *must* be defined before including this header!
 #endif
@@ -384,6 +386,13 @@ class Hardware {
    *
    */
   void enableHardwareTestMode() {}
+
+  /**
+   * Method to return the object the hardware uses for storage.
+   */
+  auto storage() -> decltype(EEPROM) & {
+    return EEPROM;
+  }
 
   /** @} */
 };

--- a/src/kaleidoscope/Kaleidoscope.cpp
+++ b/src/kaleidoscope/Kaleidoscope.cpp
@@ -34,7 +34,7 @@ Kaleidoscope_::setup(void) {
   //
   // TODO(anyone): Figure out a way we can get rid of this, and fix the bug
   // properly.
-  Serial.begin(9600);
+  KeyboardHardware.serialPort().begin(9600);
 
   kaleidoscope::Hooks::onSetup();
 

--- a/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -49,7 +49,7 @@ static void playKeyCode(Key key, uint8_t keyStates, bool explicit_report) {
 static void readKeyCodeAndPlay(uint16_t pos, uint8_t flags, uint8_t keyStates, bool explicit_report) {
   Key key;
   key.flags = flags;
-  key.keyCode = EEPROM.read(pos++);
+  key.keyCode = KeyboardHardware.storage().read(pos++);
 
   playKeyCode(key, keyStates, explicit_report);
 }
@@ -63,7 +63,7 @@ void DynamicMacros::updateDynamicMacroCache(void) {
   map_[0] = 0;
 
   while (pos < storage_base_ + storage_size_) {
-    macro = EEPROM.read(pos++);
+    macro = KeyboardHardware.storage().read(pos++);
     switch (macro) {
     case MACRO_ACTION_STEP_EXPLICIT_REPORT:
     case MACRO_ACTION_STEP_IMPLICIT_REPORT:
@@ -91,8 +91,8 @@ void DynamicMacros::updateDynamicMacroCache(void) {
       previous_macro_ended = false;
       uint8_t keyCode, flags;
       do {
-        flags = EEPROM.read(pos++);
-        keyCode = EEPROM.read(pos++);
+        flags = KeyboardHardware.storage().read(pos++);
+        keyCode = KeyboardHardware.storage().read(pos++);
       } while (!(flags == 0 && keyCode == 0));
       break;
     }
@@ -101,7 +101,7 @@ void DynamicMacros::updateDynamicMacroCache(void) {
       previous_macro_ended = false;
       uint8_t keyCode, flags;
       do {
-        keyCode = EEPROM.read(pos++);
+        keyCode = KeyboardHardware.storage().read(pos++);
       } while (keyCode != 0);
       break;
     }
@@ -128,7 +128,7 @@ void DynamicMacros::play(uint8_t macro_id) {
   pos = storage_base_ + map_[macro_id];
 
   while (true) {
-    switch (macro = EEPROM.read(pos++)) {
+    switch (macro = KeyboardHardware.storage().read(pos++)) {
     case MACRO_ACTION_STEP_EXPLICIT_REPORT:
       explicit_report = true;
       break;
@@ -140,23 +140,23 @@ void DynamicMacros::play(uint8_t macro_id) {
       kaleidoscope::hid::sendMouseReport();
       break;
     case MACRO_ACTION_STEP_INTERVAL:
-      interval = EEPROM.read(pos++);
+      interval = KeyboardHardware.storage().read(pos++);
       break;
     case MACRO_ACTION_STEP_WAIT: {
-      uint8_t wait = EEPROM.read(pos++);
+      uint8_t wait = KeyboardHardware.storage().read(pos++);
       delay(wait);
       break;
     }
     case MACRO_ACTION_STEP_KEYDOWN:
-      flags = EEPROM.read(pos++);
+      flags = KeyboardHardware.storage().read(pos++);
       readKeyCodeAndPlay(pos++, flags, IS_PRESSED, explicit_report);
       break;
     case MACRO_ACTION_STEP_KEYUP:
-      flags = EEPROM.read(pos++);
+      flags = KeyboardHardware.storage().read(pos++);
       readKeyCodeAndPlay(pos++, flags, WAS_PRESSED, explicit_report);
       break;
     case MACRO_ACTION_STEP_TAP:
-      flags = EEPROM.read(pos++);
+      flags = KeyboardHardware.storage().read(pos++);
       readKeyCodeAndPlay(pos++, flags, IS_PRESSED | WAS_PRESSED, false);
       break;
 
@@ -173,8 +173,8 @@ void DynamicMacros::play(uint8_t macro_id) {
     case MACRO_ACTION_STEP_TAP_SEQUENCE: {
       uint8_t keyCode;
       do {
-        flags = EEPROM.read(pos++);
-        keyCode = EEPROM.read(pos++);
+        flags = KeyboardHardware.storage().read(pos++);
+        keyCode = KeyboardHardware.storage().read(pos++);
         playKeyCode(Key(keyCode, flags), IS_PRESSED | WAS_PRESSED, false);
         delay(interval);
       } while (!(flags == 0 && keyCode == 0));
@@ -183,7 +183,7 @@ void DynamicMacros::play(uint8_t macro_id) {
     case MACRO_ACTION_STEP_TAP_CODE_SEQUENCE: {
       uint8_t keyCode;
       do {
-        keyCode = EEPROM.read(pos++);
+        keyCode = KeyboardHardware.storage().read(pos++);
         playKeyCode(Key(keyCode, 0), IS_PRESSED | WAS_PRESSED, false);
         delay(interval);
       } while (keyCode != 0);
@@ -221,7 +221,7 @@ EventHandlerResult DynamicMacros::onFocusEvent(const char *command) {
     if (::Focus.isEOL()) {
       for (uint16_t i = 0; i < storage_size_; i++) {
         uint8_t b;
-        b = EEPROM.read(storage_base_ + i);
+        b = KeyboardHardware.storage().read(storage_base_ + i);
         ::Focus.send(b);
       }
     } else {
@@ -231,7 +231,7 @@ EventHandlerResult DynamicMacros::onFocusEvent(const char *command) {
         uint8_t b;
         ::Focus.read(b);
 
-        EEPROM.update(storage_base_ + pos++, b);
+        KeyboardHardware.storage().update(storage_base_ + pos++, b);
       }
       updateDynamicMacroCache();
     }

--- a/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -55,8 +55,8 @@ Key EEPROMKeymap::getKey(uint8_t layer, KeyAddr key_addr) {
 
   uint16_t pos = ((layer * KeyboardHardware.numKeys()) + key_addr.toInt()) * 2;
 
-  key.flags = EEPROM.read(keymap_base_ + pos);
-  key.keyCode = EEPROM.read(keymap_base_ + pos + 1);
+  key.flags = KeyboardHardware.storage().read(keymap_base_ + pos);
+  key.keyCode = KeyboardHardware.storage().read(keymap_base_ + pos + 1);
 
   return key;
 }
@@ -77,8 +77,8 @@ uint16_t EEPROMKeymap::keymap_base(void) {
 }
 
 void EEPROMKeymap::updateKey(uint16_t base_pos, Key key) {
-  EEPROM.update(keymap_base_ + base_pos * 2, key.flags);
-  EEPROM.update(keymap_base_ + base_pos * 2 + 1, key.keyCode);
+  KeyboardHardware.storage().update(keymap_base_ + base_pos * 2, key.flags);
+  KeyboardHardware.storage().update(keymap_base_ + base_pos * 2 + 1, key.keyCode);
 }
 
 void EEPROMKeymap::dumpKeymap(uint8_t layers, Key(*getkey)(uint8_t, KeyAddr)) {

--- a/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -28,7 +28,7 @@ bool EEPROMSettings::sealed_;
 uint16_t EEPROMSettings::next_start_ = sizeof(EEPROMSettings::settings);
 
 EventHandlerResult EEPROMSettings::onSetup() {
-  EEPROM.get(0, settings_);
+  KeyboardHardware.storage().get(0, settings_);
 
   /* If the version is undefined, set up sensible defaults. */
   if (settings_.version == VERSION_UNDEFINED) {
@@ -49,7 +49,7 @@ EventHandlerResult EEPROMSettings::onSetup() {
      * not able to catch all writes yet. For the sake of consistency, if we
      * encounter a firmware with no version defined, we'll set sensible
      * defaults. */
-    EEPROM.put(0, settings_);
+    KeyboardHardware.storage().put(0, settings_);
   }
   return EventHandlerResult::OK;
 }
@@ -146,7 +146,7 @@ uint16_t EEPROMSettings::used(void) {
 }
 
 void EEPROMSettings::update(void) {
-  EEPROM.put(0, settings_);
+  KeyboardHardware.storage().put(0, settings_);
   is_valid_ = true;
 }
 
@@ -220,22 +220,22 @@ EventHandlerResult FocusEEPROMCommand::onFocusEvent(const char *command) {
   switch (sub_command) {
   case CONTENTS: {
     if (::Focus.isEOL()) {
-      for (uint16_t i = 0; i < EEPROM.length(); i++) {
-        uint8_t d = EEPROM[i];
+      for (uint16_t i = 0; i < KeyboardHardware.storage().length(); i++) {
+        uint8_t d = KeyboardHardware.storage().read(i);
         ::Focus.send(d);
       }
     } else {
-      for (uint16_t i = 0; i < EEPROM.length() && !::Focus.isEOL(); i++) {
+      for (uint16_t i = 0; i < KeyboardHardware.storage().length() && !::Focus.isEOL(); i++) {
         uint8_t d;
         ::Focus.read(d);
-        EEPROM.update(i, d);
+        KeyboardHardware.storage().update(i, d);
       }
     }
 
     break;
   }
   case FREE:
-    ::Focus.send(EEPROM.length() - ::EEPROMSettings.used());
+    ::Focus.send(KeyboardHardware.storage().length() - ::EEPROMSettings.used());
     break;
   }
 

--- a/src/kaleidoscope/plugin/EEPROM-Settings.h
+++ b/src/kaleidoscope/plugin/EEPROM-Settings.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <Kaleidoscope.h>
-#include <EEPROM.h>
 
 #define _DEPRECATED_MESSAGE_EEPROMSETTINGS_VERSION_SET            \
   "The EEPROMSettings.version(uint8_t version) method has been deprecated,\n" \

--- a/src/kaleidoscope/plugin/FingerPainter.cpp
+++ b/src/kaleidoscope/plugin/FingerPainter.cpp
@@ -101,7 +101,7 @@ EventHandlerResult FingerPainter::onFocusEvent(const char *command) {
 
   if (sub_command == CLEAR) {
     for (uint16_t i = 0; i < KeyboardHardware.numKeys() / 2; i++) {
-      EEPROM.update(color_base_ + i, 0);
+      KeyboardHardware.storage().update(color_base_ + i, 0);
     }
     return EventHandlerResult::OK;
   }

--- a/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -27,20 +27,20 @@ namespace plugin {
 char FocusSerial::command_[32];
 
 void FocusSerial::drain(void) {
-  if (Serial.available())
-    while (Serial.peek() != '\n')
-      Serial.read();
+  if (KeyboardHardware.serialPort().available())
+    while (KeyboardHardware.serialPort().peek() != '\n')
+      KeyboardHardware.serialPort().read();
 }
 
 EventHandlerResult FocusSerial::beforeReportingState() {
-  if (Serial.available() == 0)
+  if (KeyboardHardware.serialPort().available() == 0)
     return EventHandlerResult::OK;
 
   uint8_t i = 0;
   do {
-    command_[i++] = Serial.read();
+    command_[i++] = KeyboardHardware.serialPort().read();
 
-    if (Serial.peek() == '\n')
+    if (KeyboardHardware.serialPort().peek() == '\n')
       break;
   } while (command_[i - 1] != ' ' && i < 32);
   if (command_[i - 1] == ' ')
@@ -50,12 +50,12 @@ EventHandlerResult FocusSerial::beforeReportingState() {
 
   Kaleidoscope.onFocusEvent(command_);
 
-  Serial.println(F("\r\n."));
+  KeyboardHardware.serialPort().println(F("\r\n."));
 
   drain();
 
-  if (Serial.peek() == '\n')
-    Serial.read();
+  if (KeyboardHardware.serialPort().peek() == '\n')
+    KeyboardHardware.serialPort().read();
 
   return EventHandlerResult::OK;
 }
@@ -65,7 +65,7 @@ bool FocusSerial::handleHelp(const char *command,
   if (strcmp_P(command, PSTR("help")) != 0)
     return false;
 
-  Serial.println((const __FlashStringHelper *)help_message);
+  KeyboardHardware.serialPort().println((const __FlashStringHelper *)help_message);
   return true;
 }
 
@@ -75,7 +75,7 @@ EventHandlerResult FocusSerial::onFocusEvent(const char *command) {
 }
 
 void FocusSerial::printBool(bool b) {
-  Serial.print((b) ? F("true") : F("false"));
+  KeyboardHardware.serialPort().print((b) ? F("true") : F("false"));
 }
 
 }

--- a/src/kaleidoscope/plugin/FocusSerial.h
+++ b/src/kaleidoscope/plugin/FocusSerial.h
@@ -37,12 +37,12 @@ class FocusSerial : public kaleidoscope::Plugin {
   }
   void send(const bool b) {
     printBool(b);
-    Serial.print(SEPARATOR);
+    KeyboardHardware.serialPort().print(SEPARATOR);
   }
   template <typename V>
   void send(V v) {
-    Serial.print(v);
-    Serial.print(SEPARATOR);
+    KeyboardHardware.serialPort().print(v);
+    KeyboardHardware.serialPort().print(SEPARATOR);
   }
   template <typename Var, typename... Vars>
   void send(Var v, const Vars&... vars) {
@@ -53,31 +53,31 @@ class FocusSerial : public kaleidoscope::Plugin {
   void sendRaw() {}
   template <typename Var, typename... Vars>
   void sendRaw(Var v, const Vars&... vars) {
-    Serial.print(v);
+    KeyboardHardware.serialPort().print(v);
     sendRaw(vars...);
   }
 
   const char peek() {
-    return Serial.peek();
+    return KeyboardHardware.serialPort().peek();
   }
 
   void read(Key &key) {
-    key.raw = Serial.parseInt();
+    key.raw = KeyboardHardware.serialPort().parseInt();
   }
   void read(cRGB &color) {
-    color.r = Serial.parseInt();
-    color.g = Serial.parseInt();
-    color.b = Serial.parseInt();
+    color.r = KeyboardHardware.serialPort().parseInt();
+    color.g = KeyboardHardware.serialPort().parseInt();
+    color.b = KeyboardHardware.serialPort().parseInt();
   }
   void read(uint8_t &u8) {
-    u8 = Serial.parseInt();
+    u8 = KeyboardHardware.serialPort().parseInt();
   }
   void read(uint16_t &u16) {
-    u16 = Serial.parseInt();
+    u16 = KeyboardHardware.serialPort().parseInt();
   }
 
   bool isEOL() {
-    return Serial.peek() == '\n';
+    return KeyboardHardware.serialPort().peek() == '\n';
   }
 
   static constexpr char COMMENT = '#';

--- a/src/kaleidoscope/plugin/GeminiPR.cpp
+++ b/src/kaleidoscope/plugin/GeminiPR.cpp
@@ -39,7 +39,7 @@ EventHandlerResult GeminiPR::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr,
 
     if (keys_held_ == 0) {
       state_[0] |= 0x80;
-      Serial.write(state_, sizeof(state_));
+      KeyboardHardware.serialPort().write(state_, sizeof(state_));
       memset(state_, 0, sizeof(state_));
     }
   }

--- a/src/kaleidoscope/plugin/HostOS.cpp
+++ b/src/kaleidoscope/plugin/HostOS.cpp
@@ -18,8 +18,6 @@
 #include <kaleidoscope/plugin/HostOS.h>
 #include <Kaleidoscope-EEPROM-Settings.h>
 
-#include <EEPROM.h>
-
 namespace kaleidoscope {
 namespace plugin {
 
@@ -35,14 +33,14 @@ EventHandlerResult HostOS::onSetup(void) {
     return EventHandlerResult::OK;
   }
 
-  os_ = (hostos::Type)EEPROM.read(eeprom_slice_);
+  os_ = (hostos::Type)KeyboardHardware.storage().read(eeprom_slice_);
 
   return EventHandlerResult::OK;
 }
 
 void HostOS::os(hostos::Type new_os) {
   os_ = new_os;
-  EEPROM.update(eeprom_slice_, os_);
+  KeyboardHardware.storage().update(eeprom_slice_, os_);
 }
 
 }

--- a/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -58,7 +58,7 @@ void LEDPaletteTheme::refreshAt(uint16_t theme_base, uint8_t theme, KeyAddr key_
 const uint8_t LEDPaletteTheme::lookupColorIndexAtPosition(uint16_t map_base, uint16_t position) {
   uint8_t color_index;
 
-  color_index = EEPROM.read(map_base + position / 2);
+  color_index = KeyboardHardware.storage().read(map_base + position / 2);
   if (position % 2)
     color_index &= ~0xf0;
   else
@@ -76,7 +76,7 @@ const cRGB LEDPaletteTheme::lookupColorAtPosition(uint16_t map_base, uint16_t po
 const cRGB LEDPaletteTheme::lookupPaletteColor(uint8_t color_index) {
   cRGB color;
 
-  EEPROM.get(palette_base_ + color_index * sizeof(cRGB), color);
+  KeyboardHardware.storage().get(palette_base_ + color_index * sizeof(cRGB), color);
   color.r ^= 0xff;
   color.g ^= 0xff;
   color.b ^= 0xff;
@@ -87,7 +87,7 @@ const cRGB LEDPaletteTheme::lookupPaletteColor(uint8_t color_index) {
 void LEDPaletteTheme::updateColorIndexAtPosition(uint16_t map_base, uint16_t position, uint8_t color_index) {
   uint8_t indexes;
 
-  indexes = EEPROM.read(map_base + position / 2);
+  indexes = KeyboardHardware.storage().read(map_base + position / 2);
   if (position % 2) {
     uint8_t other = indexes >> 4;
     indexes = (other << 4) + color_index;
@@ -95,7 +95,7 @@ void LEDPaletteTheme::updateColorIndexAtPosition(uint16_t map_base, uint16_t pos
     uint8_t other = indexes & ~0xf0;
     indexes = (color_index << 4) + other;
   }
-  EEPROM.update(map_base + position / 2, indexes);
+  KeyboardHardware.storage().update(map_base + position / 2, indexes);
 }
 
 EventHandlerResult LEDPaletteTheme::onFocusEvent(const char *command) {
@@ -129,7 +129,7 @@ EventHandlerResult LEDPaletteTheme::onFocusEvent(const char *command) {
     color.g ^= 0xff;
     color.b ^= 0xff;
 
-    EEPROM.put(palette_base_ + i * sizeof(color), color);
+    KeyboardHardware.storage().put(palette_base_ + i * sizeof(color), color);
     i++;
   }
 
@@ -155,7 +155,7 @@ EventHandlerResult LEDPaletteTheme::themeFocusEvent(const char *command,
 
   if (::Focus.isEOL()) {
     for (uint16_t pos = 0; pos < max_index; pos++) {
-      uint8_t indexes = EEPROM.read(theme_base + pos);
+      uint8_t indexes = KeyboardHardware.storage().read(theme_base + pos);
 
       ::Focus.send((uint8_t)(indexes >> 4), indexes & ~0xf0);
     }
@@ -171,7 +171,7 @@ EventHandlerResult LEDPaletteTheme::themeFocusEvent(const char *command,
 
     uint8_t indexes = (idx1 << 4) + idx2;
 
-    EEPROM.update(theme_base + pos, indexes);
+    KeyboardHardware.storage().update(theme_base + pos, indexes);
     pos++;
   }
 

--- a/src/kaleidoscope/plugin/Model01-TestMode.cpp
+++ b/src/kaleidoscope/plugin/Model01-TestMode.cpp
@@ -159,13 +159,13 @@ void TestMode::toggle_programming_leds_on() {
 }
 
 void TestMode::run_tests() {
-  //  Serial.println("Running tests");
+  //  KeyboardHardware.serialPort().println("Running tests");
   toggle_programming_leds_on();
   // Disable debouncing
   KeyboardHardware.setKeyscanInterval(2);
   test_leds();
   testMatrix();
-  //  Serial.println("Done running tests");
+  //  KeyboardHardware.serialPort().println("Done running tests");
 }
 
 }

--- a/src/kaleidoscope/plugin/TypingBreaks.cpp
+++ b/src/kaleidoscope/plugin/TypingBreaks.cpp
@@ -107,12 +107,12 @@ EventHandlerResult TypingBreaks::onSetup() {
   // If idleTime is max, assume that EEPROM is uninitialized, and store the
   // defaults.
   uint32_t idle_time;
-  EEPROM.get(settings_base_, idle_time);
+  KeyboardHardware.storage().get(settings_base_, idle_time);
   if (idle_time == 0xffffffff) {
-    EEPROM.put(settings_base_, settings);
+    KeyboardHardware.storage().put(settings_base_, settings);
   }
 
-  EEPROM.get(settings_base_, settings);
+  KeyboardHardware.storage().get(settings_base_, settings);
   return EventHandlerResult::OK;
 }
 
@@ -192,7 +192,7 @@ EventHandlerResult TypingBreaks::onFocusEvent(const char *command) {
     break;
   }
 
-  EEPROM.put(settings_base_, settings);
+  KeyboardHardware.storage().put(settings_base_, settings);
   return EventHandlerResult::EVENT_CONSUMED;
 }
 


### PR DESCRIPTION
These two patches introduce two thin - and for the time being, dummy - abstractions: one for storage, another for serial port access. The accessor will currently return `EEPROM` and `Serial` for the time being.

The goal of these is to update all the plugins to use the newly introduced APIs, which will become wrappers around components in #695.