### PR TITLE
Fixed KeyAddr dependency problems

### DIFF
--- a/src/kaleidoscope/Device.h
+++ b/src/kaleidoscope/Device.h
@@ -65,6 +65,8 @@ class Device {
 
  public:
 
+  typedef _DeviceDescription Description;
+
   typedef typename _DeviceDescription::KeyScanner KeyScanner;
   typedef typename _DeviceDescription::KeyScannerDescription::KeyAddr KeyAddr;
   typedef typename _DeviceDescription::LEDs LEDs;

--- a/src/kaleidoscope/driver/BaseKeyScanner.h
+++ b/src/kaleidoscope/driver/BaseKeyScanner.h
@@ -29,6 +29,8 @@ class BaseKeyScanner {
 
   typedef typename _KeyScannerDescription::KeyAddr KeyAddr;
 
+  static void handleKeyswitchEvent(Key mappedKey, KeyAddr key_addr, uint8_t keyState);
+
   void setup() {}
   void readMatrix() {}
   void scanMatrix() {}

--- a/src/kaleidoscope/driver/keyscanner/ATMegaKeyScanner.h
+++ b/src/kaleidoscope/driver/keyscanner/ATMegaKeyScanner.h
@@ -20,7 +20,6 @@
 #include <Arduino.h>
 #include "Kaleidoscope-HIDAdaptor-KeyboardioHID.h"
 
-#include "kaleidoscope/key_events.h"
 #include "kaleidoscope/key_defs.h"
 #include "kaleidoscope/driver/BaseKeyScanner.h"
 
@@ -34,7 +33,6 @@ template <typename _KeyScannerDescription>
 class ATMegaKeyScanner : public kaleidoscope::driver::BaseKeyScanner<_KeyScannerDescription> {
  private:
   typedef ATMegaKeyScanner<_KeyScannerDescription> ThisType;
-  static void handleKeyswitchEvent(Key mappedKey, KeyAddr key_addr, uint8_t keyState);
 
  public:
   void setup() {
@@ -95,9 +93,9 @@ class ATMegaKeyScanner : public kaleidoscope::driver::BaseKeyScanner<_KeyScanner
                            (bitRead(keyState_[row], col) << 1);
         if (keyState) {
           KeyAddr addr = KeyAddr(
-              row + _KeyScannerDescription::row_offset,
-              col + _KeyScannerDescription::column_offset
-          );
+                           row + _KeyScannerDescription::row_offset,
+                           col + _KeyScannerDescription::column_offset
+                         );
           ThisType::handleKeyswitchEvent(Key_NoKey, addr, keyState);
         }
       }

--- a/src/kaleidoscope/hardware/ez/ErgoDox/ErgoDoxKeyScanner.h
+++ b/src/kaleidoscope/hardware/ez/ErgoDox/ErgoDoxKeyScanner.h
@@ -50,7 +50,7 @@ class ErgoDoxKeyScanner : public kaleidoscope::driver::BaseKeyScanner<_KeyScanne
 
   uint8_t pressedKeyswitchCount() {
     return atmega_scanner_.pressedKeyswitchCount() +
-      expander_scanner_.pressedKeyswitchCount();
+           expander_scanner_.pressedKeyswitchCount();
   }
   bool isKeyswitchPressed(KeyAddr key_addr) {
     if (key_addr.row() < 7) {
@@ -62,7 +62,7 @@ class ErgoDoxKeyScanner : public kaleidoscope::driver::BaseKeyScanner<_KeyScanne
 
   uint8_t previousPressedKeyswitchCount() {
     return atmega_scanner_.previousPressedKeyswitchCount() +
-      expander_scanner_.previousPressedKeyswitchCount();
+           expander_scanner_.previousPressedKeyswitchCount();
   }
   bool wasKeyswitchPressed(KeyAddr key_addr) {
     if (key_addr.row() < 7) {

--- a/src/kaleidoscope/hardware/ez/ErgoDox/ErgoDoxKeyScannerDescription.h
+++ b/src/kaleidoscope/hardware/ez/ErgoDox/ErgoDoxKeyScannerDescription.h
@@ -44,7 +44,7 @@ struct ErgoDoxATMegaKeyScannerDescription : kaleidoscope::driver::keyscanner::AT
   ATMEGA_KEYSCANNER_DESCRIPTION_WITH_OFFSET(7, 0,
       ROW_PIN_LIST({PIN_B0, PIN_B1, PIN_B2, PIN_B3, PIN_D2, PIN_D3, PIN_C6}),
       COL_PIN_LIST({PIN_F0, PIN_F1, PIN_F4, PIN_F5, PIN_F6, PIN_F7})
-  );
+                                           );
 };
 
 struct ErgoDoxMCP23018KeyScannerDescription : kaleidoscope::hardware::ez::ergodox::MCP23018KeyScannerDescription {

--- a/src/kaleidoscope/hardware/ez/ErgoDox/MCP23018KeyScanner.h
+++ b/src/kaleidoscope/hardware/ez/ErgoDox/MCP23018KeyScanner.h
@@ -52,12 +52,12 @@ class MCP23018KeyScanner : public kaleidoscope::driver::BaseKeyScanner<_KeyScann
  public:
   static void setup() {
     static_assert(
-        sizeof(_KeyScannerDescription::matrix_rows) > 0,
-        "The key scanner description has zero rows."
+      sizeof(_KeyScannerDescription::matrix_rows) > 0,
+      "The key scanner description has zero rows."
     );
     static_assert(
-        sizeof(_KeyScannerDescription::matrix_columns) > 0,
-        "The key scanner description has zero columns."
+      sizeof(_KeyScannerDescription::matrix_columns) > 0,
+      "The key scanner description has zero columns."
     );
 
     expander_error_ = initExpander();
@@ -86,9 +86,9 @@ class MCP23018KeyScanner : public kaleidoscope::driver::BaseKeyScanner<_KeyScann
           continue;
 
         KeyAddr addr = KeyAddr(
-            row + _KeyScannerDescription::row_offset,
-            col + _KeyScannerDescription::column_offset
-        );
+                         row + _KeyScannerDescription::row_offset,
+                         col + _KeyScannerDescription::column_offset
+                       );
         handleKeyswitchEvent(Key_NoKey, addr, keyState);
       }
       previousKeyState_[row] = keyState_[row];
@@ -180,7 +180,7 @@ class MCP23018KeyScanner : public kaleidoscope::driver::BaseKeyScanner<_KeyScann
     if (status)
       goto out;
 
- out:
+out:
     i2c_stop();
 
     return status;
@@ -212,7 +212,7 @@ class MCP23018KeyScanner : public kaleidoscope::driver::BaseKeyScanner<_KeyScann
     expander_error_ = i2c_write(0xFF & ~(1 << row));
     if (expander_error_)
       goto out;
- out:
+out:
     i2c_stop();
   }
 
@@ -234,7 +234,7 @@ class MCP23018KeyScanner : public kaleidoscope::driver::BaseKeyScanner<_KeyScann
 
     data = i2c_readNak();
     data = ~data;
- out:
+out:
     i2c_stop();
     return data;
   }

--- a/src/kaleidoscope/key_events.cpp
+++ b/src/kaleidoscope/key_events.cpp
@@ -137,8 +137,3 @@ void handleKeyswitchEvent(Key mappedKey, KeyAddr key_addr, uint8_t keyState) {
     return;
   handleKeyswitchEventDefault(mappedKey, key_addr, keyState);
 }
-
-inline
-void HARDWARE_IMPLEMENTATION::KeyScanner::handleKeyswitchEvent(Key mappedKey, HARDWARE_IMPLEMENTATION::KeyScannerDescription::KeyAddr key_addr, uint8_t keyState) {
-  ::handleKeyswitchEvent(mappedKey, key_addr, keyState);
-}

--- a/src/kaleidoscope/key_events.h
+++ b/src/kaleidoscope/key_events.h
@@ -72,7 +72,18 @@
  * currentState may be flagged INJECTED, which signals that the event was
  * injected, and is not a direct result of a keypress, coming from the scanner.
  */
-void handleKeyswitchEvent(Key mappedKey, HARDWARE_IMPLEMENTATION::KeyScannerDescription::KeyAddr key_addr, uint8_t keyState);
+void handleKeyswitchEvent(Key mappedKey, HARDWARE_IMPLEMENTATION::Description::KeyScannerDescription::KeyAddr key_addr, uint8_t keyState);
 DEPRECATED(ROW_COL_FUNC) inline void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
   handleKeyswitchEvent(mappedKey, KeyAddr(row, col), keyState);
 }
+
+namespace kaleidoscope {
+namespace driver {
+
+template<>
+inline
+void BaseKeyScanner<HARDWARE_IMPLEMENTATION::Description::KeyScannerDescription>::handleKeyswitchEvent(Key mappedKey, HARDWARE_IMPLEMENTATION::Description::KeyScannerDescription::KeyAddr key_addr, uint8_t keyState) {
+  ::handleKeyswitchEvent(mappedKey, key_addr, keyState);
+}
+} // namespace driver
+} // namespace kaleidoscope


### PR DESCRIPTION
This fixes problems with KeyAddr dependencies
by introducing a wrapper method in template class
BaseKeyScanner.


Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>