### PR TITLE
Cygwin support for kaleidoscope-builder

### DIFF
--- a/bin/find-device-port-windows.ps1
+++ b/bin/find-device-port-windows.ps1
@@ -1,0 +1,41 @@
+# Usage:
+#
+# > find-device-port-cygwin.ps1 '1209' '2300' -Format COM
+# COM7
+# > find-device-port-cygwin.ps1 '1209' '2300' -Format WSL
+# /dev/ttyS7
+# > find-device-port-cygwin.ps1 '1209' '2300' -Format Cygwin
+# /dev/ttyS6
+Param(
+    [string]$VendorID,
+    [string]$ProductID, # Careful; $PID is a different builtin
+    [ValidateSet('COM','Cygwin','WSL')][string]$Format
+)
+
+$DeviceParametersRegKey = @(Get-ChildItem -ErrorAction SilentlyContinue -Recurse 'HKLM:\SYSTEM\CurrentControlSet\Enum' |
+    Where-Object Name -match "VID_$VendorID&PID_$ProductID" |
+    Where-Object Property -eq PortName)
+
+if ($DeviceParametersRegKey.Count -eq 0) {
+    throw "Could not find any devices matching VID $VendorID and PID $ProductID which were mapped to a COM port"
+}
+
+if ($DeviceParametersRegKey.Count -ge 2) {
+    throw "More than one devices matching VID $VendorID and PID $ProductID were found mapped to a COM port"
+}
+
+# This will be of form 'COM6'
+$COMPortName = ($DeviceParametersRegKey | Get-ItemProperty).PortName
+$COMPortNumber = [int]$COMPortName.Substring(3)
+
+if ($Format -eq 'COM') {
+    $Output = $COMPortName
+} elseif ($Format -eq 'WSL') {
+    $Output = "/dev/ttyS$COMPortNumber"
+} elseif ($Format -eq 'Cygwin') {
+    $CygwinPortNumber = $COMPortNumber - 1
+    $Output = "/dev/ttyS$CygwinPortNumber"
+}
+
+# "-NoNewline" below is important to prevent bash from seeing an extra trailing '\r'
+Write-Host -NoNewline $Output

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -20,7 +20,7 @@ set -e
 ######
 
 build_version () {
-    GIT_VERSION="$(cd "$(find_sketch)"; if [ -d .git ]; then echo '-g' && git describe --abbrev=4 --dirty --always; fi)"
+    GIT_VERSION="$(cd "$(find_sketch)"; if [ -d .git ]; then echo -n '-g' && git describe --abbrev=4 --dirty --always; fi)"
     LIB_PROPERTIES_PATH="${LIB_PROPERTIES_PATH:-"../.."}"
     LIB_VERSION="$(cd "$(find_sketch)"; (grep version= "${LIB_PROPERTIES_PATH}/library.properties" 2>/dev/null || echo version=0.0.0) | cut -d= -f2)${GIT_VERSION}"
 }
@@ -57,7 +57,7 @@ build_filenames () {
 
 
 enable_ccache () {
-    if  [ "$(command -v ccache)" ]; then
+    if [ -z "${CCACHE_NOT_SUPPORTED}" ] && [ "$(command -v ccache)" ]; then
       if ! [ -d "$CCACHE_WRAPPER_PATH" ]; then
          mkdir -p "$CCACHE_WRAPPER_PATH"
       fi
@@ -304,12 +304,13 @@ compile () {
 	      -ide-version "${ARDUINO_IDE_VERSION}" \
 	      -built-in-libraries "${ARDUINO_PATH}/libraries" \
 	      -prefs "compiler.cpp.extra_flags=-std=c++11 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
+          -prefs compiler.path=${COMPILER_PATH} \
 	      $CCACHE_ENABLE \
 	      -warnings all \
         ${ARDUINO_VERBOSE} \
 	      ${ARDUINO_AVR_GCC_PREFIX_PARAM} \
 	      "${SKETCH_DIR}/${SKETCH}.ino"
-
+    
     cp "${BUILD_PATH}/${SKETCH}.ino.hex" "${HEX_FILE_PATH}"
     cp "${BUILD_PATH}/${SKETCH}.ino.elf" "${ELF_FILE_PATH}"
     ln -sf "${OUTPUT_FILE_PREFIX}.hex" "${OUTPUT_PATH}/${SKETCH}-latest.hex"

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -304,13 +304,13 @@ compile () {
 	      -ide-version "${ARDUINO_IDE_VERSION}" \
 	      -built-in-libraries "${ARDUINO_PATH}/libraries" \
 	      -prefs "compiler.cpp.extra_flags=-std=c++11 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
-          -prefs compiler.path=${COMPILER_PATH} \
+	      -prefs compiler.path=${COMPILER_PATH} \
 	      $CCACHE_ENABLE \
 	      -warnings all \
         ${ARDUINO_VERBOSE} \
 	      ${ARDUINO_AVR_GCC_PREFIX_PARAM} \
 	      "${SKETCH_DIR}/${SKETCH}.ino"
-    
+
     cp "${BUILD_PATH}/${SKETCH}.ino.hex" "${HEX_FILE_PATH}"
     cp "${BUILD_PATH}/${SKETCH}.ino.elf" "${ELF_FILE_PATH}"
     ln -sf "${OUTPUT_FILE_PREFIX}.hex" "${OUTPUT_PATH}/${SKETCH}-latest.hex"

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -41,6 +41,7 @@ fi
 ## Platform-specific overrides
 # Shamelessly stolen from git's Makefile
 uname_S=$(uname -s 2>/dev/null || echo not)
+uname_O=$(uname -o 2>/dev/null || echo not)
 
 
 find_max_prog_size() {
@@ -67,7 +68,7 @@ find_device_vid_pid() {
 		-tools "${ARDUINO_PATH}/tools-builder" \
 		-fqbn "${FQBN}" \
 	 	-build-path ${ARDUINO_PATH} \
-   		-dump-prefs  "${SKETCH_DIR}/${SKETCH}.ino" || grep "\.[vp]id=")
+   		-dump-prefs  "${SKETCH_DIR}/${SKETCH}.ino" | grep "\.[vp]id=")
     VID=${VID:-$(echo "${VPIDS}" | grep build.vid= | cut -dx -f2)}
     SKETCH_PID=${SKETCH_PID:-$(echo "${VPIDS}" | grep build.pid= | cut -dx -f2)}
     BOOTLOADER_PID=${BOOTLOADER_PID:-$(echo "${VPIDS}" | grep bootloader.pid= | cut -dx -f2)}
@@ -158,6 +159,58 @@ elif [ "${uname_S}" = "FreeBSD" ]; then
 	DIR=$(dirname "$0")
 	DEVICE_PORT_PROBER="${DIR}/find-device-port-freebsd"
 	DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER})"
+    }
+
+elif [ "${uname_O}" = "Cygwin" ]; then
+    # The Windows arduino-builder.exe doesn't understand being told to exec against Cygwin symlinks
+    CCACHE_NOT_SUPPORTED=1
+
+    # Note: the default ARDUINO_PATH here is the default Arduino installation path on Windows, but it won't actually
+    # work in practice right now since we haven't fixed all bugs related to interpretation of spaces in these paths.
+    #
+    # It's important that all of these be underneath /cygdrive/c so they can be converted to Windows paths that the
+    # Windows Arduino binaries can understand.
+    ARDUINO_PATH="${ARDUINO_PATH:-/cygdrive/c/Program\ Files\ (x86)/Arduino}"
+    ARDUINO_PACKAGE_PATH="${ARDUINO_PACKAGE_PATH:-/cygdrive/c/Users/${USER}/AppData/Local/Arduino15/packages}"
+    ARDUINO_LOCAL_LIB_PATH="${ARDUINO_LOCAL_LIB_PATH:-/cygdrive/c/Users/${USER}/Arduino}"
+    TMPDIR="${ARDUINO_LOCAL_LIB_PATH:-/cygdrive/c/Users/${USER}/AppData/Local/Temp}"
+
+    # We need to prevent Windows executables from being passed parameters that are absolute paths, since they won't
+    # be interpretable when of the form /cygdrive/c/foo. To work around this, we set the common path root variables
+    # to use relative paths instead of absolute paths, since those have mostly platform-agnostic behavior.
+    #
+    # Note that this trick requires that all of these paths exist on the same drive letter as the current directory,
+    # since otherwise even the relative paths would include Cygwin-specific components. So...
+    if [[ $(realpath --relative-base=/cygdrive/c .) == /* ]]; then
+        echo "kaleidoscope-builder's Cygwin support is currently limited to running from within /cygdrive/c"
+        exit 1
+    fi
+
+    ARDUINO_PATH="$(realpath --relative-to=./ ${ARDUINO_PATH})"
+    ARDUINO_PACKAGE_PATH="$(realpath --relative-to=./ ${ARDUINO_PACKAGE_PATH})"
+    ARDUINO_LOCAL_LIB_PATH="$(realpath --relative-to=./ ${ARDUINO_LOCAL_LIB_PATH})"
+    ROOT="$(realpath --relative-to=./ ${ROOT})"
+    export ROOT
+    TMPDIR="$(realpath --relative-to=./ ${ARDUINO_PATH})"
+
+    find_device_port() {
+        find_device_vid_pid
+        DIR=$(dirname "$0")
+        DEVICE_PORT_PROBER="${DIR}/find-device-port-windows.ps1"
+        DEVICE_PORT="$(powershell -noprofile -executionpolicy bypass ${DEVICE_PORT_PROBER} ${VID} ${SKETCH_PID} -Format Cygwin)"
+        DEVICE_COM_PORT="$(powershell -noprofile -executionpolicy bypass ${DEVICE_PORT_PROBER} ${VID} ${SKETCH_PID} -Format COM)"
+    }
+
+    reset_device_cmd() {
+        cmd /c mode ${DEVICE_COM_PORT} baud=1200
+    }
+
+    find_bootloader_ports() {
+        find_device_vid_pid
+        DIR=$(dirname "$0")
+        BOOTLOADER_VID="${BOOTLOADER_VID:-${VID}}"
+        DEVICE_PORT_PROBER="${DIR}/find-device-port-windows.ps1"
+        DEVICE_PORT_BOOTLOADER="$(powershell -noprofile -executionpolicy bypass ${DEVICE_PORT_PROBER} ${BOOTLOADER_VID} ${BOOTLOADER_PID} -Format COM)"
     }
 
 fi


### PR DESCRIPTION
This PR adds support for using Windows+Cygwin to do command line builds of Kaleidoscope-based Model01 firmware, including flashing. You can see my motivating example at https://github.com/dbjorge/keyboardio-model01-firmware (you'd have to update the nested submodule dependency on this project for it to actually work though).

Known limitations:
* You must run from a path under `/cygdrive/c`, due to an implementation detail related to the use of relative paths, described below. It would be feasible to make this work for people that change the name of the `/cygdrive/` mount point or develop on a non-C drive, but I didn't address that in this PR.
* CCACHE is not supported; I wasn't able to make the Windows `arduino-builder.exe` cooperate with being told to use a compiler.path full of Cygwin symlinks
* The default Arduino IDE install location in Windows is `C:\Program Files (x86)\Arduino`, but the builder has issues with paths that contain spaces, so it won't actually work if you use the default. For my own project, I chose to keep the Arduino IDE in a .gitignore'd `/lib/` folder within my firmware project itself that a `make setup` step downloads/extracts; you could also work around this by installing to a custom location like `C:\Tools\Arduino` and setting `ARDUINO_PATH` accordingly.

The significant parts of the implementation are:
* Adds a `bin/find-device-port-windows.ps1` that provides a similar interface to the existing `find-device-port-*` scripts
* Adds a new Cygwin section to `kaleidoscope-builder.conf` next to the existing platform-specific sections.
* Because it uses windows Arduino binaries, which expect windows-style paths, it converts most of the common path prefix variables to use relative paths rather than absolute paths (so they can be used in a more platform-compatible manner).
* Because the above relative path trick requires that relative paths not `../../` their way outside of Windows-visible parts of the Cygwin filesystem, the script verifies that it's being run from within `/cygdrive/c` and errors out if not. This could probably be improved by someone motivated to keep their code/Arduino installs on different drive letters; I left it at this point because I was unblocked without having to address this limitation.
* Updates `kaleidoscope-builder` to handle CCACHE not being supported (in particular, passing a non-ccache-based compiler.path argument to arduino-builder as a fallback option for when CCACHE isn't supported)

Output from using these changes to successfully flash my own firmware sketch from a Cygwin shell:

```bash
dbjor@DANIELBJ-H3 /cygdrive/c/repos/keyboardio-model01-firmware
$ make flash
BOARD_HARDWARE_PATH="./lib/hardware" ARDUINO_PATH="./lib/arduino-1.8.10" ./lib/hardware/keyboardio/avr/libraries/Kaleidoscope/bin/kaleidoscope-builder flash
Building ./firmware 0.0.0-g6c8e-dirty into ./out...
- Size: firmware/firmware/firmware-0.0.0-g6c8e-dirty.elf
  - Program:   12356 bytes (43.1% Full)
  - Data:        908 bytes (35.5% Full)

To update your keyboard's firmware, hold down the 'Prog' key on your keyboard,
and then press 'Enter'.

When the 'Prog' key glows red, you can release it.


Default to 7 data bits.
Default to even parity.

Status for device COM7:
-----------------------
    Baud:            1200
    Parity:          Even
    Data Bits:       7
    Stop Bits:       1
    Timeout:         OFF
    XON/XOFF:        OFF
    CTS handshaking: OFF
    DSR handshaking: OFF
    DSR sensitivity: OFF
    DTR circuit:     OFF
    RTS circuit:     ON

Connecting to programmer: .
Found programmer: Id = "CATERIN"; type = S
    Software Version = 1.0; No Hardware Version given.
Programmer supports auto addr increment.
Programmer supports buffered memory access with buffersize=128 bytes.

Programmer supports the following devices:
    Device code: 0x44


```

Signed-off-by: Dan Bjorge <dan@dbjorge.net>