### PR TITLE
library.properties: Remove the AVR architecture restriction

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Firmware for the Keyboardio Model 01, and other Arduino-powered keyboar
 paragraph=...
 category=Communication
 url=https://github.com/keyboardio/Kaleidoscope
-architectures=avr
+architectures=*
 dot_a_linkage=true


### PR DESCRIPTION
While we technically only support AVR for now, most of the code is arch-agnostic, and we'll soon have ARM boards too. This is a preparation step to unlock that architecture.
