### PR TITLE
Atreus2: Proposal for a keyboardio style layout

### DIFF
--- a/examples/Devices/Technomancy/Atreus2/Atreus2.ino
+++ b/examples/Devices/Technomancy/Atreus2/Atreus2.ino
@@ -83,8 +83,8 @@ KEYMAPS(
 
   /* _LOWER
      +-------+-------+-------+-------+-------+
-     |       |       |       |       |       |
-     | Left  | Down  |  Up   | Right | PgUp  +-------+
+     |       |       |  Up   |       |       |
+     |       | Left  | Down  | Right | PgUp  +-------+
      |       |       |       |       | PgDn  | Home  |
      | -L1-  | Del   | Ctrl  |  Cmd  | Shift |  Esc  |
      +-------+-------+-------+-------+-------+-------+
@@ -98,10 +98,10 @@ KEYMAPS(
   */
   [_LOWER] = KEYMAP_STACKED
   (
-       XXX      ,XXX        ,XXX    ,XXX       ,XXX
-      ,Key_Left ,Key_Down   ,Key_Up ,Key_Right ,Key_PageUp
-      ,XXX      ,XXX        ,XXX    ,XXX       ,Key_PageDown ,Key_Home
-      ,___      ,Key_Delete ,___    ,___       ,___          ,___
+       XXX ,XXX        ,Key_Up   ,XXX       ,XXX
+      ,XXX ,Key_Left   ,Key_Down ,Key_Right ,Key_PageUp
+      ,XXX ,XXX        ,XXX      ,XXX       ,Key_PageDown ,Key_Home
+      ,___ ,Key_Delete ,___      ,___       ,___          ,___
 
                  ,Key_Backtick ,Key_7 ,Key_8      ,Key_9    ,Key_Minus
                  ,Key_Period   ,Key_4 ,Key_5      ,Key_6    ,Key_Plus

--- a/examples/Devices/Technomancy/Atreus2/Atreus2.ino
+++ b/examples/Devices/Technomancy/Atreus2/Atreus2.ino
@@ -27,68 +27,141 @@
 #include "Kaleidoscope-Qukeys.h"
 #include "Kaleidoscope-SpaceCadet.h"
 
-
-
 #define MO(n) ShiftToLayer(n)
 #define TG(n) LockLayer(n)
 
-enum {
-  LAYER_QWERTY
-};
-
-#define Key_Exclamation LSHIFT(Key_1)
-#define Key_At LSHIFT(Key_2)
-#define Key_Hash LSHIFT(Key_3)
-#define Key_Dollar LSHIFT(Key_4)
-#define Key_And LSHIFT(Key_7)
+#define Key_BSpc Key_Backspace
+#define Key_VolUp Consumer_VolumeIncrement
+#define Key_VolDn Consumer_VolumeDecrement
+#define Key_LCBracket LSHIFT(Key_LeftBracket)
+#define Key_RCBracket LSHIFT(Key_RightBracket)
 #define Key_Star LSHIFT(Key_8)
 #define Key_Plus LSHIFT(Key_Equals)
 
+#define Key_Up Key_UpArrow
+#define Key_Down Key_DownArrow
+#define Key_Left Key_LeftArrow
+#define Key_Right Key_RightArrow
+
 enum {
-  QWERTY,
-  NUMPAD,
-  NAV
+  _QWERTY,
+  _LOWER,
+  _RAISE,
+  _MOUSE
 };
 
 /* *INDENT-OFF* */
 KEYMAPS(
-  [QWERTY] = KEYMAP_STACKED
-  (
-       Key_Q   ,Key_W   ,Key_E       ,Key_R         ,Key_T
-      ,Key_A   ,Key_S   ,Key_D       ,Key_F         ,Key_G
-      ,Key_Z   ,Key_X   ,Key_C       ,Key_V         ,Key_B, Key_Backtick
-      ,Key_Esc ,Key_Tab ,Key_LeftGui ,Key_LeftShift ,Key_Backspace ,Key_LeftControl
+    /* QWERTY:
+      +-------+-------+-------+-------+-------+
+      | Q     | W     | E     | R     | T     |
+      | A     | S     | D     | F     | G     +-------+
+      | Z     | X     | C     | V     | B     | Tab   |
+      | L1    | Bspc  | Ctrl  | Cmd   | Shift | Esc   |
+      +-------+-------+-------+-------+-------+-------+
 
-                     ,Key_Y     ,Key_U   ,Key_I     ,Key_O      ,Key_P
-                     ,Key_H     ,Key_J   ,Key_K     ,Key_L      ,Key_Semicolon
-       ,Key_Backslash,Key_N     ,Key_M   ,Key_Comma ,Key_Period ,Key_Slash
-       ,Key_LeftAlt  ,Key_Space ,MO(NUMPAD) ,Key_Minus ,Key_Quote  ,Key_Enter
+      .       +-------+-------+-------+-------+-------+
+      .       | Y     | U     | I     | O     | P     |
+      +-------| H     | J     | K     | L     | ;     |
+      | Enter | N     | M     | ,     | .     | /     |
+      | Space | Shift | Alt   | -     | '     | L2    |
+      +-------+-------+-------+-------+-------+-------+
+    */
+  [_QWERTY] = KEYMAP_STACKED
+  (
+       Key_Q      ,Key_W    ,Key_E           ,Key_R       ,Key_T
+      ,Key_A      ,Key_S    ,Key_D           ,Key_F       ,Key_G
+      ,Key_Z      ,Key_X    ,Key_C           ,Key_V       ,Key_B         ,Key_Tab
+      ,MO(_LOWER) ,Key_BSpc ,Key_LeftControl ,Key_LeftGui ,Key_LeftShift ,Key_Esc
+
+                  ,Key_Y          ,Key_U       ,Key_I     ,Key_O      ,Key_P
+                  ,Key_H          ,Key_J       ,Key_K     ,Key_L      ,Key_Semicolon
+       ,Key_Enter ,Key_N          ,Key_M       ,Key_Comma ,Key_Period ,Key_Slash
+       ,Key_Space ,Key_RightShift ,Key_LeftAlt ,Key_Minus ,Key_Quote  ,MO(_RAISE)
   ),
 
-  [NUMPAD] = KEYMAP_STACKED
-  (
-       Key_Exclamation ,Key_At           ,Key_UpArrow   ,Key_LeftCurlyBracket ,Key_RightCurlyBracket
-      ,Key_Hash        ,Key_LeftArrow    ,Key_DownArrow ,Key_RightArrow       ,Key_Dollar
-      ,Key_LeftBracket ,Key_RightBracket ,Key_LeftParen ,Key_RightParen       ,Key_And		     ,___
-      ,TG(NAV)         ,Key_Insert       ,Key_LeftGui   ,Key_LeftShift        ,Key_Backspace         ,Key_LeftControl
+  /* _LOWER
+     +-------+-------+-------+-------+-------+
+     |       |       |       |       |       |
+     | Left  | Down  |  Up   | Right | PgUp  +-------+
+     |       |       |       |       | PgDn  | Home  |
+     | -L1-  | Del   | Ctrl  |  Cmd  | Shift |  Esc  |
+     +-------+-------+-------+-------+-------+-------+
 
-                   ,Key_PageUp   ,Key_7 ,Key_8      ,Key_9 ,Key_Star
-                   ,Key_PageDown ,Key_4 ,Key_5      ,Key_6 ,Key_Plus
-      ,___         ,Key_Backtick ,Key_1 ,Key_2      ,Key_3 ,Key_Backslash
-      ,Key_LeftAlt ,Key_Space    ,___   ,Key_Period ,Key_0 ,Key_Equals
+     .       +-------+-------+-------+-------+-------+
+     .       |   `   |   7   |   8   |   9   |  -    |
+     +-------|   .   |   4   |   5   |   6   |  +    |
+     | End   |   0   |   1   |   2   |   3   |  \    |
+     | Enter | Shift |  Alt  |   =   |   *   | *L3*  |
+     +-------+-------+-------+-------+-------+-------+
+  */
+  [_LOWER] = KEYMAP_STACKED
+  (
+       XXX      ,XXX        ,XXX    ,XXX       ,XXX
+      ,Key_Left ,Key_Down   ,Key_Up ,Key_Right ,Key_PageUp
+      ,XXX      ,XXX        ,XXX    ,XXX       ,Key_PageDown ,Key_Home
+      ,___      ,Key_Delete ,___    ,___       ,___          ,___
+
+                 ,Key_Backtick ,Key_7 ,Key_8      ,Key_9    ,Key_Minus
+                 ,Key_Period   ,Key_4 ,Key_5      ,Key_6    ,Key_Plus
+      ,Key_End   ,Key_0        ,Key_1 ,Key_2      ,Key_3    ,Key_Slash
+      ,Key_Enter ,___          ,___   ,Key_Equals ,Key_Star ,TG(_MOUSE)
    ),
 
-  [NAV] = KEYMAP_STACKED
-  (
-       Key_Insert ,Key_Home                 ,Key_UpArrow   ,Key_End        ,Key_PageUp
-      ,Key_Delete ,Key_LeftArrow            ,Key_DownArrow ,Key_RightArrow ,Key_PageDown
-      ,XXX        ,Consumer_VolumeIncrement ,XXX           ,XXX            ,___ ,___
-      ,XXX        ,Consumer_VolumeDecrement ,___           ,___            ,___  ,___
+  /* _RAISE
+     +-------+-------+-------+-------+-------+
+     |  F7   |  F8   |  F9   | F10   |  >>   |
+     |  F4   |  F5   |  F6   | F11   |  <<   +-------+
+     |  F1   |  F2   |  F3   | F12   |Ply/Pse| Mute  |
+     | *L3*  |  Del  |  Ctrl | Cmd   | Shift |  Esc  |
+     +-------+-------+-------+-------+-------+-------+
 
-                ,Key_UpArrow   ,Key_F7 ,Key_F8          ,Key_F9         ,Key_F10
-                ,Key_DownArrow ,Key_F4 ,Key_F5          ,Key_F6         ,Key_F11
-      ,___      ,XXX           ,Key_F1 ,Key_F2          ,Key_F3         ,Key_F12
-      ,___      ,___           ,M(QWERTY)  ,Key_PrintScreen ,Key_ScrollLock ,Consumer_PlaySlashPause
+     .       +-------+-------+-------+-------+-------+
+     .       |       |       |       |       |       |
+     +-------|   {   |   }   |   [   |   ]   |       |
+     | Vol+  |  Vol- |       |       |       |  \    |
+     | Enter | Shift |  Alt  |       |       | -L2-  |
+     +-------+-------+-------+-------+-------+-------+
+  */
+  [_RAISE] = KEYMAP_STACKED
+  (
+       Key_F7     ,Key_F8     ,Key_F9 ,Key_F10 ,Consumer_ScanNextTrack
+      ,Key_F4     ,Key_F5     ,Key_F6 ,Key_F11 ,Consumer_ScanPreviousTrack
+      ,Key_F1     ,Key_F2     ,Key_F3 ,Key_F12 ,Consumer_PlaySlashPause    ,Consumer_Mute
+      ,TG(_MOUSE) ,Key_Delete ,___    ,___     ,___                        ,___
+
+                 ,XXX           ,XXX           ,XXX          ,XXX          ,XXX
+                 ,Key_LCBracket ,Key_RCBracket ,Key_LBracket ,Key_RBracket ,XXX
+      ,Key_VolUp ,Key_VolDn     ,XXX           ,XXX          ,XXX          ,Key_Slash
+      ,Key_Enter ,___           ,___           ,XXX          ,XXX          ,___
+   ),
+
+  /* _MOUSE
+     +-------+-------+-------+-------+-------+
+     |       |       |  MUp  |       |  MBL  |
+     |       | MLeft | MDown | MRght |  MBM  +-------+
+     |       |       |       |       |  MBR  |       |
+     | *L3*  |       |  Ctrl |  Cmd  | Shift |  Esc  |
+     +-------+-------+-------+-------+-------+-------+
+
+     .       +-------+-------+-------+-------+-------+
+     .       | PrScr | WClr  |       |       |       |
+     +-------|  Ins  |  WNW  |  WNE  |       |       |
+     |       |       |  WSW  |  WSE  |       |       |
+     |       | Shift |  Alt  |       |       | *L3*  |
+     +-------+-------+-------+-------+-------+-------+
+  */
+  [_MOUSE] = KEYMAP_STACKED
+  (
+       XXX ,XXX        ,Key_mouseUp ,XXX        ,Key_mouseBtnL
+      ,XXX ,Key_mouseL ,Key_mouseDn ,Key_mouseR ,Key_mouseBtnM
+      ,XXX ,XXX        ,XXX         ,XXX        ,Key_mouseBtnR ,XXX
+      ,___ ,XXX        ,___         ,___        ,___           ,___
+
+           ,Key_PrintScreen ,Key_mouseWarpEnd ,XXX             ,XXX ,XXX
+           ,Key_Insert      ,Key_mouseWarpNW  ,Key_mouseWarpNE ,XXX ,XXX
+      ,XXX ,XXX             ,Key_mouseWarpSW  ,Key_mouseWarpSE ,XXX ,XXX
+      ,XXX ,___             ,___              ,XXX             ,XXX ,___
    )
 )
 /* *INDENT-ON* */
@@ -105,18 +178,6 @@ KALEIDOSCOPE_INIT_PLUGINS(
   Macros,
   Qukeys
 );
-
-const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
-  switch (macroIndex) {
-  case QWERTY:
-    Layer.move(LAYER_QWERTY);
-    break;
-  default:
-    break;
-  }
-
-  return MACRO_NONE;
-}
 
 void setup() {
   Kaleidoscope.setup();

--- a/examples/Devices/Technomancy/Atreus2/Atreus2.ino
+++ b/examples/Devices/Technomancy/Atreus2/Atreus2.ino
@@ -37,7 +37,6 @@
 #define Key_LCBracket LSHIFT(Key_LeftBracket)
 #define Key_RCBracket LSHIFT(Key_RightBracket)
 #define Key_Star LSHIFT(Key_8)
-#define Key_Plus LSHIFT(Key_Equals)
 
 #define Key_Up Key_UpArrow
 #define Key_Down Key_DownArrow
@@ -83,58 +82,58 @@ KEYMAPS(
 
   /* _LOWER
      +-------+-------+-------+-------+-------+
-     |       |       |  Up   |       |       |
-     |       | Left  | Down  | Right | PgUp  +-------+
-     |       |       |       |       | PgDn  | Home  |
+     |       | Left  | Down  | Up    | Right |
+     |  1    |   2   | 3     | 4     | 5     +-------+
+     |       |       | PgDn  | PgUp  |       | Home  |
      | -L1-  | Del   | Ctrl  |  Cmd  | Shift |  Esc  |
      +-------+-------+-------+-------+-------+-------+
 
      .       +-------+-------+-------+-------+-------+
-     .       |   `   |   7   |   8   |   9   |  -    |
-     +-------|   .   |   4   |   5   |   6   |  +    |
-     | End   |   0   |   1   |   2   |   3   |  \    |
-     | Enter | Shift |  Alt  |   =   |   *   | *L3*  |
+     .       |   {   |   }   |   [   |   ]   |  *    |
+     +-------|   6   |   7   |   8   |   9   |  0    |
+     | End   |       |       |       |       |  \    |
+     | Enter | Shift |  Alt  |   =   |   `   | *L3*  |
      +-------+-------+-------+-------+-------+-------+
   */
   [_LOWER] = KEYMAP_STACKED
   (
-       XXX ,XXX        ,Key_Up   ,XXX       ,XXX
-      ,XXX ,Key_Left   ,Key_Down ,Key_Right ,Key_PageUp
-      ,XXX ,XXX        ,XXX      ,XXX       ,Key_PageDown ,Key_Home
-      ,___ ,Key_Delete ,___      ,___       ,___          ,___
+       XXX   ,Key_Left   ,Key_Down   ,Key_Up     ,Key_Right
+      ,Key_1 ,Key_2      ,Key_3      ,Key_4      ,Key_5
+      ,XXX   ,XXX        ,Key_PageDn ,Key_PageUp ,XXX       ,Key_Home
+      ,___   ,Key_Delete ,___        ,___        ,___       ,___
 
-                 ,Key_Backtick ,Key_7 ,Key_8      ,Key_9    ,Key_Minus
-                 ,Key_Period   ,Key_4 ,Key_5      ,Key_6    ,Key_Plus
-      ,Key_End   ,Key_0        ,Key_1 ,Key_2      ,Key_3    ,Key_Slash
-      ,Key_Enter ,___          ,___   ,Key_Equals ,Key_Star ,TG(_MOUSE)
+                 ,Key_LCBracket ,Key_RCBracket ,Key_LBracket ,Key_RBracket ,Key_Star
+                 ,Key_6         ,Key_7         ,Key_8        ,Key_9        ,Key_0
+      ,Key_End   ,XXX           ,XXX           ,XXX          ,XXX          ,Key_Slash
+      ,Key_Enter ,___           ,___           ,Key_Equals   ,Key_Backtick ,TG(_MOUSE)
    ),
 
   /* _RAISE
      +-------+-------+-------+-------+-------+
-     |  F7   |  F8   |  F9   | F10   |  >>   |
-     |  F4   |  F5   |  F6   | F11   |  <<   +-------+
-     |  F1   |  F2   |  F3   | F12   |Ply/Pse| Mute  |
+     |  F11  | F12   |       | <<    |  >>   |
+     |  F1   |  F2   |  F3   | F4    |  F5   +-------+
+     |       |       |       |       |Ply/Pse| Mute  |
      | *L3*  |  Del  |  Ctrl | Cmd   | Shift |  Esc  |
      +-------+-------+-------+-------+-------+-------+
 
      .       +-------+-------+-------+-------+-------+
      .       |       |       |       |       |       |
-     +-------|   {   |   }   |   [   |   ]   |       |
+     +-------| F6    | F7    | F8    | F9    | F10   |
      | Vol+  |  Vol- |       |       |       |  \    |
      | Enter | Shift |  Alt  |       |       | -L2-  |
      +-------+-------+-------+-------+-------+-------+
   */
   [_RAISE] = KEYMAP_STACKED
   (
-       Key_F7     ,Key_F8     ,Key_F9 ,Key_F10 ,Consumer_ScanNextTrack
-      ,Key_F4     ,Key_F5     ,Key_F6 ,Key_F11 ,Consumer_ScanPreviousTrack
-      ,Key_F1     ,Key_F2     ,Key_F3 ,Key_F12 ,Consumer_PlaySlashPause    ,Consumer_Mute
+       Key_F11    ,Key_F12    ,XXX    ,Consumer_ScanPreviousTrack ,Consumer_ScanNextTrack
+      ,Key_F1     ,Key_F2     ,Key_F3 ,Key_F4                     ,Key_F5
+      ,XXX        ,XXX        ,XXX    ,XXX                         ,Consumer_PlaySlashPause    ,Consumer_Mute
       ,TG(_MOUSE) ,Key_Delete ,___    ,___     ,___                        ,___
 
-                 ,XXX           ,XXX           ,XXX          ,XXX          ,XXX
-                 ,Key_LCBracket ,Key_RCBracket ,Key_LBracket ,Key_RBracket ,XXX
-      ,Key_VolUp ,Key_VolDn     ,XXX           ,XXX          ,XXX          ,Key_Slash
-      ,Key_Enter ,___           ,___           ,XXX          ,XXX          ,___
+                 ,XXX       ,XXX    ,XXX    ,XXX    ,XXX
+                 ,Key_F6    ,Key_F7 ,Key_F8 ,Key_F9 ,Key_F10
+      ,Key_VolUp ,Key_VolDn ,XXX    ,XXX    ,XXX    ,Key_Slash
+      ,Key_Enter ,___       ,___    ,XXX    ,XXX    ,___
    ),
 
   /* _MOUSE

--- a/examples/Devices/Technomancy/Atreus2/Atreus2.ino
+++ b/examples/Devices/Technomancy/Atreus2/Atreus2.ino
@@ -26,6 +26,7 @@
 #include "Kaleidoscope-OneShot.h"
 #include "Kaleidoscope-Qukeys.h"
 #include "Kaleidoscope-SpaceCadet.h"
+#include "Kaleidoscope-EscapeOneShot.h"
 
 #define MO(n) ShiftToLayer(n)
 #define TG(n) LockLayer(n)
@@ -69,15 +70,15 @@ KEYMAPS(
     */
   [_QWERTY] = KEYMAP_STACKED
   (
-       Key_Q      ,Key_W    ,Key_E           ,Key_R       ,Key_T
-      ,Key_A      ,Key_S    ,Key_D           ,Key_F       ,Key_G
-      ,Key_Z      ,Key_X    ,Key_C           ,Key_V       ,Key_B         ,Key_Tab
-      ,MO(_LOWER) ,Key_BSpc ,Key_LeftControl ,Key_LeftGui ,Key_LeftShift ,Key_Esc
+       Key_Q       ,Key_W    ,Key_E            ,Key_R        ,Key_T
+      ,Key_A       ,Key_S    ,Key_D            ,Key_F        ,Key_G
+      ,Key_Z       ,Key_X    ,Key_C            ,Key_V        ,Key_B          ,Key_Tab
+      ,OSL(_LOWER) ,Key_BSpc ,OSM(LeftControl) ,OSM(LeftGui) ,OSM(LeftShift) ,Key_Esc
 
-                  ,Key_Y          ,Key_U       ,Key_I     ,Key_O      ,Key_P
-                  ,Key_H          ,Key_J       ,Key_K     ,Key_L      ,Key_Semicolon
-       ,Key_Enter ,Key_N          ,Key_M       ,Key_Comma ,Key_Period ,Key_Slash
-       ,Key_Space ,Key_RightShift ,Key_LeftAlt ,Key_Minus ,Key_Quote  ,MO(_RAISE)
+                  ,Key_Y           ,Key_U        ,Key_I     ,Key_O      ,Key_P
+                  ,Key_H           ,Key_J        ,Key_K     ,Key_L      ,Key_Semicolon
+       ,Key_Enter ,Key_N           ,Key_M        ,Key_Comma ,Key_Period ,Key_Slash
+       ,Key_Space ,OSM(RightShift) ,OSM(LeftAlt) ,Key_Minus ,Key_Quote  ,OSL(_RAISE)
   ),
 
   /* _LOWER
@@ -172,6 +173,7 @@ KALEIDOSCOPE_INIT_PLUGINS(
   Focus,
   FocusEEPROMCommand,
   FocusSettingsCommand,
+  EscapeOneShot,
   OneShot,
   SpaceCadet,
   MouseKeys,


### PR DESCRIPTION
For the past few days, I've been thinking about how to best translate the spirit of the default Model01 layout to the Atreus2. There are a good number of challenges, ranging from considerably less keys, through not having palm keys, to less thumb keys. As such, a direct translation is not possible, the best one can do is try to capture the spirit of the Model01 layout.

What I came up with _feels_ okay, but I only tested on an Atreus1, which has two keys less, so I had to imagine how it'd work with two more. Some of the decisions were made based on this practice.

The layout consists of four layers: the base `QWERTY` layer, a `LOWER` and a `RAISE` layer, and a `MOUSE` layer. The `MOUSE` layer can be **toggled on** by pressing `LOWER` and `RAISE` at the same time. Pressing either of those again will get us back to the `QWERTY` layer.

I went with four layers so that we can fit everything we want onto the keyboard, without having to place some keys into awkward places.

Without much further ado, lets look at the layers:

## QWERTY

```
+-------+-------+-------+-------+-------+
| Q     | W     | E     | R     | T     |
| A     | S     | D     | F     | G     +-------+
| Z     | X     | C     | V     | B     | Tab   |
| L1    | Bspc  | Ctrl  | Cmd   | Shift | Esc   |
+-------+-------+-------+-------+-------+-------+

              +-------+-------+-------+-------+-------+
              | Y     | U     | I     | O     | P     |
      +-------| H     | J     | K     | L     | ;     |
      | Enter | N     | M     | ,     | .     | /     |
      | Space | Shift | Alt   | -     | '     | L2    |
      +-------+-------+-------+-------+-------+-------+
```

For the most part, there's nothing surprising here. The alphas are where one would expect them to be. I'd like to explain the positioning of the rest of the symbols, however:

- The `LOWER` (L1) and `RAISE` (L2) keys went to the pinky position in the bottom row. Reason for the pinky is that this makes one able to hold these keys, and press most others on the same half of the keyboard, without twisting their hands. Placing them anywhere else, it would result in uncomfortable combinations. Thumbs would be another option, but I think thumbs are better used for things pressed more often than layer keys.
- Talking about thumbs, _I_ can reach the two thumb keys, and the two innermost keys of the bottom row with my thumb, comfortably. So I consider those keys thumb-accessible.
- This makes `Cmd`,`Shift`, and `Alt` good candidates for those positions. Non-mac users may want to swap `Cmd` and `Ctrl`, though. Perhaps we could make a toggle for that somewhere, to support both with the same firmware with ease.
- `Esc` went to the lower left thumb key, because it's an important key.
- `Tab` went above it, for similar reasons.
- `Space` and `Enter` went on the right thumb keys, for similar reasons. I opted to place them on top of one another (with `Space` becoming `Enter` on the `LOWER` and `RAISE` layers, to mirror the Model01's `Fn+Space` behaviour) because it seemed logical to do so. Both are required fairly often, so are prime thumb-candidates. Having them near makes it easier to learn their position. It does make it easier to mishit though.
- `Backspace` went to the side, under the ring finger, because it is less often used than modifiers. Like on the Model01, it turns into `Delete` on the `RAISE` and `LOWER` layers.

## Lower

I borrowed the term from QMK, it doesn't really mean anything. I just couldn't come up with a better name. It's a combination of a navigation (left) and numpad (right) half:

```
+-------+-------+-------+-------+-------+
|       |       |       |       |       |
| Left  | Down  |  Up   | Right | PgUp  +-------+
|       |       |       |       | PgDn  | Home  |
| -L1-  | Del   | Ctrl  |  Cmd  | Shift |  Esc  |
+-------+-------+-------+-------+-------+-------+


     .       +-------+-------+-------+-------+-------+
     .       |   `   |   7   |   8   |   9   |  -    |
     +-------|   .   |   4   |   5   |   6   |  +    |
     | End   |   0   |   1   |   2   |   3   |  \    |
     | Enter | Shift |  Alt  |   =   |   *   | *L3*  |
     +-------+-------+-------+-------+-------+-------+
```

- Cursors are placed on the home row on the *left* side, in a `hjkl`-style arrangement. The reason I didn't put these on the right (where `hjkl` are) is because the same layer is also used for the numpad, and the numpad made more sense on the right side. Since `hjkl` is a vim-ism, vim users already have that on the right side, on the QWERTY layer. Everyone else would need to learn that way of navigation, and might as well learn them on the left side then.
- `PageUp` and `PageDown` are right next to the arrow keys for easy paging.
- I placed `Home` and `End` on the top thumb keys on each half, because I wanted them near-ish the cursors. `End` ended up on the right half, because I didn't find a comfortable place for it on the left one.
- The numpad on the right side more or less mirrors that of a numpad. The major difference is `0`, which ended up on the same row as `123`, instead of under `1`. The reason for this is that I wanted to keep `Alt` in the same position on all layers. If I had `0` under `1`, the whole cluster would've shifted to the right, and `0+\` would end up closer to the inner side. I didn't want that, because I wanted `\` to be in the same position as `/` on the base layer. I also wanted `=` in the `-` position.

## Raise

```
+-------+-------+-------+-------+-------+
|  F7   |  F8   |  F9   | F10   |  >>   |
|  F4   |  F5   |  F6   | F11   |  <<   +-------+
|  F1   |  F2   |  F3   | F12   |Ply/Pse| Mute  |
| *L3*  |  Del  |  Ctrl | Cmd   | Shift |  Esc  |
+-------+-------+-------+-------+-------+-------+

     .       +-------+-------+-------+-------+-------+
     .       |       |       |       |       |       |
     +-------|   {   |   }   |   [   |   ]   |       |
     | Vol+  |  Vol- |       |       |       |  \    |
     | Enter | Shift |  Alt  |       |       | -L2-  |
     +-------+-------+-------+-------+-------+-------+
```

- Function keys went on the left side, so that `Alt+Fx` would be easy to press, and `Cmd+Fx` would still be comfortable.
- Besides function keys, the left side sports a next and previous track key, a play/pause and a mute button. I felt that these are the most used media keys, so it made sense to have them on the opposite side than the layer key.
- The right side has the rest of volume control.
- Square and Curly brackets are on the right half, in `hjkl` position.

## Mouse

The `Mouse` layer is accessed by holding both `Lower` and `Raise` together, and the layer toggles on. As such, once toggled on, `Lower` and `Raise` will not be active anymore, once released. This makes hitting either of those keys again bring us back to the base layer.

It's toggled, because holding both layer keys with the pinkies is awkward and uncomfortable. Most of the keys here are also keys that one is likely to use for a longer time than what's comfortable while holding a layer key.

```
+-------+-------+-------+-------+-------+
|       |       |  MUp  |       |  MBL  |
|       | MLeft | MDown | MRght |  MBM  +-------+
|       |       |       |       |  MBR  |       |
| *L3*  |       |  Ctrl |  Cmd  | Shift |  Esc  |
+-------+-------+-------+-------+-------+-------+

     .       +-------+-------+-------+-------+-------+
     .       | PrScr | WClr  |       |       |       |
     +-------|  Ins  |  WNW  |  WNE  |       |       |
     |       |       |  WSW  |  WSE  |       |       |
     |       | Shift |  Alt  |       |       | *L3*  |
     +-------+-------+-------+-------+-------+-------+
```

Unlike on the Model01, mouse movement and mouse warp are on different hands. This is due to having less columns. We can't fit mouse movement, mouse warp, and mouse buttons onto the same side, not unless we sacrifice comfort or reachability.

# Summary

I tried to capture the _spirit_ of the default Model01 layout here, while keeping comfortability in mind too. Due to fewer keys, one will require more keys to access the same functionality at times, but I tried my best to keep the number of required actions small in the majority of cases.

I've been typing on a similar layout on my Atreus1: the only difference is that in my case, I only have one thumb key, so I made them into tap-dance key, where one tap functions as if the lower key was pressed, a double tap functions as if the upper one was. This tapping thing is annoying, but it's the closest I could get to the Atreus2's physical layout at this time.

Despite that annoyance, the layout feels surprisingly okay (despite being QWERTY :P).