### PR TITLE
travis: Force Arduino to use the current copy of Kaleidoscope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,16 @@ addons:
       - shellcheck
 install:
   - git clone --depth 1 --recurse-submodules https://github.com/keyboardio/Kaleidoscope-Bundle-Keyboardio hardware/keyboardio
+## We delete the library.properties of the Bundle's Kaleidoscope.
+## We do this to force Arduino to use the current one instead of the bundled version.
+  - rm -f hardware/keyboardio/avr/libraries/Kaleidoscope/library.properties
 script:
   - make travis-test KALEIDOSCOPE_TEMP_PATH=$(pwd)/.kaleidoscope-build-cache BOARD_HARDWARE_PATH=$(pwd)/hardware
 notifications:
   email:
     on_success: change
     on_failure: change
-cache: 
+cache:
   ccache: true
   directories:
     - .kaleidoscope-build-cache


### PR DESCRIPTION
While we made attempts at forcing Arduino to use the current copy (that's what all the `current-libraries` stuff are), it apparently doesn't work anymore. As a quick workaround, delete the bundled Kaleidoscope's `library.properties`, so Arduino won't find it, and will use the current one instead.