### PR TITLE
New plugin: PersistentLEDMode

### DIFF
--- a/examples/LEDs/PersistentLEDMode/PersistentLEDMode.ino
+++ b/examples/LEDs/PersistentLEDMode/PersistentLEDMode.ino
@@ -1,0 +1,64 @@
+/* -*- mode: c++ -*-
+ * kaleidoscope::plugin::PersistentLEDMode -- Persist the current LED mode to Storage
+ * Copyright (C) 2019  Keyboard.io, Inc.
+ * Copyright (C) 2019  Dygma, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-EEPROM-Settings.h>
+#include <Kaleidoscope-LEDControl.h>
+#include <Kaleidoscope-LEDEffect-Rainbow.h>
+#include <Kaleidoscope-LEDEffect-Breathe.h>
+#include <Kaleidoscope-LEDEffect-Chase.h>
+#include <Kaleidoscope-PersistentLEDMode.h>
+
+// *INDENT-OFF*
+KEYMAPS(
+  [0] = KEYMAP_STACKED
+  (
+    Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext,
+    Key_Backtick,      Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+    Key_PageUp,        Key_A, Key_S, Key_D, Key_F, Key_G,
+    Key_PageDown,      Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+
+    Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+    Key_NoKey,
+
+    Key_skip,  Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
+    Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
+               Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
+    Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
+
+    Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
+    Key_NoKey),
+)
+// *INDENT-ON*
+
+KALEIDOSCOPE_INIT_PLUGINS(LEDControl,
+                          EEPROMSettings,
+                          PersistentLEDMode,
+                          LEDRainbowWaveEffect,
+                          LEDRainbowEffect,
+                          LEDChaseEffect,
+                          LEDBreatheEffect,
+                          LEDOff);
+
+void setup() {
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/src/Kaleidoscope-PersistentLEDMode.h
+++ b/src/Kaleidoscope-PersistentLEDMode.h
@@ -1,0 +1,21 @@
+/* -*- mode: c++ -*-
+ * kaleidoscope::plugin::PersistentLEDMode -- Persist the current LED mode to Storage
+ * Copyright (C) 2019  Keyboard.io, Inc.
+ * Copyright (C) 2019  Dygma, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <kaleidoscope/plugin/PersistentLEDMode.h>

--- a/src/kaleidoscope/plugin/PersistentLEDMode.cpp
+++ b/src/kaleidoscope/plugin/PersistentLEDMode.cpp
@@ -1,0 +1,59 @@
+/* -*- mode: c++ -*-
+ * kaleidoscope::plugin::PersistentLEDMode -- Persist the current LED mode to Storage
+ * Copyright (C) 2019  Keyboard.io, Inc.
+ * Copyright (C) 2019  Dygma, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-PersistentLEDMode.h>
+#include <Kaleidoscope-LEDControl.h>
+#include <Kaleidoscope-EEPROM-Settings.h>
+
+namespace kaleidoscope {
+namespace plugin {
+
+uint16_t PersistentLEDMode::settings_base_;
+uint8_t PersistentLEDMode::cached_mode_index_;
+
+EventHandlerResult PersistentLEDMode::onSetup() {
+  settings_base_ = ::EEPROMSettings.requestSlice(sizeof(cached_mode_index_));
+
+  Kaleidoscope.storage().get(settings_base_, cached_mode_index_);
+
+  // If the index is max, assume an uninitialized EEPROM, and don't set the LED
+  // mode. We don't change the cached index here, `afterEachCycle()` will do
+  // that at the end of he cycle anyway.
+  if (cached_mode_index_ != 0xff)
+    return EventHandlerResult::OK;
+
+  ::LEDControl.set_mode(cached_mode_index_);
+
+  return EventHandlerResult::OK;
+}
+
+EventHandlerResult PersistentLEDMode::afterEachCycle() {
+  if (cached_mode_index_ == ::LEDControl.get_mode_index())
+    return EventHandlerResult::OK;
+
+  cached_mode_index_ = ::LEDControl.get_mode_index();
+  Kaleidoscope.storage().put(settings_base_, cached_mode_index_);
+  Kaleidoscope.storage().commit();
+  return EventHandlerResult::OK;
+}
+
+}
+}
+
+kaleidoscope::plugin::PersistentLEDMode PersistentLEDMode;

--- a/src/kaleidoscope/plugin/PersistentLEDMode.h
+++ b/src/kaleidoscope/plugin/PersistentLEDMode.h
@@ -1,0 +1,45 @@
+/* -*- mode: c++ -*-
+ * kaleidoscope::plugin::PersistentLEDMode -- Persist the current LED mode to Storage
+ * Copyright (C) 2019  Keyboard.io, Inc.
+ * Copyright (C) 2019  Dygma, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* NOTE: This plugin is a workaround. It allows us to (optionally) save the LED
+ * mode to storage, and restore it on next boot, without having a way to hook
+ * into led mode change events. Once we can hook into that, this plugin shall be
+ * reworked to use it instead of keeping `afterEachCycle()` busy. */
+
+#pragma once
+
+#include <Kaleidoscope.h>
+
+namespace kaleidoscope {
+namespace plugin {
+
+class PersistentLEDMode: public kaleidoscope::Plugin {
+ public:
+  PersistentLEDMode() {}
+
+  EventHandlerResult onSetup();
+  EventHandlerResult afterEachCycle();
+ private:
+  static uint16_t settings_base_;
+  static uint8_t cached_mode_index_;
+};
+
+}
+}
+
+extern kaleidoscope::plugin::PersistentLEDMode PersistentLEDMode;


### PR DESCRIPTION
This implements a new plugin, `PersistentLEDMode`, whose single purpose is to store the current LED mode to storage, whenever it changes. Since we can't hook into led mode change events yet, we abuse the `afterEachCycle()` hook to compare the current led mode to what we think it is, and store it if it changes.

This is obviously not very elegant, but the best we can do right now.

We do not want to add LED mode storage to `LEDControl` unconditionally, for a number of reasons:

1) It would break EEPROM layouts when an end-user upgrades Kaleidoscope, without moving `LEDControl` to a place after all other EEPROM-using plugins.
2) It's not always a desired behaviour, to restore the last used LED mode.

This PR replaces #649.