### PR TITLE
Guard AVR-specific parts with ifdefs

### DIFF
--- a/src/kaleidoscope/Hardware.h
+++ b/src/kaleidoscope/Hardware.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#ifdef __AVR__
+
 #include "kaleidoscope/MatrixAddr.h"
 #include "kaleidoscope_internal/deprecations.h"
 
@@ -402,3 +404,5 @@ class Hardware {
   /** @} */
 };
 }
+
+#endif

--- a/src/kaleidoscope/device/keyboardio/twi.c
+++ b/src/kaleidoscope/device/keyboardio/twi.c
@@ -18,6 +18,8 @@
   Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
 */
 
+#ifdef __AVR__
+
 #define ENABLE_TWI_SLAVE_MODE 0
 
 #include <math.h>
@@ -559,3 +561,5 @@ ISR(TWI_vect) {
     break;
   }
 }
+
+#endif

--- a/src/kaleidoscope/device/keyboardio/twi.h
+++ b/src/kaleidoscope/device/keyboardio/twi.h
@@ -16,6 +16,8 @@
   with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifdef __AVR__
+
 #ifndef twi_h
 #define twi_h
 
@@ -50,4 +52,5 @@ void twi_reply(uint8_t);
 void twi_stop(void);
 void twi_releaseBus(void);
 
+#endif
 #endif

--- a/src/kaleidoscope/driver/bootloader/None.h
+++ b/src/kaleidoscope/driver/bootloader/None.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <avr/wdt.h>
 #include "kaleidoscope/driver/bootloader/Base.h"
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/driver/storage/AVREEPROM.h
+++ b/src/kaleidoscope/driver/storage/AVREEPROM.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#ifdef ARDUINO_ARCH_AVR
+
 #include "kaleidoscope/driver/storage/Base.h"
 #include <EEPROM.h>
 
@@ -57,3 +59,5 @@ class AVREEPROM : public kaleidoscope::driver::storage::Base<_StorageProps> {
 }
 }
 }
+
+#endif

--- a/src/kaleidoscope/driver/storage/AVREEPROM.h
+++ b/src/kaleidoscope/driver/storage/AVREEPROM.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
 
 #include "kaleidoscope/driver/storage/Base.h"
 #include <EEPROM.h>

--- a/src/kaleidoscope/plugin/FirmwareDump.cpp
+++ b/src/kaleidoscope/plugin/FirmwareDump.cpp
@@ -15,6 +15,7 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef __AVR__
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
 #include <Kaleidoscope-FirmwareDump.h>
@@ -71,4 +72,5 @@ EventHandlerResult FirmwareDump::onFocusEvent(const char *command) {
 
 kaleidoscope::plugin::FirmwareDump FirmwareDump;
 
+#endif
 #endif

--- a/src/kaleidoscope/plugin/FirmwareDump.h
+++ b/src/kaleidoscope/plugin/FirmwareDump.h
@@ -21,6 +21,8 @@
 #error "Firmware Dump is not available for virtual builds"
 #else
 
+#ifdef __AVR__
+
 #include <Kaleidoscope.h>
 
 namespace kaleidoscope {
@@ -41,4 +43,5 @@ class FirmwareDump : public kaleidoscope::Plugin {
 
 extern kaleidoscope::plugin::FirmwareDump FirmwareDump;
 
+#endif
 #endif


### PR DESCRIPTION
There are a few places in Kaleidoscope that are AVR specific, and those need to be guarded with ifdefs, so Arduino doesn't try to compile them for non-AVR devices.

These places are `kaleidoscope::driver::storage::AVREEPROM`, the deprecated `kaleidoscope::Hardware` base class. While adding such guards, I also updated `kaleidoscope::device::ATMega32U4Keyboard` to use the same ifdef as the rest of the code.

Fixes #718, and similar issues.