### PR TITLE
Improved ATmega class naming

### DIFF
--- a/src/kaleidoscope/device/ATmega32U4Keyboard.h
+++ b/src/kaleidoscope/device/ATmega32U4Keyboard.h
@@ -1,5 +1,5 @@
 /* -*- mode: c++ -*-
- * device::ATMega32U4Keyboard -- Generic ATMega32U4 keyboard base class
+ * device::ATmega32U4Keyboard -- Generic ATmega32U4 keyboard base class
  * Copyright (C) 2019  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify
@@ -22,31 +22,32 @@
 #include <Arduino.h>
 #include "kaleidoscope/device/Base.h"
 
-#include "kaleidoscope/driver/mcu/ATMega32U4.h"
-#include "kaleidoscope/driver/storage/ATMega32U4EEPROMProps.h"
+#include "kaleidoscope/driver/mcu/ATmega32U4.h"
+#include "kaleidoscope/driver/keyscanner/ATmega.h"
+#include "kaleidoscope/driver/storage/ATmega32U4EEPROMProps.h"
 #include "kaleidoscope/driver/storage/AVREEPROM.h"
 
 #define ATMEGA32U4_KEYBOARD(BOARD_, BOOTLOADER_, ROW_PINS_, COL_PINS_)           \
-  struct BOARD_##Props : kaleidoscope::device::ATMega32U4KeyboardProps {         \
-    struct KeyScannerProps : public kaleidoscope::driver::keyscanner::AVRProps { \
-      AVR_KEYSCANNER_PROPS(ROW_PIN_LIST(ROW_PINS_), COL_PIN_LIST(COL_PINS_));    \
+  struct BOARD_##Props : kaleidoscope::device::ATmega32U4KeyboardProps {         \
+    struct KeyScannerProps : public kaleidoscope::driver::keyscanner::ATmegaProps { \
+      ATMEGA_KEYSCANNER_PROPS(ROW_PIN_LIST(ROW_PINS_), COL_PIN_LIST(COL_PINS_));    \
     };                                                                           \
-    typedef kaleidoscope::driver::keyscanner::AVR<KeyScannerProps> KeyScanner;   \
+    typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner;   \
     typedef kaleidoscope::driver::bootloader::avr::BOOTLOADER_ BootLoader;       \
   }; \
-  class BOARD_: public kaleidoscope::device::ATMega32U4Keyboard<BOARD_##Props> {};
+  class BOARD_: public kaleidoscope::device::ATmega32U4Keyboard<BOARD_##Props> {};
 
 namespace kaleidoscope {
 namespace device {
 
-struct ATMega32U4KeyboardProps : kaleidoscope::device::BaseProps {
-  typedef kaleidoscope::driver::mcu::ATMega32U4 MCU;
-  typedef kaleidoscope::driver::storage::ATMega32U4EEPROMProps StorageProps;
+struct ATmega32U4KeyboardProps : kaleidoscope::device::BaseProps {
+  typedef kaleidoscope::driver::mcu::ATmega32U4 MCU;
+  typedef kaleidoscope::driver::storage::ATmega32U4EEPROMProps StorageProps;
   typedef kaleidoscope::driver::storage::AVREEPROM<StorageProps> Storage;
 };
 
 template <typename _DeviceProps>
-class ATMega32U4Keyboard : public kaleidoscope::device::Base<_DeviceProps> {
+class ATmega32U4Keyboard : public kaleidoscope::device::Base<_DeviceProps> {
  public:
   auto serialPort() -> decltype(Serial) & {
     return Serial;

--- a/src/kaleidoscope/device/ez/ErgoDox.h
+++ b/src/kaleidoscope/device/ez/ErgoDox.h
@@ -41,20 +41,20 @@ struct cRGB {
 
 #include "kaleidoscope/driver/keyscanner/Base.h"
 #include "kaleidoscope/driver/bootloader/avr/HalfKay.h"
-#include "kaleidoscope/device/ATMega32U4Keyboard.h"
+#include "kaleidoscope/device/ATmega32U4Keyboard.h"
 
 namespace kaleidoscope {
 namespace device {
 namespace ez {
 
-struct ErgoDoxProps : public kaleidoscope::device::ATMega32U4KeyboardProps {
+struct ErgoDoxProps : public kaleidoscope::device::ATmega32U4KeyboardProps {
   struct KeyScannerProps : kaleidoscope::driver::keyscanner::BaseProps {
     KEYSCANNER_PROPS(14, 6);
   };
   typedef kaleidoscope::driver::bootloader::avr::HalfKay Bootloader;
 };
 
-class ErgoDox : public kaleidoscope::device::ATMega32U4Keyboard<ErgoDoxProps> {
+class ErgoDox : public kaleidoscope::device::ATmega32U4Keyboard<ErgoDoxProps> {
  public:
   ErgoDox(void) {}
 

--- a/src/kaleidoscope/device/kbdfans/KBD4x.cpp
+++ b/src/kaleidoscope/device/kbdfans/KBD4x.cpp
@@ -23,7 +23,7 @@ namespace kaleidoscope {
 namespace device {
 namespace kbdfans {
 
-AVR_KEYSCANNER_BOILERPLATE
+ATMEGA_KEYSCANNER_BOILERPLATE
 
 }
 }

--- a/src/kaleidoscope/device/kbdfans/KBD4x.h
+++ b/src/kaleidoscope/device/kbdfans/KBD4x.h
@@ -23,26 +23,26 @@
 
 #include <Arduino.h>
 
-#include "kaleidoscope/driver/keyscanner/AVR.h"
+#include "kaleidoscope/driver/keyscanner/ATmega.h"
 #include "kaleidoscope/driver/bootloader/avr/FLIP.h"
-#include "kaleidoscope/device/ATMega32U4Keyboard.h"
+#include "kaleidoscope/device/ATmega32U4Keyboard.h"
 
 namespace kaleidoscope {
 namespace device {
 namespace kbdfans {
 
-struct KBD4xProps : kaleidoscope::device::ATMega32U4KeyboardProps {
-  struct KeyScannerProps : public kaleidoscope::driver::keyscanner::AVRProps {
-    AVR_KEYSCANNER_PROPS(
+struct KBD4xProps : kaleidoscope::device::ATmega32U4KeyboardProps {
+  struct KeyScannerProps : public kaleidoscope::driver::keyscanner::ATmegaProps {
+    ATMEGA_KEYSCANNER_PROPS(
       ROW_PIN_LIST({ PIN_D0, PIN_D1, PIN_D2, PIN_D3 }),
       COL_PIN_LIST({ PIN_F0, PIN_F1, PIN_F4, PIN_F5, PIN_F6, PIN_F7, PIN_B3, PIN_B1, PIN_B0, PIN_D5, PIN_B7, PIN_C7 })
     );
   };
-  typedef kaleidoscope::driver::keyscanner::AVR<KeyScannerProps> KeyScanner;
+  typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner;
   typedef kaleidoscope::driver::bootloader::avr::FLIP Bootloader;
 };
 
-class KBD4x: public kaleidoscope::device::ATMega32U4Keyboard<KBD4xProps> {
+class KBD4x: public kaleidoscope::device::ATmega32U4Keyboard<KBD4xProps> {
  public:
   KBD4x() {
     mcu_.disableJTAG();

--- a/src/kaleidoscope/device/keyboardio/Imago.cpp
+++ b/src/kaleidoscope/device/keyboardio/Imago.cpp
@@ -48,7 +48,7 @@ static constexpr uint8_t LED_REGISTER_DATA1_SIZE = 0xAB;
 
 static constexpr uint8_t LED_REGISTER_DATA_LARGEST = LED_REGISTER_DATA0_SIZE;
 
-AVR_KEYSCANNER_BOILERPLATE
+ATMEGA_KEYSCANNER_BOILERPLATE
 
 bool ImagoLEDDriver::isLEDChanged = true;
 cRGB ImagoLEDDriver::led_data[];
@@ -181,7 +181,7 @@ void Imago::setup() {
   }
   TWBR = 10;
 
-  kaleidoscope::device::ATMega32U4Keyboard<ImagoProps>::setup();
+  kaleidoscope::device::ATmega32U4Keyboard<ImagoProps>::setup();
 }
 
 }

--- a/src/kaleidoscope/device/keyboardio/Imago.h
+++ b/src/kaleidoscope/device/keyboardio/Imago.h
@@ -29,10 +29,10 @@ struct cRGB {
 
 #define CRGB(r,g,b) (cRGB){b, g, r}
 
-#include "kaleidoscope/driver/keyscanner/AVR.h"
+#include "kaleidoscope/driver/keyscanner/ATmega.h"
 #include "kaleidoscope/driver/led/Base.h"
 #include "kaleidoscope/driver/bootloader/avr/Caterina.h"
-#include "kaleidoscope/device/ATMega32U4Keyboard.h"
+#include "kaleidoscope/device/ATmega32U4Keyboard.h"
 
 namespace kaleidoscope {
 namespace device {
@@ -61,20 +61,20 @@ class ImagoLEDDriver : public kaleidoscope::driver::led::Base<ImagoLEDDriverProp
   static void twiSend(uint8_t addr, uint8_t Reg_Add, uint8_t Reg_Dat);
 };
 
-struct ImagoProps : kaleidoscope::device::ATMega32U4KeyboardProps {
-  struct KeyScannerProps : public kaleidoscope::driver::keyscanner::AVRProps {
-    AVR_KEYSCANNER_PROPS(
+struct ImagoProps : kaleidoscope::device::ATmega32U4KeyboardProps {
+  struct KeyScannerProps : public kaleidoscope::driver::keyscanner::ATmegaProps {
+    ATMEGA_KEYSCANNER_PROPS(
       ROW_PIN_LIST({ PIN_F6, PIN_F5, PIN_F4, PIN_F1, PIN_F0}),
       COL_PIN_LIST({ PIN_B2, PIN_B7, PIN_E2, PIN_C7, PIN_C6, PIN_B6, PIN_B5, PIN_B4, PIN_D7, PIN_D6,  PIN_D4, PIN_D5, PIN_D3, PIN_D2, PIN_E6, PIN_F7})
     );
   };
-  typedef kaleidoscope::driver::keyscanner::AVR<KeyScannerProps> KeyScanner;
+  typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner;
   typedef ImagoLEDDriverProps LEDDriverProps;
   typedef ImagoLEDDriver LEDDriver;
   typedef kaleidoscope::driver::bootloader::avr::Caterina BootLoader;
 };
 
-class Imago: public kaleidoscope::device::ATMega32U4Keyboard<ImagoProps> {
+class Imago: public kaleidoscope::device::ATmega32U4Keyboard<ImagoProps> {
  public:
   void setup();
 };

--- a/src/kaleidoscope/device/keyboardio/Model01.h
+++ b/src/kaleidoscope/device/keyboardio/Model01.h
@@ -29,7 +29,7 @@
 #include "kaleidoscope/driver/keyscanner/Base.h"
 #include "kaleidoscope/driver/led/Base.h"
 #include "kaleidoscope/driver/bootloader/avr/Caterina.h"
-#include "kaleidoscope/device/ATMega32U4Keyboard.h"
+#include "kaleidoscope/device/ATmega32U4Keyboard.h"
 
 namespace kaleidoscope {
 namespace device {
@@ -93,7 +93,7 @@ class Model01KeyScanner : public kaleidoscope::driver::keyscanner::Base<Model01K
   static void enableScannerPower();
 };
 
-struct Model01Props : kaleidoscope::device::ATMega32U4KeyboardProps {
+struct Model01Props : kaleidoscope::device::ATmega32U4KeyboardProps {
   typedef Model01LEDDriverProps  LEDDriverProps;
   typedef Model01LEDDriver LEDDriver;
   typedef Model01KeyScannerProps KeyScannerProps;
@@ -101,7 +101,7 @@ struct Model01Props : kaleidoscope::device::ATMega32U4KeyboardProps {
   typedef kaleidoscope::driver::bootloader::avr::Caterina BootLoader;
 };
 
-class Model01 : public kaleidoscope::device::ATMega32U4Keyboard<Model01Props> {
+class Model01 : public kaleidoscope::device::ATmega32U4Keyboard<Model01Props> {
  public:
   static void setup();
 

--- a/src/kaleidoscope/device/olkb/Planck.cpp
+++ b/src/kaleidoscope/device/olkb/Planck.cpp
@@ -23,7 +23,7 @@ namespace kaleidoscope {
 namespace device {
 namespace olkb {
 
-AVR_KEYSCANNER_BOILERPLATE
+ATMEGA_KEYSCANNER_BOILERPLATE
 
 }
 }

--- a/src/kaleidoscope/device/olkb/Planck.h
+++ b/src/kaleidoscope/device/olkb/Planck.h
@@ -21,9 +21,8 @@
 
 #include <Arduino.h>
 
-#include "kaleidoscope/driver/keyscanner/AVR.h"
 #include "kaleidoscope/driver/bootloader/avr/HalfKay.h"
-#include "kaleidoscope/device/ATMega32U4Keyboard.h"
+#include "kaleidoscope/device/ATmega32U4Keyboard.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/src/kaleidoscope/device/softhruf/Splitography.cpp
+++ b/src/kaleidoscope/device/softhruf/Splitography.cpp
@@ -30,7 +30,7 @@ namespace kaleidoscope {
 namespace device {
 namespace softhruf {
 
-AVR_KEYSCANNER_BOILERPLATE
+ATMEGA_KEYSCANNER_BOILERPLATE
 
 }
 }

--- a/src/kaleidoscope/device/softhruf/Splitography.h
+++ b/src/kaleidoscope/device/softhruf/Splitography.h
@@ -30,26 +30,26 @@
 
 #include <Arduino.h>
 
-#include "kaleidoscope/driver/keyscanner/AVR.h"
+#include "kaleidoscope/driver/keyscanner/ATmega.h"
 #include "kaleidoscope/driver/bootloader/avr/FLIP.h"
-#include "kaleidoscope/device/ATMega32U4Keyboard.h"
+#include "kaleidoscope/device/ATmega32U4Keyboard.h"
 
 namespace kaleidoscope {
 namespace device {
 namespace softhruf {
 
-struct SplitographyProps : kaleidoscope::device::ATMega32U4KeyboardProps {
-  struct KeyScannerProps : public kaleidoscope::driver::keyscanner::AVRProps {
-    AVR_KEYSCANNER_PROPS(
+struct SplitographyProps : kaleidoscope::device::ATmega32U4KeyboardProps {
+  struct KeyScannerProps : public kaleidoscope::driver::keyscanner::ATmegaProps {
+    ATMEGA_KEYSCANNER_PROPS(
       ROW_PIN_LIST({ PIN_D0, PIN_D1, PIN_D2, PIN_D3 }),
       COL_PIN_LIST({ PIN_F0, PIN_F1, PIN_F4, PIN_F5, PIN_F6, PIN_F7, PIN_C7, PIN_C6, PIN_B6, PIN_B5, PIN_B4, PIN_D7 })
     );
   };
-  typedef kaleidoscope::driver::keyscanner::AVR<KeyScannerProps> KeyScanner;
+  typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner;
   typedef kaleidoscope::driver::bootloader::avr::FLIP BootLoader;
 };
 
-class Splitography: public kaleidoscope::device::ATMega32U4Keyboard<SplitographyProps> {
+class Splitography: public kaleidoscope::device::ATmega32U4Keyboard<SplitographyProps> {
  public:
   Splitography() {
     mcu_.disableJTAG();

--- a/src/kaleidoscope/device/technomancy/Atreus.cpp
+++ b/src/kaleidoscope/device/technomancy/Atreus.cpp
@@ -32,7 +32,7 @@ namespace kaleidoscope {
 namespace device {
 namespace technomancy {
 
-AVR_KEYSCANNER_BOILERPLATE
+ATMEGA_KEYSCANNER_BOILERPLATE
 
 }
 }

--- a/src/kaleidoscope/device/technomancy/Atreus.h
+++ b/src/kaleidoscope/device/technomancy/Atreus.h
@@ -28,9 +28,8 @@
 
 #include <Arduino.h>
 
-#include "kaleidoscope/driver/keyscanner/AVR.h"
 #include "kaleidoscope/driver/bootloader/avr/HalfKay.h"
-#include "kaleidoscope/device/ATMega32U4Keyboard.h"
+#include "kaleidoscope/device/ATmega32U4Keyboard.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/src/kaleidoscope/device/technomancy/Atreus2.cpp
+++ b/src/kaleidoscope/device/technomancy/Atreus2.cpp
@@ -24,7 +24,7 @@ namespace kaleidoscope {
 namespace device {
 namespace technomancy {
 
-AVR_KEYSCANNER_BOILERPLATE
+ATMEGA_KEYSCANNER_BOILERPLATE
 
 }
 }

--- a/src/kaleidoscope/device/technomancy/Atreus2.h
+++ b/src/kaleidoscope/device/technomancy/Atreus2.h
@@ -22,9 +22,8 @@
 
 #include <Arduino.h>
 
-#include "kaleidoscope/driver/keyscanner/AVR.h"
 #include "kaleidoscope/driver/bootloader/avr/Caterina.h"
-#include "kaleidoscope/device/ATMega32U4Keyboard.h"
+#include "kaleidoscope/device/ATmega32U4Keyboard.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/src/kaleidoscope/driver/keyscanner/ATmega.h
+++ b/src/kaleidoscope/driver/keyscanner/ATmega.h
@@ -1,5 +1,5 @@
 /* -*- mode: c++ -*-
- * kaleidoscope::driver::keyscanner::AVR -- AVR-based keyscanner component
+ * kaleidoscope::driver::keyscanner::ATmega -- AVR ATmega-based keyscanner component
  * Copyright (C) 2018-2019  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -29,20 +29,20 @@
 #define ROW_PIN_LIST(...)  __VA_ARGS__
 #define COL_PIN_LIST(...)  __VA_ARGS__
 
-#define AVR_KEYSCANNER_PROPS(ROW_PINS_, COL_PINS_)               \
-  KEYSCANNER_PROPS(NUM_ARGS(ROW_PINS_), NUM_ARGS(COL_PINS_));       \
+#define ATMEGA_KEYSCANNER_PROPS(ROW_PINS_, COL_PINS_)                   \
+  KEYSCANNER_PROPS(NUM_ARGS(ROW_PINS_), NUM_ARGS(COL_PINS_));           \
   static constexpr uint8_t matrix_row_pins[matrix_rows] =  ROW_PINS_;   \
   static constexpr uint8_t matrix_col_pins[matrix_columns] =  COL_PINS_;
 
-#define AVR_KEYSCANNER_BOILERPLATE                                                      \
+#define ATMEGA_KEYSCANNER_BOILERPLATE                                                                   \
   KEYSCANNER_PROPS_BOILERPLATE(kaleidoscope::Device::KeyScannerProps);                                  \
   constexpr uint8_t kaleidoscope::Device::KeyScannerProps::matrix_row_pins[matrix_rows];                \
-  constexpr uint8_t kaleidoscope::Device::KeyScannerProps::matrix_col_pins[matrix_columns]; \
-  template<>                                                                               \
+  constexpr uint8_t kaleidoscope::Device::KeyScannerProps::matrix_col_pins[matrix_columns];             \
+  template<>                                                                                            \
   volatile uint16_t kaleidoscope::Device::KeyScanner::previousKeyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {}; \
-  template<>                                                                               \
-  volatile uint16_t kaleidoscope::Device::KeyScanner::keyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {}; \
-  template<>                                                                               \
+  template<>                                                                                            \
+  volatile uint16_t kaleidoscope::Device::KeyScanner::keyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};         \
+  template<>                                                                                            \
   uint16_t kaleidoscope::Device::KeyScanner::masks_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};            \
   template<>                                                                               \
   uint8_t kaleidoscope::Device::KeyScanner::debounce_matrix_[kaleidoscope::Device::KeyScannerProps::matrix_rows][kaleidoscope::Device::KeyScannerProps::matrix_columns] = {}; \
@@ -55,7 +55,7 @@ namespace kaleidoscope {
 namespace driver {
 namespace keyscanner {
 
-struct AVRProps: kaleidoscope::driver::keyscanner::BaseProps {
+struct ATmegaProps: kaleidoscope::driver::keyscanner::BaseProps {
   static const uint8_t debounce = 3;
 
   /*
@@ -67,9 +67,9 @@ struct AVRProps: kaleidoscope::driver::keyscanner::BaseProps {
 };
 
 template <typename _KeyScannerProps>
-class AVR : public kaleidoscope::driver::keyscanner::Base<_KeyScannerProps> {
+class ATmega: public kaleidoscope::driver::keyscanner::Base<_KeyScannerProps> {
  private:
-  typedef AVR<_KeyScannerProps> ThisType;
+  typedef ATmega<_KeyScannerProps> ThisType;
 
  public:
   void setup() {

--- a/src/kaleidoscope/driver/mcu/ATmega32U4.h
+++ b/src/kaleidoscope/driver/mcu/ATmega32U4.h
@@ -1,5 +1,5 @@
 /* -*- mode: c++ -*-
- * driver::MCU::ATMega32U4 -- ATMega32U4 MCU driver for Kaleidoscope
+ * driver::MCU::ATmega32U4 -- ATmega32U4 MCU driver for Kaleidoscope
  * Copyright (C) 2019  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -23,7 +23,7 @@ namespace kaleidoscope {
 namespace driver {
 namespace mcu {
 
-class ATMega32U4 : public kaleidoscope::driver::mcu::Base {
+class ATmega32U4 : public kaleidoscope::driver::mcu::Base {
  public:
   void detachFromHost() {
     UDCON |= _BV(DETACH);
@@ -45,7 +45,7 @@ class ATMega32U4 : public kaleidoscope::driver::mcu::Base {
      * that's doable, we just have to write the JTD bit into MCUCR twice within
      * four cycles. These two lines do just that.
      *
-     * For more information, see the ATMega16U4/ATMega32U4 datasheet, the
+     * For more information, see the ATmega16U4/ATmega32U4 datasheet, the
      * following sections:
      *  - 2.2.7 (PIN Descriptions; PIN F)
      *  - 7.8.7 (On-chip Debug System)

--- a/src/kaleidoscope/driver/storage/ATmega32U4EEPROMProps.h
+++ b/src/kaleidoscope/driver/storage/ATmega32U4EEPROMProps.h
@@ -1,5 +1,5 @@
 /* -*- mode: c++ -*-
- * kaleidoscope::driver::storage::ATMega32U4StorageProps -- Storage driver props for ATMega32U4
+ * kaleidoscope::driver::storage::ATmega32U4StorageProps -- Storage driver props for ATmega32U4
  * Copyright (C) 2019  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -23,7 +23,7 @@ namespace kaleidoscope {
 namespace driver {
 namespace storage {
 
-struct ATMega32U4EEPROMProps : kaleidoscope::driver::storage::AVREEPROMProps {
+struct ATmega32U4EEPROMProps : kaleidoscope::driver::storage::AVREEPROMProps {
   static constexpr uint16_t length = 1024;
 };
 


### PR DESCRIPTION
The MCU family is called `ATmega`. not `ATMega`, so correct all occurrences of
it, while we still can. Also renamed `kaleidoscope::driver::keyscanner::AVR` to
`kaleidoscope::driver::keyscanner::ATmega`.

As a side-effect, this fixes compilation under the Arduino IDE, which defines
`AVR` as a symbol.
