### PR TITLE
Key offset to LED index map made LED driver property

### DIFF
--- a/src/kaleidoscope/device/keyboardio/Imago.cpp
+++ b/src/kaleidoscope/device/keyboardio/Imago.cpp
@@ -31,6 +31,8 @@ namespace kaleidoscope {
 namespace device {
 namespace keyboardio {
 
+constexpr uint8_t ImagoLEDDriverProps::key_led_map[] PROGMEM;
+
 static constexpr uint8_t CMD_SET_REGISTER = 0xFD;
 static constexpr uint8_t CMD_WRITE_ENABLE = 0xFE;
 static constexpr uint8_t WRITE_ENABLE_ONCE = 0b11000101;
@@ -52,16 +54,6 @@ ATMEGA_KEYSCANNER_BOILERPLATE
 
 bool ImagoLEDDriver::isLEDChanged = true;
 cRGB ImagoLEDDriver::led_data[];
-
-#define NOLED 254
-
-static constexpr uint8_t key_led_map[5][16] PROGMEM = {
-  { 104,    0,     1,    2,     3,    4,    5,     6,    7,     8,    9,   10,   11,   115,   12,   116},
-  {  91,   13, NOLED,   15,    16,   17,   18,    19,   20,    21,   22,   23,   24,   102,   15,   103},
-  {  78,   26,    27,   28,    29,   30,   31, NOLED,   33,    34,   35,   36,   37,   89,    38, NOLED},
-  {  65,   39,    40,   41,    42,   43,   44,    45,   46,    47,   48,   49,   50,   51, NOLED,    90},
-  {  52,   66,    53,   54, NOLED,   56,   57,    71,   59, NOLED,   61,   62,   63,   64, NOLED,    77}
-};
 
 void ImagoLEDDriver::setup() {
   setAllPwmTo(0xFF);
@@ -94,10 +86,6 @@ void ImagoLEDDriver::setCrgbAt(uint8_t i, cRGB crgb) {
   isLEDChanged |= !(oldColor.r == crgb.r && oldColor.g == crgb.g && oldColor.b == crgb.b);
 
   led_data[i] = crgb;
-}
-
-uint8_t ImagoLEDDriver::getLedIndex(uint8_t key_offset) {
-  return pgm_read_byte(key_led_map + key_offset);
 }
 
 cRGB ImagoLEDDriver::getCrgbAt(uint8_t i) {

--- a/src/kaleidoscope/device/keyboardio/Imago.h
+++ b/src/kaleidoscope/device/keyboardio/Imago.h
@@ -38,8 +38,17 @@ namespace kaleidoscope {
 namespace device {
 namespace keyboardio {
 
+using kaleidoscope::driver::led::no_led;
+
 struct ImagoLEDDriverProps: public kaleidoscope::driver::led::BaseProps {
   static constexpr uint8_t led_count = 78;
+  static constexpr uint8_t key_led_map[/* 5*16 */] PROGMEM = {
+    104,    0,     1,     2,     3,    4,    5,     6,    7,     8,    9,   10,   11,   115,   12,   116,
+    91,   13, no_led,   15,    16,   17,   18,    19,   20,    21,   22,   23,   24,   102,   15,   103,
+    78,   26,    27,    28,    29,   30,   31, no_led,  33,    34,   35,   36,   37,    89,   38, no_led,
+    65,   39,    40,    41,    42,   43,   44,    45,   46,    47,   48,   49,   50,    51, no_led,  90,
+    52,   66,    53,    54, no_led,  56,   57,    71,   59, no_led,  61,   62,   63,    64, no_led,  77
+  };
 };
 
 class ImagoLEDDriver : public kaleidoscope::driver::led::Base<ImagoLEDDriverProps> {
@@ -48,7 +57,6 @@ class ImagoLEDDriver : public kaleidoscope::driver::led::Base<ImagoLEDDriverProp
   static void syncLeds();
   static void setCrgbAt(uint8_t i, cRGB crgb);
   static cRGB getCrgbAt(uint8_t i);
-  static uint8_t getLedIndex(uint8_t key_offset);
 
   static cRGB led_data[117]; // 117 is the number of LEDs the chip drives
   // until we clean stuff up a bit, it's easiest to just have the whole struct around

--- a/src/kaleidoscope/device/keyboardio/Model01.cpp
+++ b/src/kaleidoscope/device/keyboardio/Model01.cpp
@@ -26,6 +26,8 @@ namespace kaleidoscope {
 namespace device {
 namespace keyboardio {
 
+constexpr uint8_t Model01LEDDriverProps::key_led_map[] PROGMEM;
+
 /********* Model01Hands *********/
 
 struct Model01Hands {
@@ -55,13 +57,6 @@ void Model01Hands::setup(void) {
 /********* LED Driver *********/
 bool Model01LEDDriver::isLEDChanged = true;
 
-static constexpr int8_t key_led_map[Model01::led_count] PROGMEM = {
-  3, 4, 11, 12, 19, 20, 26, 27,     36, 37, 43, 44, 51, 52, 59, 60,
-  2, 5, 10, 13, 18, 21, 25, 28,     35, 38, 42, 45, 50, 53, 58, 61,
-  1, 6, 9, 14, 17, 22, 24, 29,     34, 39, 41, 46, 49, 54, 57, 62,
-  0, 7, 8, 15, 16, 23, 31, 30,     33, 32, 40, 47, 48, 55, 56, 63,
-};
-
 void Model01LEDDriver::setCrgbAt(uint8_t i, cRGB crgb) {
   if (i < 32) {
     cRGB oldColor = getCrgbAt(i);
@@ -78,10 +73,6 @@ void Model01LEDDriver::setCrgbAt(uint8_t i, cRGB crgb) {
     // how do we want to handle debugging assertions about crazy user
     // code that would overwrite other memory?
   }
-}
-
-uint8_t Model01LEDDriver::getLedIndex(uint8_t key_offset) {
-  return pgm_read_byte(&(key_led_map[key_offset]));
 }
 
 cRGB Model01LEDDriver::getCrgbAt(uint8_t i) {

--- a/src/kaleidoscope/device/keyboardio/Model01.h
+++ b/src/kaleidoscope/device/keyboardio/Model01.h
@@ -37,6 +37,12 @@ namespace keyboardio {
 
 struct Model01LEDDriverProps : public kaleidoscope::driver::led::BaseProps {
   static constexpr uint8_t led_count = 64;
+  static constexpr uint8_t key_led_map[] PROGMEM = {
+    3, 4, 11, 12, 19, 20, 26, 27,     36, 37, 43, 44, 51, 52, 59, 60,
+    2, 5, 10, 13, 18, 21, 25, 28,     35, 38, 42, 45, 50, 53, 58, 61,
+    1, 6, 9, 14, 17, 22, 24, 29,     34, 39, 41, 46, 49, 54, 57, 62,
+    0, 7, 8, 15, 16, 23, 31, 30,     33, 32, 40, 47, 48, 55, 56, 63,
+  };
 };
 
 class Model01LEDDriver : public kaleidoscope::driver::led::Base<Model01LEDDriverProps> {
@@ -44,8 +50,6 @@ class Model01LEDDriver : public kaleidoscope::driver::led::Base<Model01LEDDriver
   static void syncLeds();
   static void setCrgbAt(uint8_t i, cRGB crgb);
   static cRGB getCrgbAt(uint8_t i);
-
-  static uint8_t getLedIndex(uint8_t key_offset);
 
   static void enableHighPowerLeds();
   static boolean ledPowerFault();


### PR DESCRIPTION
This is an implementation of https://github.com/keyboardio/Kaleidoscope/issues/726#issuecomment-557780011

LED driver properties now can re-define an array
for their individual mapping from key offsets to LED indices.

This array is both constexpr (can be used at compiletime) and
stored in PROGMEM. The latter is used by the LED driver base
class to map key offsets to LED ids at runtime.

I gave this a WIP, because I do not have my Model01 around for testing. Will do that ASAP. Submitted this to ask for feedback.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>