### PR TITLE
Add an `onLEDModeChange()` hook

### DIFF
--- a/src/kaleidoscope/event_handlers.h
+++ b/src/kaleidoscope/event_handlers.h
@@ -161,6 +161,14 @@
              _CURRENT_IMPLEMENTATION,                                     __NL__ \
                 _NOT_ABORTABLE,                                           __NL__ \
                 (), (), ##__VA_ARGS__)                                    __NL__ \
+   /* Called when the LED mode changes. If one needs to know what      */ __NL__ \
+   /* from and what to the mode changed, they should track that        */ __NL__ \
+   /* themselves.                                                      */ __NL__ \
+   OPERATION(onLEDModeChange,                                             __NL__ \
+             1,                                                           __NL__ \
+             _CURRENT_IMPLEMENTATION,                                     __NL__ \
+                _NOT_ABORTABLE,                                           __NL__ \
+                (), (), ##__VA_ARGS__)                                    __NL__ \
    /* Called before reporting our state to the host. This is the       */ __NL__ \
    /* last point in a cycle where a plugin can alter what gets         */ __NL__ \
    /* reported to the host.                                            */ __NL__ \
@@ -218,6 +226,10 @@
    START(onLayerChange, 1)                                              __NL__ \
       OP(onLayerChange, 1)                                              __NL__ \
    END(onLayerChange, 1)                                                __NL__ \
+                                                                        __NL__ \
+   START(onLEDModeChange, 1)                                            __NL__ \
+      OP(onLEDModeChange, 1)                                            __NL__ \
+   END(onLEDModeChange, 1)                                              __NL__ \
                                                                         __NL__ \
    START(beforeReportingState, 1)                                       __NL__ \
       OP(beforeReportingState, 1)                                       __NL__ \

--- a/src/kaleidoscope/hooks.h
+++ b/src/kaleidoscope/hooks.h
@@ -33,6 +33,10 @@ extern void handleKeyswitchEvent(kaleidoscope::Key mappedKey, KeyAddr key_addr, 
 DEPRECATED(ROW_COL_FUNC) extern void handleKeyswitchEvent(kaleidoscope::Key mappedKey, byte row, byte col, uint8_t keyState);
 
 namespace kaleidoscope {
+namespace plugin {
+// Forward declaration to enable friend declarations.
+class LEDControl;
+}
 
 // Forward declaration to enable friend declarations.
 class Layer_;
@@ -55,6 +59,7 @@ class Hooks {
   // and Hooks::afterEachCycle.
   friend class Kaleidoscope_;
   friend class ::kaleidoscope::Layer_;
+  friend class ::kaleidoscope::plugin::LEDControl;
 
   // ::handleKeyswitchEvent(...) calls Hooks::onKeyswitchEvent.
   friend void ::handleKeyswitchEvent(kaleidoscope::Key mappedKey,

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -68,6 +68,8 @@ LEDControl::set_mode(uint8_t mode_) {
   cur_led_mode_ = LEDModeManager::getLEDMode(mode_id);
 
   refreshAll();
+
+  kaleidoscope::Hooks::onLEDModeChange();
 }
 
 void LEDControl::activate(LEDModeInterface *plugin) {

--- a/src/kaleidoscope/plugin/PersistentLEDMode.cpp
+++ b/src/kaleidoscope/plugin/PersistentLEDMode.cpp
@@ -33,8 +33,8 @@ EventHandlerResult PersistentLEDMode::onSetup() {
   Kaleidoscope.storage().get(settings_base_, cached_mode_index_);
 
   // If the index is max, assume an uninitialized EEPROM, and don't set the LED
-  // mode. We don't change the cached index here, `afterEachCycle()` will do
-  // that at the end of he cycle anyway.
+  // mode. We don't change the cached index here, `onLEDModeChange()` will do
+  // that whenever a led mode change happens.
   if (cached_mode_index_ != 0xff)
     return EventHandlerResult::OK;
 
@@ -43,7 +43,7 @@ EventHandlerResult PersistentLEDMode::onSetup() {
   return EventHandlerResult::OK;
 }
 
-EventHandlerResult PersistentLEDMode::afterEachCycle() {
+EventHandlerResult PersistentLEDMode::onLEDModeChange() {
   if (cached_mode_index_ == ::LEDControl.get_mode_index())
     return EventHandlerResult::OK;
 

--- a/src/kaleidoscope/plugin/PersistentLEDMode.h
+++ b/src/kaleidoscope/plugin/PersistentLEDMode.h
@@ -16,11 +16,6 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* NOTE: This plugin is a workaround. It allows us to (optionally) save the LED
- * mode to storage, and restore it on next boot, without having a way to hook
- * into led mode change events. Once we can hook into that, this plugin shall be
- * reworked to use it instead of keeping `afterEachCycle()` busy. */
-
 #pragma once
 
 #include <Kaleidoscope.h>
@@ -33,7 +28,7 @@ class PersistentLEDMode: public kaleidoscope::Plugin {
   PersistentLEDMode() {}
 
   EventHandlerResult onSetup();
-  EventHandlerResult afterEachCycle();
+  EventHandlerResult onLEDModeChange();
  private:
   static uint16_t settings_base_;
   static uint8_t cached_mode_index_;


### PR DESCRIPTION
As explained in #731, we want this to be able to more efficiently hook into led mode changes. Apart from adding the hook, and calling it from `LEDControl.set_mode()` (which is the point all mode changes go through), this also ports the `PersistentLEDMode` plugin to use the new hook.

Fixes #731.