### PR TITLE
Build time optimization with include-what-you-use

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -488,6 +488,10 @@ Older versions of the plugin required one to set up `Key_Redial` manually, and l
 
 ## Deprecated APIs and their replacements
 
+### Class/global instance Kaleidoscope_/Kaleidoscope renamed to kaleidoscope::Runtime_/kaleidoscope::Runtime
+
+After renaming, some of the original symbols have been deprecated. The deprecated symbols in `kaleidoscope/Runtime.h` are scheduled for removal on **2019-03-10**.
+
 ### Transition to linear indexing
 
 Row/col based indexing was replaced by linear indexing throughout the whole firmware. A compatibility layer of functions was introduced that allows

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -16,4 +16,106 @@
 
 #pragma once
 
-#include "kaleidoscope/Kaleidoscope.h"
+#include <Arduino.h>
+
+//end of add your includes here
+#ifdef __cplusplus
+extern "C" {
+#endif
+void loop();
+void setup();
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+//add your function definitions for the project KeyboardIO here
+
+#define TS(X) //Serial.print(micros() );Serial.print("\t");Serial.println(X);
+
+#include <stdio.h>
+#include <math.h>
+#include <stdint.h>
+
+#include "kaleidoscope/device/device.h"
+#include "kaleidoscope/device/key_indexes.h"
+#include "kaleidoscope_internal/device.h"
+#include "kaleidoscope_internal/deprecations.h"
+
+static constexpr DEPRECATED(KEYBOARDHARDWARE) kaleidoscope::Device &KeyboardHardware = kaleidoscope_internal::device;
+
+#ifdef PER_KEY_DATA_STACKED
+#define KEYMAP_STACKED(...) { PER_KEY_DATA_STACKED(XXX, __VA_ARGS__) }
+#endif
+
+#ifdef PER_KEY_DATA
+#define KEYMAP(...) { PER_KEY_DATA(XXX, __VA_ARGS__) }
+#endif
+
+static constexpr DEPRECATED(ROWS) uint8_t ROWS = kaleidoscope_internal::device.matrix_rows;
+static constexpr DEPRECATED(COLS) uint8_t COLS = kaleidoscope_internal::device.matrix_columns;
+static constexpr DEPRECATED(LED_COUNT) uint8_t LED_COUNT = kaleidoscope_internal::device.led_count;
+
+#include "kaleidoscope/KeyAddr.h"
+#include "kaleidoscope/key_events.h"
+#include "kaleidoscope/hid.h"
+#include "kaleidoscope/layers.h"
+#include "kaleidoscope_internal/sketch_exploration/sketch_exploration.h"
+#include "kaleidoscope/macro_map.h"
+#include "kaleidoscope_internal/event_dispatch.h"
+#include "kaleidoscope_internal/LEDModeManager.h"
+#include "kaleidoscope/macro_helpers.h"
+#include "kaleidoscope/plugin.h"
+#include "kaleidoscope/Runtime.h"
+
+#define HOOK_MAX 64
+
+#ifndef VERSION
+#define VERSION "locally-built"
+#endif
+
+/** Kaleidoscope API (major) version.
+ *
+ * The API is guaranteed to be backwards compatible for the entire duration of a
+ * major version. However, breaking changes may come, and result in a major
+ * version bump. To help migration, the `KALEIDOSCOPE_API_VERSION` macro can be
+ * used to check the major version provided by the Kaleidoscope we are compiling
+ * against. This can be used to error out with a helpful message, or change how
+ * the API is used - it is entirely up to the plugin or sketch author. The point
+ * of this macro is to let them easily check the version.
+ */
+#define KALEIDOSCOPE_API_VERSION 2
+
+/** Required Kaleidoscope major version.
+ *
+ * For the sake of convenience, defining `KALEIDOSCOPE_REQUIRED_API_VERSION`
+ * before including `Kaleidoscope.h` itself will result in comparing its value
+ * to `KALEIDOSCOPE_API_VERSION`. If they differ, a helpful error message is
+ * printed.
+ *
+ * Done so that a new API version would result in a helpful error message,
+ * instead of cryptic compile errors.
+ */
+#if defined(KALEIDOSCOPE_REQUIRED_API_VERSION) && (KALEIDOSCOPE_REQUIRED_API_VERSION != KALEIDOSCOPE_API_VERSION)
+#define xstr(a) str(a)
+#define str(a) #a
+static_assert(KALEIDOSCOPE_REQUIRED_API_VERSION == KALEIDOSCOPE_API_VERSION,
+              "Kaleidoscope API version mismatch! We have version " xstr(KALEIDOSCOPE_API_VERSION)
+              " available, but version " xstr(KALEIDOSCOPE_REQUIRED_API_VERSION) " is required.");
+#endif
+
+// Use this function macro to register plugins with Kaleidoscope's
+// hooking system. The macro accepts a list of plugin instances that
+// must have been instantiated at global scope.
+//
+#define KALEIDOSCOPE_INIT_PLUGINS(...) _KALEIDOSCOPE_INIT_PLUGINS(__VA_ARGS__)
+
+// For compatibility reasons we export class Runtime_ as Kaleidoscope_
+// in global namespace.
+//
+DEPRECATED(GLOBAL_TYPENAME_KALEIDOSCOPE)
+typedef kaleidoscope::Runtime_  Kaleidoscope_;
+
+// For compatibility/usability reasons we enable the global variable
+// Kaleidoscope in global namespace.
+//
+extern kaleidoscope::Runtime_ &Kaleidoscope;

--- a/src/kaleidoscope/Hardware.h
+++ b/src/kaleidoscope/Hardware.h
@@ -246,7 +246,7 @@ class Hardware {
    *
    * Because different hardware has different ways to accomplish this, the
    * hardware plugin must provide these functions. Kaleidoscope will wrap them,
-   * so user code does not have to deal with `Kaleidoscope.device()`.
+   * so user code does not have to deal with `Runtime.device()`.
    * @{
    */
   /**

--- a/src/kaleidoscope/MatrixAddr.h
+++ b/src/kaleidoscope/MatrixAddr.h
@@ -211,7 +211,7 @@ class MatrixAddr {
 // cause ambiguous symbol lookup when used in the regular firmware.
 //
 // To use them also for the regular firmware they would need to be
-// disambiguated by moving them to the Kaleidoscope.h header and replacing
+// disambiguated by moving them to the Runtime.h header and replacing
 // them with non-template versions that operate on the actual typedefed
 // KeyAddr and KeyAddr.
 

--- a/src/kaleidoscope/Runtime.cpp
+++ b/src/kaleidoscope/Runtime.cpp
@@ -14,18 +14,20 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/Kaleidoscope.h"
-#include <stdarg.h>
+#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/hid.h"
+#include "kaleidoscope/layers.h"
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 
-uint32_t Kaleidoscope_::millis_at_cycle_start_;
+uint32_t Runtime_::millis_at_cycle_start_;
 
-Kaleidoscope_::Kaleidoscope_(void) {
+Runtime_::Runtime_(void) {
 }
 
 void
-Kaleidoscope_::setup(void) {
+Runtime_::setup(void) {
   // We are explicitly initializing the Serial port as early as possible to
   // (temporarily, hopefully) work around an issue on OSX. If we initialize
   // Serial too late, no matter what we do, we'll end up reading garbage from
@@ -53,7 +55,7 @@ Kaleidoscope_::setup(void) {
 }
 
 void
-Kaleidoscope_::loop(void) {
+Runtime_::loop(void) {
   millis_at_cycle_start_ = millis();
 
   kaleidoscope::Hooks::beforeEachCycle();
@@ -68,6 +70,8 @@ Kaleidoscope_::loop(void) {
   kaleidoscope::Hooks::afterEachCycle();
 }
 
-Kaleidoscope_ Kaleidoscope;
+Runtime_ Runtime;
 
 } // namespace kaleidoscope
+
+kaleidoscope::Runtime_ &Kaleidoscope = kaleidoscope::Runtime;

--- a/src/kaleidoscope/Runtime.h
+++ b/src/kaleidoscope/Runtime.h
@@ -16,97 +16,15 @@
 
 #pragma once
 
-#include <Arduino.h>
-
-//end of add your includes here
-#ifdef __cplusplus
-extern "C" {
-#endif
-void loop();
-void setup();
-#ifdef __cplusplus
-} // extern "C"
-#endif
-
-//add your function definitions for the project KeyboardIO here
-
-#define TS(X) //Serial.print(micros() );Serial.print("\t");Serial.println(X);
-
-#include <stdio.h>
-#include <math.h>
-#include <stdint.h>
-
-#include "kaleidoscope/device/device.h"
-#include "kaleidoscope/device/key_indexes.h"
 #include "kaleidoscope_internal/device.h"
-#include "kaleidoscope_internal/deprecations.h"
-
-static constexpr DEPRECATED(KEYBOARDHARDWARE) kaleidoscope::Device &KeyboardHardware = kaleidoscope_internal::device;
-
-#ifdef PER_KEY_DATA_STACKED
-#define KEYMAP_STACKED(...) { PER_KEY_DATA_STACKED(XXX, __VA_ARGS__) }
-#endif
-
-#ifdef PER_KEY_DATA
-#define KEYMAP(...) { PER_KEY_DATA(XXX, __VA_ARGS__) }
-#endif
-
-static constexpr DEPRECATED(ROWS) uint8_t ROWS = kaleidoscope_internal::device.matrix_rows;
-static constexpr DEPRECATED(COLS) uint8_t COLS = kaleidoscope_internal::device.matrix_columns;
-static constexpr DEPRECATED(LED_COUNT) uint8_t LED_COUNT = kaleidoscope_internal::device.led_count;
-
-#include "kaleidoscope/KeyAddr.h"
-#include "kaleidoscope/key_events.h"
-#include "kaleidoscope/hid.h"
-#include "kaleidoscope/layers.h"
-#include "kaleidoscope_internal/sketch_exploration/sketch_exploration.h"
-#include "kaleidoscope/macro_map.h"
-#include "kaleidoscope_internal/event_dispatch.h"
-#include "kaleidoscope_internal/LEDModeManager.h"
-#include "kaleidoscope/macro_helpers.h"
-#include "kaleidoscope/plugin.h"
-
-#define HOOK_MAX 64
-
-#ifndef VERSION
-#define VERSION "locally-built"
-#endif
-
-/** Kaleidoscope API (major) version.
- *
- * The API is guaranteed to be backwards compatible for the entire duration of a
- * major version. However, breaking changes may come, and result in a major
- * version bump. To help migration, the `KALEIDOSCOPE_API_VERSION` macro can be
- * used to check the major version provided by the Kaleidoscope we are compiling
- * against. This can be used to error out with a helpful message, or change how
- * the API is used - it is entirely up to the plugin or sketch author. The point
- * of this macro is to let them easily check the version.
- */
-#define KALEIDOSCOPE_API_VERSION 2
-
-/** Required Kaleidoscope major version.
- *
- * For the sake of convenience, defining `KALEIDOSCOPE_REQUIRED_API_VERSION`
- * before including `Kaleidoscope.h` itself will result in comparing its value
- * to `KALEIDOSCOPE_API_VERSION`. If they differ, a helpful error message is
- * printed.
- *
- * Done so that a new API version would result in a helpful error message,
- * instead of cryptic compile errors.
- */
-#if defined(KALEIDOSCOPE_REQUIRED_API_VERSION) && (KALEIDOSCOPE_REQUIRED_API_VERSION != KALEIDOSCOPE_API_VERSION)
-#define xstr(a) str(a)
-#define str(a) #a
-static_assert(KALEIDOSCOPE_REQUIRED_API_VERSION == KALEIDOSCOPE_API_VERSION,
-              "Kaleidoscope API version mismatch! We have version " xstr(KALEIDOSCOPE_API_VERSION)
-              " available, but version " xstr(KALEIDOSCOPE_REQUIRED_API_VERSION) " is required.");
-#endif
+#include "kaleidoscope/event_handler_result.h"
+#include "kaleidoscope/hooks.h"
 
 namespace kaleidoscope {
 
-class Kaleidoscope_ {
+class Runtime_ {
  public:
-  Kaleidoscope_(void);
+  Runtime_(void);
 
   void setup(void);
   void loop(void);
@@ -121,7 +39,7 @@ class Kaleidoscope_ {
    *
    * These two functions wrap the hardware plugin's similarly named functions.
    * We wrap them, because we'd like plugins and user-code not having to use
-   * `Kaleidoscope.device()` directly.
+   * `Runtime.device()` directly.
    *
    * The methods themselves implement detaching from / attaching to the host,
    * without rebooting the device, and remaining powered in between.
@@ -176,7 +94,7 @@ class Kaleidoscope_ {
    * occurs, given a start time and a timeout. It takes two parameters:
    *
    * - start_time: A timestamp when the timer started, which should be set by
-   *      calling `Kaleidoscope.millisAtCycleStart()`. It can be any integer
+   *      calling `Runtime.millisAtCycleStart()`. It can be any integer
    *      type.
    *
    * - ttl: The timeout value or interval to check (ttl = "time to live"). The
@@ -210,22 +128,6 @@ class Kaleidoscope_ {
   static uint32_t millis_at_cycle_start_;
 };
 
-extern kaleidoscope::Kaleidoscope_ Kaleidoscope;
+extern kaleidoscope::Runtime_ Runtime;
 
 } // namespace kaleidoscope
-
-// For compatibility reasons we enable class Kaleidoscope_ also to be available
-// in global namespace.
-//
-typedef kaleidoscope::Kaleidoscope_  Kaleidoscope_;
-
-// For compatibility reasons we enable the global variable Kaleidoscope
-// in global namespace.
-//
-using kaleidoscope::Kaleidoscope;
-
-// Use this function macro to register plugins with Kaleidoscope's
-// hooking system. The macro accepts a list of plugin instances that
-// must have been instantiated at global scope.
-//
-#define KALEIDOSCOPE_INIT_PLUGINS(...) _KALEIDOSCOPE_INIT_PLUGINS(__VA_ARGS__)

--- a/src/kaleidoscope/bitfields.cpp
+++ b/src/kaleidoscope/bitfields.cpp
@@ -14,7 +14,7 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope.h"
+#include <Arduino.h>
 
 #include "bitfields.h"
 

--- a/src/kaleidoscope/bitfields.h
+++ b/src/kaleidoscope/bitfields.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stddef.h>
 
 namespace kaleidoscope {
 namespace bitfields {

--- a/src/kaleidoscope/device/dygma/Raise.cpp
+++ b/src/kaleidoscope/device/dygma/Raise.cpp
@@ -18,7 +18,7 @@
 
 #ifdef ARDUINO_SAMD_RAISE
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-EEPROM-Settings.h>
 #include <Kaleidoscope-LEDControl.h>
 #include <KeyboardioHID.h>
@@ -85,20 +85,20 @@ void RaiseHands::setup() {
   // If keyscan is max, assume that EEPROM is uninitialized, and store the
   // defaults.
   uint16_t interval;
-  Kaleidoscope.storage().get(settings_base_, interval);
+  Runtime.storage().get(settings_base_, interval);
   if (interval == 0xffff) {
-    Kaleidoscope.storage().put(settings_base_, keyscan_interval_);
-    Kaleidoscope.storage().commit();
+    Runtime.storage().put(settings_base_, keyscan_interval_);
+    Runtime.storage().commit();
   }
-  Kaleidoscope.storage().get(settings_base_, keyscan_interval_);
+  Runtime.storage().get(settings_base_, keyscan_interval_);
 }
 
 void RaiseHands::keyscanInterval(uint16_t interval) {
   leftHand.setKeyscanInterval(interval);
   rightHand.setKeyscanInterval(interval);
   keyscan_interval_ = interval;
-  Kaleidoscope.storage().put(settings_base_, keyscan_interval_);
-  Kaleidoscope.storage().commit();
+  Runtime.storage().put(settings_base_, keyscan_interval_);
+  Runtime.storage().commit();
 }
 
 void RaiseHands::initializeSides() {

--- a/src/kaleidoscope/device/dygma/raise/Focus.cpp
+++ b/src/kaleidoscope/device/dygma/raise/Focus.cpp
@@ -18,7 +18,7 @@
 
 #ifdef ARDUINO_SAMD_RAISE
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-FocusSerial.h>
 #include "kaleidoscope/device/dygma/raise/Focus.h"
 
@@ -50,72 +50,72 @@ EventHandlerResult Focus::onFocusEvent(const char *command) {
 
   if (strcmp_P(command + 9, PSTR("side_power")) == 0)
     if (::Focus.isEOL()) {
-      ::Focus.send(Kaleidoscope.device().side.getPower());
+      ::Focus.send(Runtime.device().side.getPower());
       return EventHandlerResult::EVENT_CONSUMED;
     } else {
       uint8_t power;
       ::Focus.read(power);
-      Kaleidoscope.device().side.setPower(power);
+      Runtime.device().side.setPower(power);
       return EventHandlerResult::EVENT_CONSUMED;
     }
 
   if (strcmp_P(command + 9, PSTR("side_ver")) == 0) {
     ::Focus.send("left:");
-    ::Focus.send(Kaleidoscope.device().side.leftVersion());
+    ::Focus.send(Runtime.device().side.leftVersion());
     ::Focus.send("\nright:");
-    ::Focus.send(Kaleidoscope.device().side.rightVersion());
+    ::Focus.send(Runtime.device().side.rightVersion());
     return EventHandlerResult::EVENT_CONSUMED;
   }
 
   if (strcmp_P(command + 9, PSTR("crc_errors")) == 0) {
     ::Focus.send("left:");
-    ::Focus.send(Kaleidoscope.device().side.leftCRCErrors());
+    ::Focus.send(Runtime.device().side.leftCRCErrors());
     ::Focus.send("\nright:");
-    ::Focus.send(Kaleidoscope.device().side.rightCRCErrors());
+    ::Focus.send(Runtime.device().side.rightCRCErrors());
     return EventHandlerResult::EVENT_CONSUMED;
   }
 
   if (strcmp_P(command + 9, PSTR("sled_ver")) == 0) {
     ::Focus.send("left:");
-    ::Focus.send(Kaleidoscope.device().side.leftSLEDVersion());
+    ::Focus.send(Runtime.device().side.leftSLEDVersion());
     ::Focus.send("\nright:");
-    ::Focus.send(Kaleidoscope.device().side.rightSLEDVersion());
+    ::Focus.send(Runtime.device().side.rightSLEDVersion());
     return EventHandlerResult::EVENT_CONSUMED;
   }
 
   if (strcmp_P(command + 9, PSTR("sled_current")) == 0)
     if (::Focus.isEOL()) {
       ::Focus.send("left:");
-      ::Focus.send(Kaleidoscope.device().side.leftSLEDCurrent());
+      ::Focus.send(Runtime.device().side.leftSLEDCurrent());
       ::Focus.send("\nright:");
-      ::Focus.send(Kaleidoscope.device().side.rightSLEDCurrent());
+      ::Focus.send(Runtime.device().side.rightSLEDCurrent());
       return EventHandlerResult::EVENT_CONSUMED;
     } else {
       uint8_t current;
       ::Focus.read(current);
-      Kaleidoscope.device().side.setSLEDCurrent(current);
+      Runtime.device().side.setSLEDCurrent(current);
       return EventHandlerResult::EVENT_CONSUMED;
     }
 
   if (strcmp_P(command + 9, PSTR("layout")) == 0) {
-    static const auto ANSI = Kaleidoscope.device().settings.Layout::ANSI;
-    ::Focus.send(Kaleidoscope.device().settings.layout() == ANSI ? "ANSI" : "ISO");
+    static const auto ANSI = Runtime.device().settings.Layout::ANSI;
+    ::Focus.send(Runtime.device().settings.layout() == ANSI ? "ANSI" : "ISO");
     return EventHandlerResult::EVENT_CONSUMED;
   }
 
   if (strcmp_P(command + 9, PSTR("joint")) == 0) {
-    ::Focus.send(Kaleidoscope.device().settings.joint());
+    ::Focus.send(Runtime.device().settings.joint());
     return EventHandlerResult::EVENT_CONSUMED;
   }
 
   if (strcmp_P(command + 9, PSTR("keyscan")) == 0) {
     if (::Focus.isEOL()) {
-      ::Focus.send(Kaleidoscope.device().settings.keyscanInterval());
+      ::Focus.send(Runtime.device().settings.keyscanInterval());
       return EventHandlerResult::EVENT_CONSUMED;
     } else {
       uint8_t keyscan;
       ::Focus.read(keyscan);
-      Kaleidoscope.device().settings.keyscanInterval(keyscan);
+      Runtime.device().settings.keyscanInterval(keyscan);
       return EventHandlerResult::EVENT_CONSUMED;
     }
   }

--- a/src/kaleidoscope/device/dygma/raise/Focus.h
+++ b/src/kaleidoscope/device/dygma/raise/Focus.h
@@ -20,7 +20,7 @@
 
 #ifdef ARDUINO_SAMD_RAISE
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/plugin.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/src/kaleidoscope/device/dygma/raise/SideFlash.h
+++ b/src/kaleidoscope/device/dygma/raise/SideFlash.h
@@ -20,7 +20,8 @@
 
 #ifdef ARDUINO_SAMD_RAISE
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/plugin.h"
 
 namespace kaleidoscope {
 namespace device {
@@ -39,9 +40,9 @@ class SideFlash : public kaleidoscope::Plugin {
     if (strncmp_P(command, PSTR("hardware."), 9) != 0)
       return EventHandlerResult::OK;
 
-    auto sideFlasher = Kaleidoscope.device().sideFlasher();
-    uint8_t left_boot_address = Kaleidoscope.device().side.left_boot_address;
-    uint8_t right_boot_address = Kaleidoscope.device().side.right_boot_address;
+    auto sideFlasher = Runtime.device().sideFlasher();
+    uint8_t left_boot_address = Runtime.device().side.left_boot_address;
+    uint8_t right_boot_address = Runtime.device().side.right_boot_address;
     enum {
       FLASH,
       VERIFY
@@ -65,7 +66,7 @@ class SideFlash : public kaleidoscope::Plugin {
     }
 
     bool result;
-    Kaleidoscope.device().side.prepareForFlash();
+    Runtime.device().side.prepareForFlash();
     if (sub_command == FLASH)
       result = sideFlasher.flash(address, firmware);
     else

--- a/src/kaleidoscope/device/ez/ErgoDox.cpp
+++ b/src/kaleidoscope/device/ez/ErgoDox.cpp
@@ -27,10 +27,11 @@
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #ifdef ARDUINO_AVR_ERGODOX
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <KeyboardioHID.h>
 #include <avr/wdt.h>
 #include "kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.h"
+#include "kaleidoscope/key_events.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/src/kaleidoscope/device/kbdfans/KBD4x.cpp
+++ b/src/kaleidoscope/device/kbdfans/KBD4x.cpp
@@ -18,7 +18,10 @@
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #ifdef ARDUINO_AVR_KBD4X
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/key_events.h"
+#include "kaleidoscope/driver/keyscanner/ATmega.h"
+#include "kaleidoscope/driver/keyscanner/Base_Impl.h"
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/src/kaleidoscope/device/keyboardio/Imago.cpp
+++ b/src/kaleidoscope/device/keyboardio/Imago.cpp
@@ -17,7 +17,8 @@
 
 #ifdef ARDUINO_AVR_KEYBOARDIO_IMAGO
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/driver/keyscanner/Base_Impl.h"
 
 extern "C" {
 #include "twi.h"
@@ -81,7 +82,7 @@ void ImagoLEDDriver::selectRegister(uint8_t page) {
 }
 
 void ImagoLEDDriver::setCrgbAt(uint8_t i, cRGB crgb) {
-  if (!Kaleidoscope.device().LEDs().isValid(i))
+  if (!Runtime.device().LEDs().isValid(i))
     return;
 
   cRGB oldColor = getCrgbAt(i);
@@ -91,7 +92,7 @@ void ImagoLEDDriver::setCrgbAt(uint8_t i, cRGB crgb) {
 }
 
 cRGB ImagoLEDDriver::getCrgbAt(uint8_t i) {
-  if (!Kaleidoscope.device().LEDs().isValid(i))
+  if (!Runtime.device().LEDs().isValid(i))
     return {0, 0, 0};
 
   return led_data[i];

--- a/src/kaleidoscope/device/keyboardio/Model01.cpp
+++ b/src/kaleidoscope/device/keyboardio/Model01.cpp
@@ -17,7 +17,10 @@
 
 #ifdef ARDUINO_AVR_MODEL01
 
-#include <Kaleidoscope.h>
+#include "Arduino.h"                                 // for PROGMEM
+#include "kaleidoscope/device/keyboardio/Model01.h"  // for Model01LEDDriver...
+#include "kaleidoscope/key_events.h"
+#include "kaleidoscope/driver/keyscanner/Base_Impl.h"
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #include <KeyboardioHID.h>

--- a/src/kaleidoscope/device/olkb/Planck.cpp
+++ b/src/kaleidoscope/device/olkb/Planck.cpp
@@ -18,7 +18,8 @@
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #ifdef ARDUINO_AVR_PLANCK
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/driver/keyscanner/Base_Impl.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/src/kaleidoscope/device/softhruf/Splitography.cpp
+++ b/src/kaleidoscope/device/softhruf/Splitography.cpp
@@ -25,7 +25,8 @@
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #ifdef ARDUINO_AVR_SPLITOGRAPHY
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/driver/keyscanner/Base_Impl.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/src/kaleidoscope/device/technomancy/Atreus.cpp
+++ b/src/kaleidoscope/device/technomancy/Atreus.cpp
@@ -27,7 +27,8 @@
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #ifdef ARDUINO_AVR_ATREUS
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/driver/keyscanner/Base_Impl.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/src/kaleidoscope/device/technomancy/Atreus2.cpp
+++ b/src/kaleidoscope/device/technomancy/Atreus2.cpp
@@ -19,7 +19,8 @@
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #ifdef ARDUINO_AVR_ATREUS2
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/driver/keyscanner/Base_Impl.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/src/kaleidoscope/device/virtual/Virtual.cpp
+++ b/src/kaleidoscope/device/virtual/Virtual.cpp
@@ -22,7 +22,10 @@
 #include "kaleidoscope/device/virtual/Logging.h"
 
 #include "kaleidoscope/keyswitch_state.h"
-#include "Kaleidoscope.h"
+#include "kaleidoscope/MatrixAddr.h"
+#include "kaleidoscope/key_defs.h"
+#include "kaleidoscope/key_events.h"
+
 
 #include "HIDReportObserver.h"
 #include "virtual_io.h"
@@ -30,7 +33,6 @@
 
 #include <sstream>
 #include <string>
-#include <iomanip>
 
 // FIXME: This relates to virtual/cores/arduino/EEPROM.h.
 //        EEPROM static data must be defined here as only

--- a/src/kaleidoscope/driver/bootloader/avr/FLIP.cpp
+++ b/src/kaleidoscope/driver/bootloader/avr/FLIP.cpp
@@ -16,7 +16,7 @@
  */
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 #ifdef KALEIDOSCOPE_BOOTLOADER_FLIP_WORKAROUND
 #include "kaleidoscope/driver/bootloader/avr/FLIP.h"

--- a/src/kaleidoscope/driver/keyscanner/ATmega.h
+++ b/src/kaleidoscope/driver/keyscanner/ATmega.h
@@ -57,7 +57,7 @@
   uint8_t kaleidoscope::Device::KeyScanner::debounce_matrix_[kaleidoscope::Device::KeyScannerProps::matrix_rows][kaleidoscope::Device::KeyScannerProps::matrix_columns] = {}; \
                                                                                            \
   ISR(TIMER1_OVF_vect) {                                                                   \
-    Kaleidoscope.device().readMatrix();                                              \
+    Runtime.device().readMatrix();                                              \
   }
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/driver/keyscanner/Base_Impl.h
+++ b/src/kaleidoscope/driver/keyscanner/Base_Impl.h
@@ -1,5 +1,6 @@
-/* kaleidoscope_internal::device - Global device object for internal use
- * Copyright (C) 2019  Keyboard.io, Inc.
+/* -*- mode: c++ -*-
+ * kaleidoscope::driver::keyscanner::base -- Keyscanner base class
+ * Copyright (C) 2019  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -16,8 +17,17 @@
 
 #pragma once
 
+#include "kaleidoscope/driver/keyscanner/Base.h"
 #include "kaleidoscope/device/device.h"
 
-namespace kaleidoscope_internal {
-extern kaleidoscope::Device device;
+namespace kaleidoscope {
+namespace driver {
+namespace keyscanner {
+
+template<>
+void Base<kaleidoscope::Device::Props::KeyScannerProps>::handleKeyswitchEvent(Key mappedKey, kaleidoscope::Device::Props::KeyScannerProps::KeyAddr key_addr, uint8_t keyState) {
+  ::handleKeyswitchEvent(mappedKey, key_addr, keyState);
 }
+} // namespace keyscanner
+} // namespace driver
+} // namespace kaleidoscope

--- a/src/kaleidoscope/hooks.cpp
+++ b/src/kaleidoscope/hooks.cpp
@@ -14,7 +14,9 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope.h"
+#include "kaleidoscope/event_handler_result.h"
+#include "kaleidoscope/event_handlers.h"
+#include "kaleidoscope/macro_helpers.h"
 #include "kaleidoscope/hooks.h"
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/hooks.h
+++ b/src/kaleidoscope/hooks.h
@@ -59,9 +59,9 @@ class Hooks {
   // The following friend declarations restrict access to
   // the hook routing system.
 
-  // Kaleidoscope_ calls Hooks::onSetup, Hooks::beforeReportingState
+  // Runtime_ calls Hooks::onSetup, Hooks::beforeReportingState
   // and Hooks::afterEachCycle.
-  friend class Kaleidoscope_;
+  friend class Runtime_;
   friend class ::kaleidoscope::Layer_;
   friend class ::kaleidoscope::plugin::LEDControl;
   friend void ::kaleidoscope::sketch_exploration::pluginsExploreSketch();

--- a/src/kaleidoscope/key_defs_keymaps.h
+++ b/src/kaleidoscope/key_defs_keymaps.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "kaleidoscope_internal/deprecations.h"
 
 static const uint8_t LAYER_SHIFT_OFFSET = 42;

--- a/src/kaleidoscope/key_events.cpp
+++ b/src/kaleidoscope/key_events.cpp
@@ -14,9 +14,11 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/Kaleidoscope.h"
+#include "kaleidoscope/Runtime.h"
 #include "kaleidoscope/hooks.h"
-#include "kaleidoscope/plugin.h"
+#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/hid.h"
+#include "kaleidoscope/layers.h"
 
 static bool handleSyntheticKeyswitchEvent(Key mappedKey, uint8_t keyState) {
   if (mappedKey.getFlags() & RESERVED)
@@ -60,6 +62,9 @@ static bool handleKeyswitchEventDefault(Key mappedKey, KeyAddr key_addr, uint8_t
 }
 
 void handleKeyswitchEvent(Key mappedKey, KeyAddr key_addr, uint8_t keyState) {
+
+  using kaleidoscope::Runtime;
+
   /* These first steps are only done for keypresses that have a valid key_addr.
    * In particular, doing them for keypresses with out-of-bounds key_addr
    *   would cause out-of-bounds array accesses in Layer.lookup(),
@@ -96,9 +101,9 @@ void handleKeyswitchEvent(Key mappedKey, KeyAddr key_addr, uint8_t keyState) {
      * See layers.cpp for an example that masks keys, and the reason why it does
      * so.
      */
-    if (Kaleidoscope.device().isKeyMasked(key_addr)) {
+    if (Runtime.device().isKeyMasked(key_addr)) {
       if (keyToggledOff(keyState)) {
-        Kaleidoscope.device().unMaskKey(key_addr);
+        Runtime.device().unMaskKey(key_addr);
       } else {
         return;
       }

--- a/src/kaleidoscope/key_events.h
+++ b/src/kaleidoscope/key_events.h
@@ -17,9 +17,11 @@
 #pragma once
 #include <Arduino.h>
 
+#include "kaleidoscope/driver/keyscanner/Base.h"
 #include "kaleidoscope/device/device.h"
 #include "kaleidoscope/key_defs.h"
 #include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/KeyAddr.h"
 
 
 // Code can use this macro on injected key events to signal that
@@ -76,16 +78,3 @@ void handleKeyswitchEvent(Key mappedKey, kaleidoscope::Device::Props::KeyScanner
 DEPRECATED(ROW_COL_FUNC) inline void handleKeyswitchEvent(Key mappedKey, byte row, byte col, uint8_t keyState) {
   handleKeyswitchEvent(mappedKey, KeyAddr(row, col), keyState);
 }
-
-namespace kaleidoscope {
-namespace driver {
-namespace keyscanner {
-
-template<>
-inline
-void Base<kaleidoscope::Device::Props::KeyScannerProps>::handleKeyswitchEvent(Key mappedKey, kaleidoscope::Device::Props::KeyScannerProps::KeyAddr key_addr, uint8_t keyState) {
-  ::handleKeyswitchEvent(mappedKey, key_addr, keyState);
-}
-} // namespace keyscanner
-} // namespace driver
-} // namespace kaleidoscope

--- a/src/kaleidoscope/keymaps.h
+++ b/src/kaleidoscope/keymaps.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include "kaleidoscope/key_defs.h"
+#include "kaleidoscope/KeyAddr.h"
+#include "kaleidoscope_internal/device.h"
 
 extern const Key keymaps_linear[][kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns];
 

--- a/src/kaleidoscope/layers.cpp
+++ b/src/kaleidoscope/layers.cpp
@@ -14,7 +14,9 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/Kaleidoscope.h"
+#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/layers.h"
+#include "kaleidoscope/keyswitch_state.h"
 
 // The maximum number of layers allowed. `layer_state_`, which stores
 // the on/off status of the layers in a bitfield has only 32 bits, and
@@ -38,8 +40,8 @@ extern constexpr Key keymaps_linear[][kaleidoscope_internal::device.matrix_rows 
 namespace kaleidoscope {
 uint32_t Layer_::layer_state_;
 uint8_t Layer_::top_active_layer_;
-Key Layer_::live_composite_keymap_[Kaleidoscope.device().numKeys()];
-uint8_t Layer_::active_layers_[Kaleidoscope.device().numKeys()];
+Key Layer_::live_composite_keymap_[Runtime.device().numKeys()];
+uint8_t Layer_::active_layers_[Runtime.device().numKeys()];
 Layer_::GetKeyFunction Layer_::getKey = &Layer_::getKeyFromPROGMEM;
 
 void Layer_::handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState) {
@@ -111,7 +113,7 @@ void Layer_::updateLiveCompositeKeymap(KeyAddr key_addr) {
 }
 
 void Layer_::updateActiveLayers(void) {
-  memset(active_layers_, 0, Kaleidoscope.device().numKeys());
+  memset(active_layers_, 0, Runtime.device().numKeys());
   for (auto key_addr : KeyAddr::all()) {
     int8_t layer = top_active_layer_;
 

--- a/src/kaleidoscope/plugin/Colormap.cpp
+++ b/src/kaleidoscope/plugin/Colormap.cpp
@@ -19,6 +19,7 @@
 #include <Kaleidoscope-Colormap.h>
 #include <Kaleidoscope-EEPROM-Settings.h>
 #include <Kaleidoscope-FocusSerial.h>
+#include "kaleidoscope/layers.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -36,7 +37,7 @@ void ColormapEffect::max_layers(uint8_t max_) {
 }
 
 void ColormapEffect::TransientLEDMode::onActivate(void) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return;
 
   parent_->top_layer_ = Layer.top();

--- a/src/kaleidoscope/plugin/Cycle.cpp
+++ b/src/kaleidoscope/plugin/Cycle.cpp
@@ -15,9 +15,11 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Cycle.h>
 #include "kaleidoscope/hid.h"
+#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/key_events.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/Cycle.h
+++ b/src/kaleidoscope/plugin/Cycle.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
 
 #define Key_Cycle Key(kaleidoscope::ranges::CYCLE)

--- a/src/kaleidoscope/plugin/CycleTimeReport.cpp
+++ b/src/kaleidoscope/plugin/CycleTimeReport.cpp
@@ -25,7 +25,7 @@ uint32_t CycleTimeReport::loop_start_time_;
 uint32_t CycleTimeReport::average_loop_time;
 
 EventHandlerResult CycleTimeReport::onSetup() {
-  last_report_time_ = Kaleidoscope.millisAtCycleStart();
+  last_report_time_ = Runtime.millisAtCycleStart();
   return EventHandlerResult::OK;
 }
 
@@ -42,11 +42,11 @@ EventHandlerResult CycleTimeReport::afterEachCycle() {
   else
     average_loop_time = loop_time;
 
-  if (Kaleidoscope.hasTimeExpired(last_report_time_, uint16_t(1000))) {
+  if (Runtime.hasTimeExpired(last_report_time_, uint16_t(1000))) {
     cycleTimeReport();
 
     average_loop_time = 0;
-    last_report_time_ = Kaleidoscope.millisAtCycleStart();
+    last_report_time_ = Runtime.millisAtCycleStart();
   }
 
   return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/CycleTimeReport.h
+++ b/src/kaleidoscope/plugin/CycleTimeReport.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/DynamicMacros.h
+++ b/src/kaleidoscope/plugin/DynamicMacros.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-EEPROM-Settings.h>
 #include <Kaleidoscope-Ranges.h>
 

--- a/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
+++ b/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
@@ -17,6 +17,8 @@
 
 #include <Kaleidoscope-EEPROM-Keymap-Programmer.h>
 #include <Kaleidoscope-FocusSerial.h>
+#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/layers.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -39,7 +41,7 @@ void EEPROMKeymapProgrammer::nextState(void) {
   case WAIT_FOR_CODE:
   case WAIT_FOR_SOURCE_KEY:
     ::EEPROMKeymap.updateKey(update_position_, new_key_);
-    Kaleidoscope.storage().commit();
+    Runtime.storage().commit();
     cancel();
     break;
   }
@@ -57,10 +59,10 @@ EventHandlerResult EEPROMKeymapProgrammer::onKeyswitchEvent(Key &mapped_key, Key
 
   if (state_ == WAIT_FOR_KEY) {
     if (keyToggledOn(key_state)) {
-      update_position_ = Layer.top() * Kaleidoscope.device().numKeys() + key_addr.toInt();
+      update_position_ = Layer.top() * Runtime.device().numKeys() + key_addr.toInt();
     }
     if (keyToggledOff(key_state)) {
-      if ((uint16_t)(Layer.top() * Kaleidoscope.device().numKeys() + key_addr.toInt()) == update_position_)
+      if ((uint16_t)(Layer.top() * Runtime.device().numKeys() + key_addr.toInt()) == update_position_)
         nextState();
     }
     return EventHandlerResult::EVENT_CONSUMED;

--- a/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.h
+++ b/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-EEPROM-Keymap.h>
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -18,6 +18,7 @@
 #include <Kaleidoscope-EEPROM-Settings.h>
 #include <Kaleidoscope-EEPROM-Keymap.h>
 #include <Kaleidoscope-FocusSerial.h>
+#include "kaleidoscope/layers.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -44,17 +45,17 @@ void EEPROMKeymap::setup(uint8_t max) {
 
 void EEPROMKeymap::max_layers(uint8_t max) {
   max_layers_ = max;
-  keymap_base_ = ::EEPROMSettings.requestSlice(max_layers_ * Kaleidoscope.device().numKeys() * 2);
+  keymap_base_ = ::EEPROMSettings.requestSlice(max_layers_ * Runtime.device().numKeys() * 2);
 }
 
 Key EEPROMKeymap::getKey(uint8_t layer, KeyAddr key_addr) {
   if (layer >= max_layers_)
     return Key_NoKey;
 
-  uint16_t pos = ((layer * Kaleidoscope.device().numKeys()) + key_addr.toInt()) * 2;
+  uint16_t pos = ((layer * Runtime.device().numKeys()) + key_addr.toInt()) * 2;
 
-  return Key(Kaleidoscope.storage().read(keymap_base_ + pos + 1), // key_code
-             Kaleidoscope.storage().read(keymap_base_ + pos));    // flags
+  return Key(Runtime.storage().read(keymap_base_ + pos + 1), // key_code
+             Runtime.storage().read(keymap_base_ + pos));    // flags
 }
 
 Key EEPROMKeymap::getKeyExtended(uint8_t layer, KeyAddr key_addr) {
@@ -73,8 +74,8 @@ uint16_t EEPROMKeymap::keymap_base(void) {
 }
 
 void EEPROMKeymap::updateKey(uint16_t base_pos, Key key) {
-  Kaleidoscope.storage().update(keymap_base_ + base_pos * 2, key.getFlags());
-  Kaleidoscope.storage().update(keymap_base_ + base_pos * 2 + 1, key.getKeyCode());
+  Runtime.storage().update(keymap_base_ + base_pos * 2, key.getFlags());
+  Runtime.storage().update(keymap_base_ + base_pos * 2 + 1, key.getKeyCode());
 }
 
 void EEPROMKeymap::dumpKeymap(uint8_t layers, Key(*getkey)(uint8_t, KeyAddr)) {
@@ -146,14 +147,14 @@ EventHandlerResult EEPROMKeymap::onFocusEvent(const char *command) {
   } else {
     uint16_t i = 0;
 
-    while (!::Focus.isEOL() && (i < (uint16_t)Kaleidoscope.device().numKeys() * max_layers_)) {
+    while (!::Focus.isEOL() && (i < (uint16_t)Runtime.device().numKeys() * max_layers_)) {
       Key k;
 
       ::Focus.read(k);
       updateKey(i, k);
       i++;
     }
-    Kaleidoscope.storage().commit();
+    Runtime.storage().commit();
   }
 
   return EventHandlerResult::EVENT_CONSUMED;

--- a/src/kaleidoscope/plugin/EEPROM-Keymap.h
+++ b/src/kaleidoscope/plugin/EEPROM-Keymap.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-EEPROM-Settings.h>
 
 #define _DEPRECATED_MESSAGE_EEPROM_KEYMAP_SETUP_MODE                       \

--- a/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -18,6 +18,7 @@
 #include <Kaleidoscope-EEPROM-Settings.h>
 #include <Kaleidoscope-FocusSerial.h>
 #include "kaleidoscope/plugin/EEPROM-Settings/crc.h"
+#include "kaleidoscope/layers.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -28,7 +29,7 @@ bool EEPROMSettings::sealed_;
 uint16_t EEPROMSettings::next_start_ = sizeof(EEPROMSettings::settings);
 
 EventHandlerResult EEPROMSettings::onSetup() {
-  Kaleidoscope.storage().get(0, settings_);
+  Runtime.storage().get(0, settings_);
 
   /* If the version is undefined, set up sensible defaults. */
   if (settings_.version == VERSION_UNDEFINED) {
@@ -49,8 +50,8 @@ EventHandlerResult EEPROMSettings::onSetup() {
      * not able to catch all writes yet. For the sake of consistency, if we
      * encounter a firmware with no version defined, we'll set sensible
      * defaults. */
-    Kaleidoscope.storage().put(0, settings_);
-    Kaleidoscope.storage().commit();
+    Runtime.storage().put(0, settings_);
+    Runtime.storage().commit();
   }
   return EventHandlerResult::OK;
 }
@@ -147,8 +148,8 @@ uint16_t EEPROMSettings::used(void) {
 }
 
 void EEPROMSettings::update(void) {
-  Kaleidoscope.storage().put(0, settings_);
-  Kaleidoscope.storage().commit();
+  Runtime.storage().put(0, settings_);
+  Runtime.storage().commit();
   is_valid_ = true;
 }
 
@@ -222,22 +223,22 @@ EventHandlerResult FocusEEPROMCommand::onFocusEvent(const char *command) {
   switch (sub_command) {
   case CONTENTS: {
     if (::Focus.isEOL()) {
-      for (uint16_t i = 0; i < Kaleidoscope.storage().length(); i++) {
-        uint8_t d = Kaleidoscope.storage().read(i);
+      for (uint16_t i = 0; i < Runtime.storage().length(); i++) {
+        uint8_t d = Runtime.storage().read(i);
         ::Focus.send(d);
       }
     } else {
-      for (uint16_t i = 0; i < Kaleidoscope.storage().length() && !::Focus.isEOL(); i++) {
+      for (uint16_t i = 0; i < Runtime.storage().length() && !::Focus.isEOL(); i++) {
         uint8_t d;
         ::Focus.read(d);
-        Kaleidoscope.storage().update(i, d);
+        Runtime.storage().update(i, d);
       }
     }
 
     break;
   }
   case FREE:
-    ::Focus.send(Kaleidoscope.storage().length() - ::EEPROMSettings.used());
+    ::Focus.send(Runtime.storage().length() - ::EEPROMSettings.used());
     break;
   }
 

--- a/src/kaleidoscope/plugin/EEPROM-Settings.h
+++ b/src/kaleidoscope/plugin/EEPROM-Settings.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 #define _DEPRECATED_MESSAGE_EEPROMSETTINGS_VERSION_SET            \
   "The EEPROMSettings.version(uint8_t version) method has been deprecated,\n" \

--- a/src/kaleidoscope/plugin/Escape-OneShot.cpp
+++ b/src/kaleidoscope/plugin/Escape-OneShot.cpp
@@ -15,9 +15,10 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-OneShot.h>
 #include <Kaleidoscope-Escape-OneShot.h>
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -32,7 +33,7 @@ EventHandlerResult EscapeOneShot::onKeyswitchEvent(Key &mapped_key, KeyAddr key_
     return EventHandlerResult::OK;
   }
 
-  Kaleidoscope.device().maskKey(key_addr);
+  Runtime.device().maskKey(key_addr);
 
   ::OneShot.cancel(true);
   return EventHandlerResult::EVENT_CONSUMED;

--- a/src/kaleidoscope/plugin/Escape-OneShot.h
+++ b/src/kaleidoscope/plugin/Escape-OneShot.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/FingerPainter.cpp
+++ b/src/kaleidoscope/plugin/FingerPainter.cpp
@@ -21,6 +21,7 @@
 #include <Kaleidoscope-FocusSerial.h>
 #include <Kaleidoscope-LEDControl.h>
 #include <Kaleidoscope-LED-Palette-Theme.h>
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -46,7 +47,7 @@ void FingerPainter::toggle(void) {
 }
 
 EventHandlerResult FingerPainter::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
-  if (!Kaleidoscope.has_leds || !edit_mode_)
+  if (!Runtime.has_leds || !edit_mode_)
     return EventHandlerResult::OK;
 
   if (!keyToggledOn(key_state)) {
@@ -58,7 +59,7 @@ EventHandlerResult FingerPainter::onKeyswitchEvent(Key &mapped_key, KeyAddr key_
 
   // TODO: The following works only for keyboards with LEDs for each key.
 
-  uint8_t color_index = ::LEDPaletteTheme.lookupColorIndexAtPosition(color_base_, Kaleidoscope.device().getLedIndex(key_addr));
+  uint8_t color_index = ::LEDPaletteTheme.lookupColorIndexAtPosition(color_base_, Runtime.device().getLedIndex(key_addr));
 
   // Find the next color in the palette that is different.
   // But do not loop forever!
@@ -75,7 +76,7 @@ EventHandlerResult FingerPainter::onKeyswitchEvent(Key &mapped_key, KeyAddr key_
     new_color = ::LEDPaletteTheme.lookupPaletteColor(color_index);
   }
 
-  ::LEDPaletteTheme.updateColorIndexAtPosition(color_base_, Kaleidoscope.device().getLedIndex(key_addr), color_index);
+  ::LEDPaletteTheme.updateColorIndexAtPosition(color_base_, Runtime.device().getLedIndex(key_addr), color_index);
 
   return EventHandlerResult::EVENT_CONSUMED;
 }
@@ -100,10 +101,10 @@ EventHandlerResult FingerPainter::onFocusEvent(const char *command) {
     return EventHandlerResult::OK;
 
   if (sub_command == CLEAR) {
-    for (uint16_t i = 0; i < Kaleidoscope.device().numKeys() / 2; i++) {
-      Kaleidoscope.storage().update(color_base_ + i, 0);
+    for (uint16_t i = 0; i < Runtime.device().numKeys() / 2; i++) {
+      Runtime.storage().update(color_base_ + i, 0);
     }
-    Kaleidoscope.storage().commit();
+    Runtime.storage().commit();
     return EventHandlerResult::OK;
   }
 

--- a/src/kaleidoscope/plugin/FirmwareDump.h
+++ b/src/kaleidoscope/plugin/FirmwareDump.h
@@ -23,7 +23,7 @@
 
 #ifdef __AVR__
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -27,20 +27,20 @@ namespace plugin {
 char FocusSerial::command_[32];
 
 void FocusSerial::drain(void) {
-  if (Kaleidoscope.serialPort().available())
-    while (Kaleidoscope.serialPort().peek() != '\n')
-      Kaleidoscope.serialPort().read();
+  if (Runtime.serialPort().available())
+    while (Runtime.serialPort().peek() != '\n')
+      Runtime.serialPort().read();
 }
 
 EventHandlerResult FocusSerial::beforeReportingState() {
-  if (Kaleidoscope.serialPort().available() == 0)
+  if (Runtime.serialPort().available() == 0)
     return EventHandlerResult::OK;
 
   uint8_t i = 0;
   do {
-    command_[i++] = Kaleidoscope.serialPort().read();
+    command_[i++] = Runtime.serialPort().read();
 
-    if (Kaleidoscope.serialPort().peek() == '\n')
+    if (Runtime.serialPort().peek() == '\n')
       break;
   } while (command_[i - 1] != ' ' && i < 32);
   if (command_[i - 1] == ' ')
@@ -48,14 +48,14 @@ EventHandlerResult FocusSerial::beforeReportingState() {
   else
     command_[i] = '\0';
 
-  Kaleidoscope.onFocusEvent(command_);
+  Runtime.onFocusEvent(command_);
 
-  Kaleidoscope.serialPort().println(F("\r\n."));
+  Runtime.serialPort().println(F("\r\n."));
 
   drain();
 
-  if (Kaleidoscope.serialPort().peek() == '\n')
-    Kaleidoscope.serialPort().read();
+  if (Runtime.serialPort().peek() == '\n')
+    Runtime.serialPort().read();
 
   return EventHandlerResult::OK;
 }
@@ -65,7 +65,7 @@ bool FocusSerial::handleHelp(const char *command,
   if (strcmp_P(command, PSTR("help")) != 0)
     return false;
 
-  Kaleidoscope.serialPort().println((const __FlashStringHelper *)help_message);
+  Runtime.serialPort().println((const __FlashStringHelper *)help_message);
   return true;
 }
 
@@ -75,7 +75,7 @@ EventHandlerResult FocusSerial::onFocusEvent(const char *command) {
 }
 
 void FocusSerial::printBool(bool b) {
-  Kaleidoscope.serialPort().print((b) ? F("true") : F("false"));
+  Runtime.serialPort().print((b) ? F("true") : F("false"));
 }
 
 }

--- a/src/kaleidoscope/plugin/FocusSerial.h
+++ b/src/kaleidoscope/plugin/FocusSerial.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -37,12 +37,12 @@ class FocusSerial : public kaleidoscope::Plugin {
   }
   void send(const bool b) {
     printBool(b);
-    Kaleidoscope.serialPort().print(SEPARATOR);
+    Runtime.serialPort().print(SEPARATOR);
   }
   template <typename V>
   void send(V v) {
-    Kaleidoscope.serialPort().print(v);
-    Kaleidoscope.serialPort().print(SEPARATOR);
+    Runtime.serialPort().print(v);
+    Runtime.serialPort().print(SEPARATOR);
   }
   template <typename Var, typename... Vars>
   void send(Var v, Vars... vars) {
@@ -53,31 +53,31 @@ class FocusSerial : public kaleidoscope::Plugin {
   void sendRaw() {}
   template <typename Var, typename... Vars>
   void sendRaw(Var v, Vars... vars) {
-    Kaleidoscope.serialPort().print(v);
+    Runtime.serialPort().print(v);
     sendRaw(vars...);
   }
 
   const char peek() {
-    return Kaleidoscope.serialPort().peek();
+    return Runtime.serialPort().peek();
   }
 
   void read(Key &key) {
-    key.setRaw(Kaleidoscope.serialPort().parseInt());
+    key.setRaw(Runtime.serialPort().parseInt());
   }
   void read(cRGB &color) {
-    color.r = Kaleidoscope.serialPort().parseInt();
-    color.g = Kaleidoscope.serialPort().parseInt();
-    color.b = Kaleidoscope.serialPort().parseInt();
+    color.r = Runtime.serialPort().parseInt();
+    color.g = Runtime.serialPort().parseInt();
+    color.b = Runtime.serialPort().parseInt();
   }
   void read(uint8_t &u8) {
-    u8 = Kaleidoscope.serialPort().parseInt();
+    u8 = Runtime.serialPort().parseInt();
   }
   void read(uint16_t &u16) {
-    u16 = Kaleidoscope.serialPort().parseInt();
+    u16 = Runtime.serialPort().parseInt();
   }
 
   bool isEOL() {
-    return Kaleidoscope.serialPort().peek() == '\n';
+    return Runtime.serialPort().peek() == '\n';
   }
 
   static constexpr char COMMENT = '#';

--- a/src/kaleidoscope/plugin/GeminiPR.cpp
+++ b/src/kaleidoscope/plugin/GeminiPR.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope-Steno.h>
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -39,7 +40,7 @@ EventHandlerResult GeminiPR::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr,
 
     if (keys_held_ == 0) {
       state_[0] |= 0x80;
-      Kaleidoscope.serialPort().write(state_, sizeof(state_));
+      Runtime.serialPort().write(state_, sizeof(state_));
       memset(state_, 0, sizeof(state_));
     }
   }

--- a/src/kaleidoscope/plugin/GeminiPR.h
+++ b/src/kaleidoscope/plugin/GeminiPR.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
 
 #define S(n) Key(kaleidoscope::plugin::steno::geminipr::n)

--- a/src/kaleidoscope/plugin/GhostInTheFirmware.cpp
+++ b/src/kaleidoscope/plugin/GhostInTheFirmware.cpp
@@ -15,8 +15,9 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-GhostInTheFirmware.h>
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -46,11 +47,11 @@ EventHandlerResult GhostInTheFirmware::beforeReportingState() {
       return EventHandlerResult::OK;
     }
     is_pressed_ = true;
-    start_time_ = Kaleidoscope.millisAtCycleStart();
+    start_time_ = Runtime.millisAtCycleStart();
   } else {
-    if (is_pressed_ && Kaleidoscope.hasTimeExpired(start_time_, press_timeout_)) {
+    if (is_pressed_ && Runtime.hasTimeExpired(start_time_, press_timeout_)) {
       is_pressed_ = false;
-      start_time_ = Kaleidoscope.millisAtCycleStart();
+      start_time_ = Runtime.millisAtCycleStart();
 
       byte row = pgm_read_byte(&(ghost_keys[current_pos_].row));
       byte col = pgm_read_byte(&(ghost_keys[current_pos_].col));
@@ -61,7 +62,7 @@ EventHandlerResult GhostInTheFirmware::beforeReportingState() {
       byte col = pgm_read_byte(&(ghost_keys[current_pos_].col));
 
       handleKeyswitchEvent(Key_NoKey, KeyAddr(row, col), IS_PRESSED);
-    } else if (Kaleidoscope.hasTimeExpired(start_time_, delay_timeout_)) {
+    } else if (Runtime.hasTimeExpired(start_time_, delay_timeout_)) {
       current_pos_++;
       press_timeout_ = 0;
     }

--- a/src/kaleidoscope/plugin/GhostInTheFirmware.h
+++ b/src/kaleidoscope/plugin/GhostInTheFirmware.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/HardwareTestMode.cpp
+++ b/src/kaleidoscope/plugin/HardwareTestMode.cpp
@@ -14,9 +14,10 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope.h"
+#include "kaleidoscope/Runtime.h"
 #include "Kaleidoscope-HardwareTestMode.h"
 #include "Kaleidoscope-LEDEffect-Rainbow.h"
+#include "kaleidoscope/hid.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -32,9 +33,9 @@ void HardwareTestMode::setActionKey(uint8_t key) {
 
 void HardwareTestMode::waitForKeypress() {
   while (1) {
-    Kaleidoscope.device().readMatrix();
-    if (Kaleidoscope.device().isKeyswitchPressed(actionKey) &&
-        ! Kaleidoscope.device().wasKeyswitchPressed(actionKey)) {
+    Runtime.device().readMatrix();
+    if (Runtime.device().isKeyswitchPressed(actionKey) &&
+        ! Runtime.device().wasKeyswitchPressed(actionKey)) {
       break;
     }
   }
@@ -76,7 +77,7 @@ void HardwareTestMode::testLeds(void) {
 
 void HardwareTestMode::testMatrix() {
   // Reset bad keys from previous tests.
-  chatter_data state[Kaleidoscope.device().numKeys()] = {{0, 0, 0}};
+  chatter_data state[Runtime.device().numKeys()] = {{0, 0, 0}};
 
   constexpr cRGB red = CRGB(201, 0, 0);
   constexpr cRGB blue = CRGB(0, 0, 201);
@@ -84,12 +85,12 @@ void HardwareTestMode::testMatrix() {
   constexpr cRGB yellow = CRGB(201, 100, 0);
 
   while (1) {
-    Kaleidoscope.device().readMatrix();
+    Runtime.device().readMatrix();
     for (auto key_addr : KeyAddr::all()) {
       uint8_t keynum = key_addr.toInt();
 
       // If the key is toggled on
-      if (Kaleidoscope.device().isKeyswitchPressed(key_addr) && ! Kaleidoscope.device().wasKeyswitchPressed(key_addr)) {
+      if (Runtime.device().isKeyswitchPressed(key_addr) && ! Runtime.device().wasKeyswitchPressed(key_addr)) {
         // And it's too soon (in terms of cycles between changes)
         state[keynum].tested = 1;
         if (state[keynum].cyclesSinceStateChange < CHATTER_CYCLE_LIMIT) {
@@ -100,19 +101,19 @@ void HardwareTestMode::testMatrix() {
         state[keynum].cyclesSinceStateChange++;
       }
       // If the key is held down
-      if (Kaleidoscope.device().isKeyswitchPressed(key_addr) && Kaleidoscope.device().wasKeyswitchPressed(key_addr)) {
-        Kaleidoscope.device().setCrgbAt(key_addr, green);
+      if (Runtime.device().isKeyswitchPressed(key_addr) && Runtime.device().wasKeyswitchPressed(key_addr)) {
+        Runtime.device().setCrgbAt(key_addr, green);
       }
 
       // If we triggered chatter detection ever on this key
       else if (state[keynum].bad == 1) {
-        Kaleidoscope.device().setCrgbAt(key_addr, red);
+        Runtime.device().setCrgbAt(key_addr, red);
       } else if (state[keynum].tested == 0) {
-        Kaleidoscope.device().setCrgbAt(key_addr, yellow);
+        Runtime.device().setCrgbAt(key_addr, yellow);
       }
       // If the key is not currently pressed and was not just released and is not marked bad
-      else if (! Kaleidoscope.device().isKeyswitchPressed(key_addr)) {
-        Kaleidoscope.device().setCrgbAt(key_addr, blue);
+      else if (! Runtime.device().isKeyswitchPressed(key_addr)) {
+        Runtime.device().setCrgbAt(key_addr, blue);
       }
     }
     ::LEDControl.syncLeds();
@@ -124,7 +125,7 @@ void HardwareTestMode::runTests() {
   // out and send a new report
   kaleidoscope::hid::releaseAllKeys();
   kaleidoscope::hid::sendKeyboardReport();
-  Kaleidoscope.device().enableHardwareTestMode();
+  Runtime.device().enableHardwareTestMode();
   testLeds();
   testMatrix();
 }

--- a/src/kaleidoscope/plugin/HardwareTestMode.h
+++ b/src/kaleidoscope/plugin/HardwareTestMode.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <Arduino.h>
-#include "Kaleidoscope.h"
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/Heatmap.cpp
+++ b/src/kaleidoscope/plugin/Heatmap.cpp
@@ -15,9 +15,10 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Heatmap.h>
 #include <Kaleidoscope-LEDControl.h>
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -38,7 +39,7 @@ Heatmap::TransientLEDMode::TransientLEDMode(const Heatmap *parent)
     // max of heatmap_ (we divide by it so we start at 1)
     highest_(1),
     // last heatmap computation time
-    last_heatmap_comp_time_(Kaleidoscope.millisAtCycleStart())
+    last_heatmap_comp_time_(Runtime.millisAtCycleStart())
 {}
 
 cRGB Heatmap::TransientLEDMode::computeColor(float v) {
@@ -133,7 +134,7 @@ void Heatmap::TransientLEDMode::resetMap() {
 }
 
 EventHandlerResult Heatmap::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return EventHandlerResult::OK;
 
   // this methode is called frequently by Kaleidoscope
@@ -175,7 +176,7 @@ EventHandlerResult Heatmap::TransientLEDMode::onKeyswitchEvent(Key &mapped_key, 
 }
 
 EventHandlerResult Heatmap::beforeEachCycle() {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return EventHandlerResult::OK;
 
   if (::LEDControl.get_mode_index() != led_mode_id_)
@@ -201,19 +202,19 @@ EventHandlerResult Heatmap::TransientLEDMode::beforeEachCycle() {
 }
 
 void Heatmap::TransientLEDMode::update(void) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return;
 
   // this methode is called frequently by the LEDControl::loopHook
 
   // do nothing if the update interval hasn't elapsed since the previous update
-  if (!Kaleidoscope.hasTimeExpired(last_heatmap_comp_time_, update_delay))
+  if (!Runtime.hasTimeExpired(last_heatmap_comp_time_, update_delay))
     return;
   // do the heatmap computing
   // (update_delay milliseconds elapsed since last_heatmap_comp_time)
 
   // schedule the next heatmap computing
-  last_heatmap_comp_time_ = Kaleidoscope.millisAtCycleStart();
+  last_heatmap_comp_time_ = Runtime.millisAtCycleStart();
 
   // for each key
   for (auto key_addr : KeyAddr::all()) {

--- a/src/kaleidoscope/plugin/Heatmap.h
+++ b/src/kaleidoscope/plugin/Heatmap.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-LEDControl.h>
 
 namespace kaleidoscope {
@@ -57,7 +57,7 @@ class Heatmap : public Plugin,
 
    private:
 
-    uint16_t heatmap_[Kaleidoscope.device().numKeys()];
+    uint16_t heatmap_[Runtime.device().numKeys()];
     uint16_t highest_;
     uint16_t last_heatmap_comp_time_;
 

--- a/src/kaleidoscope/plugin/HostOS-Focus.h
+++ b/src/kaleidoscope/plugin/HostOS-Focus.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/HostOS.cpp
+++ b/src/kaleidoscope/plugin/HostOS.cpp
@@ -33,15 +33,15 @@ EventHandlerResult HostOS::onSetup(void) {
     return EventHandlerResult::OK;
   }
 
-  os_ = (hostos::Type)Kaleidoscope.storage().read(eeprom_slice_);
+  os_ = (hostos::Type)Runtime.storage().read(eeprom_slice_);
 
   return EventHandlerResult::OK;
 }
 
 void HostOS::os(hostos::Type new_os) {
   os_ = new_os;
-  Kaleidoscope.storage().update(eeprom_slice_, os_);
-  Kaleidoscope.storage().commit();
+  Runtime.storage().update(eeprom_slice_, os_);
+  Runtime.storage().commit();
 }
 
 }

--- a/src/kaleidoscope/plugin/HostOS.h
+++ b/src/kaleidoscope/plugin/HostOS.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/HostPowerManagement.cpp
+++ b/src/kaleidoscope/plugin/HostPowerManagement.cpp
@@ -15,7 +15,7 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-HostPowerManagement.h>
 #include <Kaleidoscope-LEDControl.h>
 

--- a/src/kaleidoscope/plugin/HostPowerManagement.h
+++ b/src/kaleidoscope/plugin/HostPowerManagement.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 #define _DEPRECATED_MESSAGE_ENABLEWAKEUP                                    \
   "The HostPowerManagement.enableWakeup() call is not necessary anymore,\n" \

--- a/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -37,7 +37,7 @@ void IdleLEDs::setIdleTimeoutSeconds(uint32_t new_limit) {
 
 EventHandlerResult IdleLEDs::beforeEachCycle() {
   if (!::LEDControl.paused &&
-      Kaleidoscope.hasTimeExpired(start_time_, idle_time_limit)) {
+      Runtime.hasTimeExpired(start_time_, idle_time_limit)) {
     ::LEDControl.set_all_leds_to(CRGB(0, 0, 0));
     ::LEDControl.syncLeds();
 
@@ -54,7 +54,7 @@ EventHandlerResult IdleLEDs::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr,
     ::LEDControl.refreshAll();
   }
 
-  start_time_ = Kaleidoscope.millisAtCycleStart();
+  start_time_ = Runtime.millisAtCycleStart();
 
   return EventHandlerResult::OK;
 }
@@ -67,7 +67,7 @@ EventHandlerResult PersistentIdleLEDs::onSetup() {
   // If idleTime is max, assume that EEPROM is uninitialized, and store the
   // defaults.
   uint16_t idle_time;
-  Kaleidoscope.storage().get(settings_base_, idle_time);
+  Runtime.storage().get(settings_base_, idle_time);
   if (idle_time == 0xffff) {
     idle_time = idle_time_limit;
   }
@@ -80,8 +80,8 @@ void PersistentIdleLEDs::setIdleTimeoutSeconds(uint32_t new_limit) {
   IdleLEDs::setIdleTimeoutSeconds(new_limit);
 
   uint16_t stored_limit = (uint16_t)new_limit;
-  Kaleidoscope.storage().put(settings_base_, stored_limit);
-  Kaleidoscope.storage().commit();
+  Runtime.storage().put(settings_base_, stored_limit);
+  Runtime.storage().commit();
 }
 
 EventHandlerResult PersistentIdleLEDs::onFocusEvent(const char *command) {

--- a/src/kaleidoscope/plugin/IdleLEDs.h
+++ b/src/kaleidoscope/plugin/IdleLEDs.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/LED-ActiveLayerColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveLayerColor.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope-LED-ActiveLayerColor.h>
+#include "kaleidoscope/layers.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -45,7 +46,7 @@ cRGB LEDActiveLayerColorEffect::TransientLEDMode::getActiveColor() {
 }
 
 void LEDActiveLayerColorEffect::TransientLEDMode::onActivate(void) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return;
 
   active_color_ = getActiveColor();

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -18,6 +18,7 @@
 #include <Kaleidoscope-LED-ActiveModColor.h>
 #include <Kaleidoscope-OneShot.h>
 #include <kaleidoscope/hid.h>
+#include "kaleidoscope/layers.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -33,7 +34,7 @@ cRGB ActiveModColorEffect::highlight_color = (cRGB) {
 cRGB ActiveModColorEffect::sticky_color = CRGB(160, 0, 0);
 
 EventHandlerResult ActiveModColorEffect::onLayerChange() {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return EventHandlerResult::OK;
 
   mod_key_count_ = 0;

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.h
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-LEDControl.h>
 
 #define MAX_MODS_PER_LAYER 16

--- a/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
@@ -64,7 +64,7 @@ static const uint16_t alphabet[] PROGMEM = {
 cRGB AlphaSquare::color = {0x80, 0x80, 0x80};
 
 void AlphaSquare::display(Key key, KeyAddr key_addr, cRGB key_color) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return;
 
   if (key < Key_A || key > Key_0)
@@ -81,7 +81,7 @@ void AlphaSquare::display(Key key, KeyAddr key_addr) {
 }
 
 void AlphaSquare::display(uint16_t symbol, KeyAddr key_addr, cRGB key_color) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return;
 
   for (uint8_t r = 0; r < 4; r++) {
@@ -106,7 +106,7 @@ void AlphaSquare::display(uint16_t symbol, KeyAddr key_addr) {
 bool AlphaSquare::isSymbolPart(Key key,
                                KeyAddr displayLedAddr,
                                KeyAddr key_addr) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return false;
 
   if (key < Key_A || key > Key_0)
@@ -121,7 +121,7 @@ bool AlphaSquare::isSymbolPart(Key key,
 bool AlphaSquare::isSymbolPart(uint16_t symbol,
                                KeyAddr displayLedAddr,
                                KeyAddr key_addr) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return false;
 
   for (uint8_t r = 0; r < 4; r++) {

--- a/src/kaleidoscope/plugin/LED-AlphaSquare.h
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-LEDControl.h>
 
 #define SYM4x4(                                                   \

--- a/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope-LED-AlphaSquare.h>
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -28,16 +29,16 @@ AlphaSquareEffect::TransientLEDMode::TransientLEDMode(AlphaSquareEffect */*paren
 {}
 
 void AlphaSquareEffect::TransientLEDMode::update(void) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return;
 
   if (last_key_left_ != Key_NoKey &&
-      Kaleidoscope.hasTimeExpired(start_time_left_, length)) {
+      Runtime.hasTimeExpired(start_time_left_, length)) {
     ::AlphaSquare.clear(last_key_left_);
     last_key_left_ = Key_NoKey;
   }
   if (last_key_right_ != Key_NoKey &&
-      Kaleidoscope.hasTimeExpired(start_time_right_, length)) {
+      Runtime.hasTimeExpired(start_time_right_, length)) {
     ::AlphaSquare.clear(last_key_right_, 10);
     last_key_right_ = Key_NoKey;
   }
@@ -48,12 +49,12 @@ void AlphaSquareEffect::TransientLEDMode::refreshAt(KeyAddr key_addr) {
   uint8_t display_col = 2;
   Key key = last_key_left_;
 
-  if (key_addr.col() < Kaleidoscope.device().matrix_columns / 2) {
-    timed_out = Kaleidoscope.hasTimeExpired(start_time_left_, length);
+  if (key_addr.col() < Runtime.device().matrix_columns / 2) {
+    timed_out = Runtime.hasTimeExpired(start_time_left_, length);
   } else {
     key = last_key_right_;
     display_col = 10;
-    timed_out = Kaleidoscope.hasTimeExpired(start_time_right_, length);
+    timed_out = Runtime.hasTimeExpired(start_time_right_, length);
   }
 
   if (!::AlphaSquare.isSymbolPart(key, KeyAddr(0, display_col), key_addr) || timed_out)
@@ -61,7 +62,7 @@ void AlphaSquareEffect::TransientLEDMode::refreshAt(KeyAddr key_addr) {
 }
 
 EventHandlerResult AlphaSquareEffect::onKeyswitchEvent(Key &mappedKey, KeyAddr key_addr, uint8_t keyState) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return EventHandlerResult::OK;
 
   if (::LEDControl.get_mode_index() != led_mode_id_)
@@ -81,13 +82,13 @@ EventHandlerResult AlphaSquareEffect::onKeyswitchEvent(Key &mappedKey, KeyAddr k
 
   Key prev_key = this_led_mode->last_key_left_;
 
-  if (key_addr.col() < Kaleidoscope.device().matrix_columns / 2) {
+  if (key_addr.col() < Runtime.device().matrix_columns / 2) {
     this_led_mode->last_key_left_ = mappedKey;
-    this_led_mode->start_time_left_ = Kaleidoscope.millisAtCycleStart();
+    this_led_mode->start_time_left_ = Runtime.millisAtCycleStart();
   } else {
     prev_key = this_led_mode->last_key_right_;
     this_led_mode->last_key_right_ = mappedKey;
-    this_led_mode->start_time_right_ = Kaleidoscope.millisAtCycleStart();
+    this_led_mode->start_time_right_ = Runtime.millisAtCycleStart();
     display_col = 10;
   }
 

--- a/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-LEDControl.h>
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/plugin/LED-Palette-Theme.h
+++ b/src/kaleidoscope/plugin/LED-Palette-Theme.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-LEDControl.h>
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/plugin/LED-Stalker.cpp
+++ b/src/kaleidoscope/plugin/LED-Stalker.cpp
@@ -17,6 +17,7 @@
 
 #include <Kaleidoscope-LED-Stalker.h>
 #include <Kaleidoscope-LEDControl.h>
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -34,7 +35,7 @@ StalkerEffect::TransientLEDMode::TransientLEDMode(const StalkerEffect *parent)
 {}
 
 EventHandlerResult StalkerEffect::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return EventHandlerResult::OK;
 
   if (!key_addr.isValid())
@@ -51,13 +52,13 @@ EventHandlerResult StalkerEffect::onKeyswitchEvent(Key &mapped_key, KeyAddr key_
 }
 
 void StalkerEffect::TransientLEDMode::update(void) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return;
 
   if (!parent_->variant)
     return;
 
-  if (!Kaleidoscope.hasTimeExpired(step_start_time_, parent_->step_length))
+  if (!Runtime.hasTimeExpired(step_start_time_, parent_->step_length))
     return;
 
   for (auto key_addr : KeyAddr::all()) {
@@ -72,7 +73,7 @@ void StalkerEffect::TransientLEDMode::update(void) {
       ::LEDControl.setCrgbAt(key_addr, parent_->inactive_color);
   }
 
-  step_start_time_ = Kaleidoscope.millisAtCycleStart();
+  step_start_time_ = Runtime.millisAtCycleStart();
 }
 
 namespace stalker {

--- a/src/kaleidoscope/plugin/LED-Stalker.h
+++ b/src/kaleidoscope/plugin/LED-Stalker.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-LEDControl.h>
 
 #define STALKER(v, ...) ({static kaleidoscope::plugin::stalker::v _effect __VA_ARGS__; &_effect;})
@@ -61,7 +61,7 @@ class StalkerEffect : public Plugin,
     const StalkerEffect *parent_;
 
     uint16_t step_start_time_;
-    uint8_t map_[Kaleidoscope.device().numKeys()];
+    uint8_t map_[Runtime.device().numKeys()];
 
     friend class StalkerEffect;
   };

--- a/src/kaleidoscope/plugin/LED-Wavepool.cpp
+++ b/src/kaleidoscope/plugin/LED-Wavepool.cpp
@@ -19,6 +19,7 @@
 #ifdef ARDUINO_AVR_MODEL01
 
 #include <Kaleidoscope-LED-Wavepool.h>
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -31,7 +32,7 @@ uint16_t WavepoolEffect::idle_timeout = 5000;  // 5 seconds
 int16_t WavepoolEffect::ripple_hue = WavepoolEffect::rainbow_hue; // automatic hue
 
 // map native keyboard coordinates (16x4) into geometric space (14x5)
-PROGMEM const uint8_t WavepoolEffect::TransientLEDMode::rc2pos[Kaleidoscope.device().numKeys()] = {
+PROGMEM const uint8_t WavepoolEffect::TransientLEDMode::rc2pos[Runtime.device().numKeys()] = {
   0,  1,  2,  3,  4,  5,  6,     59, 66,    7,  8,  9, 10, 11, 12, 13,
   14, 15, 16, 17, 18, 19, 34,    60, 65,   35, 22, 23, 24, 25, 26, 27,
   28, 29, 30, 31, 32, 33, 48,    61, 64,   49, 36, 37, 38, 39, 40, 41,
@@ -79,14 +80,14 @@ void WavepoolEffect::TransientLEDMode::raindrop(uint8_t x, uint8_t y, int8_t *pa
 uint8_t WavepoolEffect::TransientLEDMode::wp_rand() {
   static intptr_t offset = 0x400;
   offset = ((offset + 1) & 0x4fff) | 0x400;
-  return (Kaleidoscope.millisAtCycleStart() / MS_PER_FRAME) + pgm_read_byte((const uint8_t *)offset);
+  return (Runtime.millisAtCycleStart() / MS_PER_FRAME) + pgm_read_byte((const uint8_t *)offset);
 }
 
 void WavepoolEffect::TransientLEDMode::update(void) {
 
   // limit the frame rate; one frame every 64 ms
   static uint8_t prev_time = 0;
-  uint8_t now = Kaleidoscope.millisAtCycleStart() / MS_PER_FRAME;
+  uint8_t now = Runtime.millisAtCycleStart() / MS_PER_FRAME;
   if (now != prev_time) {
     prev_time = now;
   } else {

--- a/src/kaleidoscope/plugin/LED-Wavepool.h
+++ b/src/kaleidoscope/plugin/LED-Wavepool.h
@@ -20,7 +20,7 @@
 
 #ifdef ARDUINO_AVR_MODEL01
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-LEDControl.h>
 
 #define WP_WID 14
@@ -64,7 +64,7 @@ class WavepoolEffect : public Plugin,
     uint8_t frames_since_event_;
     int8_t surface_[2][WP_WID * WP_HGT];
     uint8_t page_;
-    static PROGMEM const uint8_t rc2pos[Kaleidoscope.device().numKeys()];
+    static PROGMEM const uint8_t rc2pos[Runtime.device().numKeys()];
 
     void raindrop(uint8_t x, uint8_t y, int8_t *page);
     uint8_t wp_rand();

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -17,6 +17,7 @@
 #include "Kaleidoscope-LEDControl.h"
 #include "Kaleidoscope-FocusSerial.h"
 #include "kaleidoscope_internal/LEDModeManager.h"
+#include "kaleidoscope/keyswitch_state.h"
 
 using namespace kaleidoscope::internal;
 
@@ -87,7 +88,7 @@ void LEDControl::activate(LEDModeInterface *plugin) {
 }
 
 void LEDControl::set_all_leds_to(uint8_t r, uint8_t g, uint8_t b) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return;
 
   cRGB color;
@@ -98,31 +99,31 @@ void LEDControl::set_all_leds_to(uint8_t r, uint8_t g, uint8_t b) {
 }
 
 void LEDControl::set_all_leds_to(cRGB color) {
-  for (auto led_index : Kaleidoscope.device().LEDs().all()) {
+  for (auto led_index : Runtime.device().LEDs().all()) {
     setCrgbAt(led_index.offset(), color);
   }
 }
 
 void LEDControl::setCrgbAt(uint8_t led_index, cRGB crgb) {
-  Kaleidoscope.device().setCrgbAt(led_index, crgb);
+  Runtime.device().setCrgbAt(led_index, crgb);
 }
 
 void LEDControl::setCrgbAt(KeyAddr key_addr, cRGB color) {
-  Kaleidoscope.device().setCrgbAt(key_addr, color);
+  Runtime.device().setCrgbAt(key_addr, color);
 }
 
 cRGB LEDControl::getCrgbAt(uint8_t led_index) {
-  return Kaleidoscope.device().getCrgbAt(led_index);
+  return Runtime.device().getCrgbAt(led_index);
 }
 cRGB LEDControl::getCrgbAt(KeyAddr key_addr) {
-  return Kaleidoscope.device().getCrgbAt(Kaleidoscope.device().getLedIndex(key_addr));
+  return Runtime.device().getCrgbAt(Runtime.device().getLedIndex(key_addr));
 }
 
 void LEDControl::syncLeds(void) {
   if (paused)
     return;
 
-  Kaleidoscope.device().syncLeds();
+  Runtime.device().syncLeds();
 }
 
 kaleidoscope::EventHandlerResult LEDControl::onSetup() {
@@ -156,7 +157,7 @@ kaleidoscope::EventHandlerResult LEDControl::beforeReportingState(void) {
   if (paused)
     return kaleidoscope::EventHandlerResult::OK;
 
-  if (Kaleidoscope.hasTimeExpired(syncTimer, syncDelay)) {
+  if (Runtime.hasTimeExpired(syncTimer, syncDelay)) {
     syncLeds();
     syncTimer += syncDelay;
     update();
@@ -173,7 +174,7 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
     THEME,
   } subCommand;
 
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return EventHandlerResult::OK;
 
   if (::Focus.handleHelp(command, PSTR("led.at\n"
@@ -241,7 +242,7 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
   }
   case THEME: {
     if (::Focus.isEOL()) {
-      for (auto led_index : Kaleidoscope.device().LEDs().all()) {
+      for (auto led_index : Runtime.device().LEDs().all()) {
         cRGB c = ::LEDControl.getCrgbAt(led_index.offset());
 
         ::Focus.send(c);
@@ -249,7 +250,7 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
       break;
     }
 
-    for (auto led_index : Kaleidoscope.device().LEDs().all()) {
+    for (auto led_index : Runtime.device().LEDs().all()) {
       if (::Focus.isEOL()) {
         break;
       }

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -16,7 +16,8 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/plugin/LEDMode.h"
 
 #define LED_TOGGLE   B00000001  // Synthetic, internal
 
@@ -41,13 +42,13 @@ class LEDControl : public kaleidoscope::Plugin {
   static void prev_mode(void);
   static void setup(void);
   static void update(void) {
-    if (!Kaleidoscope.has_leds)
+    if (!Runtime.has_leds)
       return;
 
     cur_led_mode_->update();
   }
   static void refreshAt(KeyAddr key_addr) {
-    if (!Kaleidoscope.has_leds)
+    if (!Runtime.has_leds)
       return;
 
     cur_led_mode_->refreshAt(key_addr);
@@ -69,7 +70,7 @@ class LEDControl : public kaleidoscope::Plugin {
   }
 
   static void refreshAll() {
-    if (!Kaleidoscope.has_leds)
+    if (!Runtime.has_leds)
       return;
 
     if (paused)

--- a/src/kaleidoscope/plugin/LEDControl/LEDUtils.cpp
+++ b/src/kaleidoscope/plugin/LEDControl/LEDUtils.cpp
@@ -18,6 +18,9 @@
 
 cRGB
 breath_compute(uint8_t hue, uint8_t saturation, uint8_t phase_offset) {
+
+  using kaleidoscope::Runtime;
+
   // This code is adapted from FastLED lib8tion.h as of dd5d96c6b289cb6b4b891748a4aeef3ddceaf0e6
   // Eventually, we should consider just using FastLED
 
@@ -35,7 +38,7 @@ breath_compute(uint8_t hue, uint8_t saturation, uint8_t phase_offset) {
 
   // We do a bit shift here instead of division to ensure that there's no discontinuity
   // in the output brightness when the integer overflows.
-  uint8_t i = ((uint16_t)Kaleidoscope.millisAtCycleStart() + (phase_offset << 4)) >> 4;
+  uint8_t i = ((uint16_t)Runtime.millisAtCycleStart() + (phase_offset << 4)) >> 4;
 
   if (i & 0x80) {
     i = 255 - i;

--- a/src/kaleidoscope/plugin/LEDControl/LEDUtils.h
+++ b/src/kaleidoscope/plugin/LEDControl/LEDUtils.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 cRGB breath_compute(uint8_t hue = 170, uint8_t saturation = 255, uint8_t phase_offset = 0);
 cRGB hsvToRgb(uint16_t h, uint16_t s, uint16_t v);

--- a/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Kaleidoscope-LEDEffect-BootAnimation.h"
+#include "kaleidoscope/layers.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -44,7 +45,7 @@ EventHandlerResult BootAnimationEffect::onSetup() {
 }
 
 EventHandlerResult BootAnimationEffect::afterEachCycle() {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return EventHandlerResult::OK;
 
   //If already done or we're not in a ready state, bail
@@ -65,7 +66,7 @@ EventHandlerResult BootAnimationEffect::afterEachCycle() {
     }
   }
 
-  if (Kaleidoscope.hasTimeExpired(start_time_, timeout)) {
+  if (Runtime.hasTimeExpired(start_time_, timeout)) {
     current_index_++;
     if (current_index_ == sizeof(greeting_))
       done_ = true;

--- a/src/kaleidoscope/plugin/LEDEffect-BootAnimation.h
+++ b/src/kaleidoscope/plugin/LEDEffect-BootAnimation.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "Kaleidoscope.h"
+#include "kaleidoscope/Runtime.h"
 #include "Kaleidoscope-LEDControl.h"
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Kaleidoscope-LEDEffect-BootGreeting.h"
+#include "kaleidoscope/layers.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -59,7 +60,7 @@ EventHandlerResult BootGreetingEffect::onSetup() {
 }
 
 EventHandlerResult BootGreetingEffect::afterEachCycle() {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return EventHandlerResult::OK;
 
   //If already done or we're not in a ready state, bail
@@ -68,7 +69,7 @@ EventHandlerResult BootGreetingEffect::afterEachCycle() {
   }
 
   //Only run for 'timeout' milliseconds
-  if (Kaleidoscope.hasTimeExpired(start_time, timeout)) {
+  if (Runtime.hasTimeExpired(start_time, timeout)) {
     done_ = true;
     ::LEDControl.refreshAt(key_addr_);
     return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/LEDEffect-Breathe.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Breathe.cpp
@@ -19,10 +19,10 @@
 namespace kaleidoscope {
 namespace plugin {
 void LEDBreatheEffect::TransientLEDMode::update(void) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return;
 
-  if (!Kaleidoscope.hasTimeExpired(last_update_, update_interval_))
+  if (!Runtime.hasTimeExpired(last_update_, update_interval_))
     return;
   last_update_ += update_interval_;
 

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
@@ -20,10 +20,10 @@ namespace kaleidoscope {
 namespace plugin {
 
 void LEDChaseEffect::TransientLEDMode::update(void) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return;
 
-  if (!Kaleidoscope.hasTimeExpired(last_update_, parent_->update_delay_)) {
+  if (!Runtime.hasTimeExpired(last_update_, parent_->update_delay_)) {
     return;
   }
   last_update_ += parent_->update_delay_;
@@ -38,7 +38,7 @@ void LEDChaseEffect::TransientLEDMode::update(void) {
   // Since it's an unsigned integer, even when it would have a value below zero,
   // it underflows and so one test is good for both ends of the range.
   ::LEDControl.setCrgbAt(pos_, CRGB(0, 0, 0));
-  if (Kaleidoscope.device().LEDs().isValid(pos2))
+  if (Runtime.device().LEDs().isValid(pos2))
     ::LEDControl.setCrgbAt(pos2, CRGB(0, 0, 0));
 
   // Next, we adjust the red light's position. If the direction hasn't changed (the red
@@ -48,18 +48,18 @@ void LEDChaseEffect::TransientLEDMode::update(void) {
   // will be out of bounds. The simplest way to do this is to assign it a value that is
   // known to be invalid (LED_COUNT).
   pos_ += direction_;
-  if (Kaleidoscope.device().LEDs().isValid(pos_)) {
+  if (Runtime.device().LEDs().isValid(pos_)) {
     pos2 += direction_;
   } else {
     direction_ = -direction_;
     pos_ += direction_;
-    pos2 = Kaleidoscope.device().led_count;
+    pos2 = Runtime.device().led_count;
   }
 
   // Last, we turn on the LEDs at their new positions. As before, the blue light (pos2) is
   // only set if it's in the valid LED range.
   ::LEDControl.setCrgbAt(pos_, CRGB(255, 0, 0));
-  if (Kaleidoscope.device().LEDs().isValid(pos2))
+  if (Runtime.device().LEDs().isValid(pos2))
     ::LEDControl.setCrgbAt(pos2, CRGB(0, 0, 255));
 }
 

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.h
@@ -48,7 +48,7 @@ class LEDChaseEffect : public Plugin,
     // members of their parent class. Most LED modes can do without.
     //
     TransientLEDMode(const LEDChaseEffect *parent)
-      : parent_(parent), last_update_(Kaleidoscope.millisAtCycleStart()) {}
+      : parent_(parent), last_update_(Runtime.millisAtCycleStart()) {}
 
    protected:
 

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
@@ -20,11 +20,11 @@ namespace kaleidoscope {
 namespace plugin {
 
 void LEDRainbowEffect::TransientLEDMode::update(void) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return;
 
-  if (!Kaleidoscope.hasTimeExpired(rainbow_last_update,
-                                   parent_->rainbow_update_delay)) {
+  if (!Runtime.hasTimeExpired(rainbow_last_update,
+                              parent_->rainbow_update_delay)) {
     return;
   } else {
     rainbow_last_update += parent_->rainbow_update_delay;
@@ -51,17 +51,17 @@ void LEDRainbowEffect::update_delay(byte delay) {
 // ---------
 
 void LEDRainbowWaveEffect::TransientLEDMode::update(void) {
-  if (!Kaleidoscope.has_leds)
+  if (!Runtime.has_leds)
     return;
 
-  if (!Kaleidoscope.hasTimeExpired(rainbow_last_update,
-                                   parent_->rainbow_update_delay)) {
+  if (!Runtime.hasTimeExpired(rainbow_last_update,
+                              parent_->rainbow_update_delay)) {
     return;
   } else {
     rainbow_last_update += parent_->rainbow_update_delay;
   }
 
-  for (auto led_index : Kaleidoscope.device().LEDs().all()) {
+  for (auto led_index : Runtime.device().LEDs().all()) {
     uint16_t led_hue = rainbow_hue + 16 * (led_index.offset() / 4);
     // We want led_hue to be capped at 255, but we do not want to clip it to
     // that, because that does not result in a nice animation. Instead, when it

--- a/src/kaleidoscope/plugin/LEDMode.h
+++ b/src/kaleidoscope/plugin/LEDMode.h
@@ -110,7 +110,7 @@ class LEDMode : public kaleidoscope::Plugin,
 
   /** Plugin initialization.
    *
-   * Called via `Kaleidoscope.use()`, registers the LED mode, and does the
+   * Called via `Runtime.use()`, registers the LED mode, and does the
    * necessary initialization steps. Calls @ref setup at the end.
    */
   kaleidoscope::EventHandlerResult onSetup() {

--- a/src/kaleidoscope/plugin/Leader.cpp
+++ b/src/kaleidoscope/plugin/Leader.cpp
@@ -16,6 +16,9 @@
  */
 
 #include <Kaleidoscope-Leader.h>
+#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/key_events.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -94,7 +97,7 @@ EventHandlerResult Leader::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, u
 
     if (keyToggledOff(keyState)) {
       // not active, but a leader key = start the sequence on key release!
-      start_time_ = Kaleidoscope.millisAtCycleStart();
+      start_time_ = Runtime.millisAtCycleStart();
       sequence_pos_ = 0;
       sequence_[sequence_pos_] = mapped_key;
     }
@@ -113,7 +116,7 @@ EventHandlerResult Leader::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, u
       return EventHandlerResult::OK;
     }
 
-    start_time_ = Kaleidoscope.millisAtCycleStart();
+    start_time_ = Runtime.millisAtCycleStart();
     sequence_[sequence_pos_] = mapped_key;
     action_index = lookup();
 
@@ -143,7 +146,7 @@ EventHandlerResult Leader::afterEachCycle() {
   if (!isActive())
     return EventHandlerResult::OK;
 
-  if (Kaleidoscope.hasTimeExpired(start_time_, time_out))
+  if (Runtime.hasTimeExpired(start_time_, time_out))
     reset();
 
   return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/Leader.h
+++ b/src/kaleidoscope/plugin/Leader.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
 
 #define LEADER_MAX_SEQUENCE_LENGTH 4

--- a/src/kaleidoscope/plugin/Macros.cpp
+++ b/src/kaleidoscope/plugin/Macros.cpp
@@ -16,6 +16,8 @@
 
 #include "Kaleidoscope-Macros.h"
 #include "kaleidoscope/hid.h"
+#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/key_events.h"
 
 __attribute__((weak))
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {

--- a/src/kaleidoscope/plugin/Macros.h
+++ b/src/kaleidoscope/plugin/Macros.h
@@ -16,10 +16,12 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 #include "kaleidoscope/plugin/Macros/MacroKeyDefs.h"
 #include "kaleidoscope/plugin/Macros/MacroSteps.h"
+#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/key_events.h"
 
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState);
 
@@ -61,7 +63,7 @@ class Macros_ : public kaleidoscope::Plugin {
 
   /* What follows below, is a bit of template magic that allows us to use
      Macros.type() with any number of arguments, without having to use a
-     sentinel. See the comments on Kaleidoscope.use() for more details - this is
+     sentinel. See the comments on Runtime.use() for more details - this is
      the same trick.
    */
   inline const macro_t *type() {

--- a/src/kaleidoscope/plugin/MagicCombo.cpp
+++ b/src/kaleidoscope/plugin/MagicCombo.cpp
@@ -34,19 +34,19 @@ EventHandlerResult MagicCombo::beforeReportingState() {
       if (comboKey == 0)
         break;
 
-      match &= Kaleidoscope.device().isKeyswitchPressed(comboKey);
+      match &= Runtime.device().isKeyswitchPressed(comboKey);
       if (!match)
         break;
     }
 
-    if (j != Kaleidoscope.device().pressedKeyswitchCount())
+    if (j != Runtime.device().pressedKeyswitchCount())
       match = false;
 
-    if (match && Kaleidoscope.hasTimeExpired(start_time_, min_interval)) {
+    if (match && Runtime.hasTimeExpired(start_time_, min_interval)) {
       ComboAction action = (ComboAction) pgm_read_ptr((void const **) & (magiccombo::combos[i].action));
 
       (*action)(i);
-      start_time_ = Kaleidoscope.millisAtCycleStart();
+      start_time_ = Runtime.millisAtCycleStart();
     }
   }
 

--- a/src/kaleidoscope/plugin/MagicCombo.h
+++ b/src/kaleidoscope/plugin/MagicCombo.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 #define MAX_COMBO_LENGTH 5
 

--- a/src/kaleidoscope/plugin/Model01-TestMode.h
+++ b/src/kaleidoscope/plugin/Model01-TestMode.h
@@ -23,7 +23,7 @@
 #ifdef ARDUINO_AVR_MODEL01
 
 #include <Arduino.h>
-#include "Kaleidoscope.h"
+#include "kaleidoscope/Runtime.h"
 #include "kaleidoscope_internal/deprecations.h"
 
 #define _DEPRECATED_MESSAGE_MODEL01_TESTMODE                                      \

--- a/src/kaleidoscope/plugin/MouseKeys.cpp
+++ b/src/kaleidoscope/plugin/MouseKeys.cpp
@@ -16,8 +16,10 @@
 
 #include <Arduino.h>
 
-#include "Kaleidoscope.h"
+#include "kaleidoscope/Runtime.h"
 #include "Kaleidoscope-MouseKeys.h"
+#include "kaleidoscope/hid.h"
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -46,10 +48,10 @@ void MouseKeys_::setSpeedLimit(uint8_t speed_limit) {
 }
 
 void MouseKeys_::scrollWheel(uint8_t keyCode) {
-  if (!Kaleidoscope.hasTimeExpired(wheel_start_time_, wheelDelay))
+  if (!Runtime.hasTimeExpired(wheel_start_time_, wheelDelay))
     return;
 
-  wheel_start_time_ = Kaleidoscope.millisAtCycleStart();
+  wheel_start_time_ = Runtime.millisAtCycleStart();
 
   if (keyCode & KEY_MOUSE_UP)
     kaleidoscope::hid::moveMouse(0, 0, wheelSpeed);
@@ -75,18 +77,18 @@ EventHandlerResult MouseKeys_::beforeReportingState() {
     return EventHandlerResult::OK;
   }
 
-  if (!Kaleidoscope.hasTimeExpired(move_start_time_, speedDelay))
+  if (!Runtime.hasTimeExpired(move_start_time_, speedDelay))
     return EventHandlerResult::OK;
 
-  move_start_time_ = Kaleidoscope.millisAtCycleStart();
+  move_start_time_ = Runtime.millisAtCycleStart();
 
   int8_t moveX = 0, moveY = 0;
 
-  if (Kaleidoscope.hasTimeExpired(accel_start_time_, accelDelay)) {
+  if (Runtime.hasTimeExpired(accel_start_time_, accelDelay)) {
     if (MouseWrapper.accelStep < 255 - accelSpeed) {
       MouseWrapper.accelStep += accelSpeed;
     }
-    accel_start_time_ = Kaleidoscope.millisAtCycleStart();
+    accel_start_time_ = Runtime.millisAtCycleStart();
   }
 
   if (mouseMoveIntent & KEY_MOUSE_UP)
@@ -124,9 +126,9 @@ EventHandlerResult MouseKeys_::onKeyswitchEvent(Key &mappedKey, KeyAddr key_addr
     }
   } else if (!(mappedKey.getKeyCode() & KEY_MOUSE_WARP)) {
     if (keyToggledOn(keyState)) {
-      move_start_time_ = Kaleidoscope.millisAtCycleStart();
-      accel_start_time_ = Kaleidoscope.millisAtCycleStart();
-      wheel_start_time_ = Kaleidoscope.millisAtCycleStart() - wheelDelay;
+      move_start_time_ = Runtime.millisAtCycleStart();
+      accel_start_time_ = Runtime.millisAtCycleStart();
+      wheel_start_time_ = Runtime.millisAtCycleStart() - wheelDelay;
     }
     if (keyIsPressed(keyState)) {
       if (mappedKey.getKeyCode() & KEY_MOUSE_WHEEL) {

--- a/src/kaleidoscope/plugin/MouseKeys.h
+++ b/src/kaleidoscope/plugin/MouseKeys.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "Kaleidoscope.h"
+#include "kaleidoscope/Runtime.h"
 #include "kaleidoscope/plugin/MouseKeys/MouseKeyDefs.h"
 #include "kaleidoscope/plugin/MouseKeys/MouseWarpModes.h"
 #include "kaleidoscope/plugin/MouseKeys/MouseWrapper.h"

--- a/src/kaleidoscope/plugin/NumPad.cpp
+++ b/src/kaleidoscope/plugin/NumPad.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "Kaleidoscope-NumPad.h"
+#include "kaleidoscope/layers.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/OneShot.cpp
+++ b/src/kaleidoscope/plugin/OneShot.cpp
@@ -16,6 +16,8 @@
  */
 
 #include <Kaleidoscope-OneShot.h>
+#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/key_events.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -89,7 +91,7 @@ EventHandlerResult OneShot::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, 
     if (keyToggledOff(keyState)) {
       state_[idx].pressed = false;
     } else if (keyToggledOn(keyState)) {
-      start_time_ = Kaleidoscope.millisAtCycleStart();
+      start_time_ = Runtime.millisAtCycleStart();
       state_[idx].position = key_addr.toInt();
       state_[idx].pressed = true;
       state_[idx].active = true;
@@ -112,7 +114,7 @@ EventHandlerResult OneShot::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, 
     } else {
       if (keyToggledOff(keyState)) {
         state_[idx].pressed = false;
-        if (Kaleidoscope.hasTimeExpired(start_time_, hold_time_out)) {
+        if (Runtime.hasTimeExpired(start_time_, hold_time_out)) {
           cancelOneShot(idx);
           should_cancel_ = false;
         }
@@ -123,12 +125,12 @@ EventHandlerResult OneShot::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, 
 
         if (prev_key_ == mapped_key && isStickable(mapped_key)) {
           uint16_t dtto = (double_tap_time_out == -1) ? time_out : double_tap_time_out;
-          if (!Kaleidoscope.hasTimeExpired(start_time_, dtto)) {
+          if (!Runtime.hasTimeExpired(start_time_, dtto)) {
             state_[idx].sticky = true;
             prev_key_ = mapped_key;
           }
         } else {
-          start_time_ = Kaleidoscope.millisAtCycleStart();
+          start_time_ = Runtime.millisAtCycleStart();
 
           state_[idx].position = key_addr.toInt();
           state_[idx].active = true;

--- a/src/kaleidoscope/plugin/OneShot.h
+++ b/src/kaleidoscope/plugin/OneShot.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
 
 #define OSM(kc) Key(kaleidoscope::ranges::OSM_FIRST + (Key_ ## kc).getKeyCode() - Key_LeftControl.getKeyCode())
@@ -103,7 +103,7 @@ class OneShot : public kaleidoscope::Plugin {
     return key.getRaw() >= ranges::OS_FIRST && key.getRaw() <= ranges::OS_LAST;
   }
   static bool hasTimedOut() {
-    return Kaleidoscope.hasTimeExpired(start_time_, time_out);
+    return Runtime.hasTimeExpired(start_time_, time_out);
   }
 };
 }

--- a/src/kaleidoscope/plugin/PersistentLEDMode.cpp
+++ b/src/kaleidoscope/plugin/PersistentLEDMode.cpp
@@ -16,7 +16,7 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-PersistentLEDMode.h>
 #include <Kaleidoscope-LEDControl.h>
 #include <Kaleidoscope-EEPROM-Settings.h>
@@ -30,7 +30,7 @@ uint8_t PersistentLEDMode::cached_mode_index_;
 EventHandlerResult PersistentLEDMode::onSetup() {
   settings_base_ = ::EEPROMSettings.requestSlice(sizeof(cached_mode_index_));
 
-  Kaleidoscope.storage().get(settings_base_, cached_mode_index_);
+  Runtime.storage().get(settings_base_, cached_mode_index_);
 
   // If the index is max, assume an uninitialized EEPROM, and don't set the LED
   // mode. We don't change the cached index here, `onLEDModeChange()` will do
@@ -48,8 +48,8 @@ EventHandlerResult PersistentLEDMode::onLEDModeChange() {
     return EventHandlerResult::OK;
 
   cached_mode_index_ = ::LEDControl.get_mode_index();
-  Kaleidoscope.storage().put(settings_base_, cached_mode_index_);
-  Kaleidoscope.storage().commit();
+  Runtime.storage().put(settings_base_, cached_mode_index_);
+  Runtime.storage().commit();
   return EventHandlerResult::OK;
 }
 

--- a/src/kaleidoscope/plugin/PersistentLEDMode.h
+++ b/src/kaleidoscope/plugin/PersistentLEDMode.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/Qukeys.cpp
+++ b/src/kaleidoscope/plugin/Qukeys.cpp
@@ -18,9 +18,10 @@
 
 #include "kaleidoscope/plugin/Qukeys.h"
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
 #include "kaleidoscope/progmem_helpers.h"
+#include "kaleidoscope/layers.h"
 
 
 namespace kaleidoscope {
@@ -118,7 +119,7 @@ EventHandlerResult Qukeys::beforeReportingState() {
   // If we get here, that means that the first event in the queue is a qukey
   // press. All that's left to do is to check if it's been held long enough that
   // it has timed out.
-  if (Kaleidoscope.hasTimeExpired(event_queue_.timestamp(0), hold_timeout_)) {
+  if (Runtime.hasTimeExpired(event_queue_.timestamp(0), hold_timeout_)) {
     // If it's a SpaceCadet-type key, it takes on its primary value, otherwise
     // it takes on its secondary value.
     Key event_key = isModifierKey(queue_head_.primary_key) ?
@@ -356,7 +357,7 @@ bool Qukeys::releaseDelayed(uint16_t overlap_start,
   // here to make sure it doesn't overflow when we multiply by 100.
   uint32_t overlap_duration = overlap_end - overlap_start;
   uint32_t release_timeout = (overlap_duration * 100) / overlap_threshold_;
-  return !Kaleidoscope.hasTimeExpired(overlap_start, uint16_t(release_timeout));
+  return !Runtime.hasTimeExpired(overlap_start, uint16_t(release_timeout));
 }
 
 

--- a/src/kaleidoscope/plugin/Qukeys.h
+++ b/src/kaleidoscope/plugin/Qukeys.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
 #include "kaleidoscope/plugin/Qukeys/KeyAddrEventQueue.h"
 

--- a/src/kaleidoscope/plugin/Qukeys/KeyAddrEventQueue.h
+++ b/src/kaleidoscope/plugin/Qukeys/KeyAddrEventQueue.h
@@ -20,8 +20,9 @@
 #include <Arduino.h>
 //#include <assert.h>
 
-#include "kaleidoscope/Kaleidoscope.h"
+#include "kaleidoscope/Runtime.h"
 #include "kaleidoscope/KeyAddr.h"
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -85,7 +86,7 @@ class KeyAddrEventQueue {
   void append(KeyAddr k, uint8_t keyswitch_state) {
     // assert(length_ < _capacity);
     addrs_[length_]      = k;
-    timestamps_[length_] = Kaleidoscope.millisAtCycleStart();
+    timestamps_[length_] = Runtime.millisAtCycleStart();
     bitWrite(release_event_bits_, length_, keyToggledOff(keyswitch_state));
     ++length_;
   }

--- a/src/kaleidoscope/plugin/Redial.cpp
+++ b/src/kaleidoscope/plugin/Redial.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope-Redial.h>
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/Redial.h
+++ b/src/kaleidoscope/plugin/Redial.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
 
 #define Key_Redial Key(kaleidoscope::ranges::REDIAL)

--- a/src/kaleidoscope/plugin/ShapeShifter.h
+++ b/src/kaleidoscope/plugin/ShapeShifter.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/SpaceCadet.cpp
+++ b/src/kaleidoscope/plugin/SpaceCadet.cpp
@@ -17,6 +17,8 @@
 
 #include <Kaleidoscope-SpaceCadet.h>
 #include <kaleidoscope/hid.h>
+#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/key_events.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -119,7 +121,7 @@ EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, KeyAddr key_add
       if (mapped_key == map[i].input) {
         //The keypress was valid and a match. Mark it as flagged and reset the counter
         map[i].flagged = true;
-        map[i].start_time = Kaleidoscope.millisAtCycleStart();
+        map[i].start_time = Runtime.millisAtCycleStart();
 
         //yes, we found a valid key
         valid_key = true;
@@ -199,7 +201,7 @@ EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, KeyAddr key_add
   }
 
   //Check to determine if we have surpassed our timeout for holding this key
-  if (Kaleidoscope.hasTimeExpired(map[index].start_time, current_timeout)) {
+  if (Runtime.hasTimeExpired(map[index].start_time, current_timeout)) {
     // if we timed out, that means we need to keep pressing the mapped
     // key, but we won't need to send the alternative key in the end
     map[index].flagged = false;

--- a/src/kaleidoscope/plugin/SpaceCadet.h
+++ b/src/kaleidoscope/plugin/SpaceCadet.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
 
 #ifndef SPACECADET_MAP_END

--- a/src/kaleidoscope/plugin/Syster.cpp
+++ b/src/kaleidoscope/plugin/Syster.cpp
@@ -17,6 +17,8 @@
 
 #include <Kaleidoscope-Syster.h>
 #include <kaleidoscope/hid.h>
+#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/key_events.h"
 
 #undef SYSTER
 

--- a/src/kaleidoscope/plugin/Syster.h
+++ b/src/kaleidoscope/plugin/Syster.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
 
 #define SYSTER_MAX_SYMBOL_LENGTH 32

--- a/src/kaleidoscope/plugin/TapDance.cpp
+++ b/src/kaleidoscope/plugin/TapDance.cpp
@@ -17,6 +17,7 @@
 
 #include <Kaleidoscope-TapDance.h>
 #include <kaleidoscope/hid.h>
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -38,7 +39,7 @@ void TapDance::interrupt(KeyAddr key_addr) {
 
   last_tap_dance_key_ = Key_NoKey;
 
-  Kaleidoscope.device().maskKey(key_addr);
+  Runtime.device().maskKey(key_addr);
   kaleidoscope::hid::sendKeyboardReport();
   kaleidoscope::hid::releaseAllKeys();
 
@@ -74,7 +75,7 @@ void TapDance::tap(void) {
   uint8_t idx = last_tap_dance_key_.getRaw() - ranges::TD_FIRST;
 
   state_[idx].count++;
-  start_time_ = Kaleidoscope.millisAtCycleStart();
+  start_time_ = Runtime.millisAtCycleStart();
 
   tapDanceAction(idx, last_tap_dance_addr_, state_[idx].count, Tap);
 }
@@ -117,8 +118,8 @@ EventHandlerResult TapDance::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr,
     if (keyToggledOn(keyState))
       interrupt(key_addr);
 
-    if (Kaleidoscope.device().isKeyMasked(key_addr)) {
-      Kaleidoscope.device().unMaskKey(key_addr);
+    if (Runtime.device().isKeyMasked(key_addr)) {
+      Runtime.device().unMaskKey(key_addr);
       return EventHandlerResult::EVENT_CONSUMED;
     }
     return EventHandlerResult::OK;
@@ -193,7 +194,7 @@ EventHandlerResult TapDance::afterEachCycle() {
   if (last_tap_dance_key_ == Key_NoKey)
     return EventHandlerResult::OK;
 
-  if (Kaleidoscope.hasTimeExpired(start_time_, time_out))
+  if (Runtime.hasTimeExpired(start_time_, time_out))
     timeout();
 
   return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/TapDance.h
+++ b/src/kaleidoscope/plugin/TapDance.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
 
 #define TD(n) Key(kaleidoscope::ranges::TD_FIRST + n)

--- a/src/kaleidoscope/plugin/TopsyTurvy.cpp
+++ b/src/kaleidoscope/plugin/TopsyTurvy.cpp
@@ -17,6 +17,7 @@
 
 #include <Kaleidoscope-TopsyTurvy.h>
 #include "kaleidoscope/hid.h"
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/TopsyTurvy.h
+++ b/src/kaleidoscope/plugin/TopsyTurvy.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
 
 #define TOPSY(k) Key(kaleidoscope::ranges::TT_FIRST + (Key_ ## k).getKeyCode())

--- a/src/kaleidoscope/plugin/TriColor.cpp
+++ b/src/kaleidoscope/plugin/TriColor.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope-LEDEffects.h>
+#include "kaleidoscope/layers.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/TriColor.h
+++ b/src/kaleidoscope/plugin/TriColor.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-LEDControl.h>
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/plugin/Turbo.cpp
+++ b/src/kaleidoscope/plugin/Turbo.cpp
@@ -17,6 +17,9 @@
 
 #include <Kaleidoscope-Turbo.h>
 #include <Kaleidoscope-LEDControl.h>
+#include "kaleidoscope/layers.h"
+#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/hid.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -101,18 +104,18 @@ EventHandlerResult Turbo::onKeyswitchEvent(Key &key, KeyAddr key_addr, uint8_t k
 
 EventHandlerResult Turbo::afterEachCycle() {
   if (enable) {
-    if (Kaleidoscope.millisAtCycleStart() - startTime > interval_) {
+    if (Runtime.millisAtCycleStart() - startTime > interval_) {
       kaleidoscope::hid::sendKeyboardReport();
-      startTime = Kaleidoscope.millisAtCycleStart();
+      startTime = Runtime.millisAtCycleStart();
     }
 
     if (flash_) {
-      if (Kaleidoscope.millisAtCycleStart() - flashStartTime > flashInterval_ * 2) {
+      if (Runtime.millisAtCycleStart() - flashStartTime > flashInterval_ * 2) {
         for (uint16_t i = 0; i < numKeys; i++) {
           LEDControl::setCrgbAt(KeyAddr(keyPositions[i]), activeColor_);
         }
-        flashStartTime = Kaleidoscope.millisAtCycleStart();
-      } else if (Kaleidoscope.millisAtCycleStart() - flashStartTime > flashInterval_) {
+        flashStartTime = Runtime.millisAtCycleStart();
+      } else if (Runtime.millisAtCycleStart() - flashStartTime > flashInterval_) {
         for (uint16_t i = 0; i < numKeys; i++) {
           LEDControl::setCrgbAt(KeyAddr(keyPositions[i]), {0, 0, 0});
         }

--- a/src/kaleidoscope/plugin/Turbo.h
+++ b/src/kaleidoscope/plugin/Turbo.h
@@ -16,7 +16,7 @@
  */
 
 #include <stdint.h>
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
 
 #define Key_Turbo Key{kaleidoscope::ranges::TURBO }

--- a/src/kaleidoscope/plugin/TypingBreaks.h
+++ b/src/kaleidoscope/plugin/TypingBreaks.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/USB-Quirks.cpp
+++ b/src/kaleidoscope/plugin/USB-Quirks.cpp
@@ -29,11 +29,11 @@ void USBQuirks::toggleKeyboardProtocol() {
 #if KALEIDOSCOPE_HIDADAPTOR_ENABLE_KEYBOARD_BOOT_PROTOCOL
   uint8_t new_protocol = !BootKeyboard.getProtocol();
 
-  Kaleidoscope.detachFromHost();
+  Runtime.detachFromHost();
   BootKeyboard.default_protocol = new_protocol;
   BootKeyboard.setProtocol(new_protocol);
   delay(1000);
-  Kaleidoscope.attachToHost();
+  Runtime.attachToHost();
 #endif
 
 }

--- a/src/kaleidoscope/plugin/USB-Quirks.h
+++ b/src/kaleidoscope/plugin/USB-Quirks.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/Unicode.h
+++ b/src/kaleidoscope/plugin/Unicode.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-HostOS.h>
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/plugin/WinKeyToggle.cpp
+++ b/src/kaleidoscope/plugin/WinKeyToggle.cpp
@@ -15,7 +15,7 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-WinKeyToggle.h>
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/plugin/WinKeyToggle.h
+++ b/src/kaleidoscope/plugin/WinKeyToggle.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope_internal/deprecations.h
+++ b/src/kaleidoscope_internal/deprecations.h
@@ -71,3 +71,11 @@
   "\n"                                                                         \
   "For further information and examples on how to do that, \n"                 \
   "please see UPGRADING.md."
+
+#define _DEPRECATED_MESSAGE_GLOBAL_VARIABLE_KALEIDOSCOPE                       \
+  "Variable `Kaleidoscope` in global namespace has been deprecated.\n"         \
+  "Please use `kaleidoscope::Runtime` instead."
+
+#define _DEPRECATED_MESSAGE_GLOBAL_TYPENAME_KALEIDOSCOPE                       \
+  "Type `Kaleidoscope_` in global namespace has been deprecated.\n"            \
+  "Please use `kaleidoscope::Runtime_` instead."

--- a/src/kaleidoscope_internal/device.cpp
+++ b/src/kaleidoscope_internal/device.cpp
@@ -14,7 +14,7 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope.h>
+#include "kaleidoscope_internal/device.h"
 
 namespace kaleidoscope_internal {
 kaleidoscope::Device device;


### PR DESCRIPTION
# Build time optimization

This is a follow up to discussion https://github.com/keyboardio/Kaleidoscope/issues/736.

## TL;DR

This PR reduces firmware build times by ~20%.

## Motivation

Firmware builds take longer than necessary. That's especially annoying if frequent rebuilds are required during development or if one needs to wait till the smoke-examples test bench runs through before submitting a PR.

## Reasons for build time accumulation

Kaleidoscope has one central header `Kaleidoscope.h` that is meant to simplify handling of the firmware for users. This header pulls in a lot of stuff and is unfortunately included in many places of the firmware core. Thus, many compilation units include stuff that is not necessary for them to build. Also, `Kaleidoscope.h` includes stuff that is only required in the sketch, like the mostly templated infrastructure of the plugin API and transient LED modes, just to name two of them.

## Ways to improve this

### Conditionally excluding parts of the code

A first attempt was to reduce build times by introducing a wrapper compiler that command-line defines a macro that can be used to distinguish the sketch compilation unit from all others. This was meant to suppress infrastructure stuff for all other compilation units and only make it available to the sketch.
This comes with two major drawbacks, namely the wrapper compiler and the burden to figure out what to suppress and how to do it. Especially as this must be done in a way that it remains maintainable.
After experimenting with this idea for a while, I gave up.

### Cleaning up includes

#### Where/what to clean up

A second attempt to reduce build time was far more successful. Instead of excluding parts of the code, I cleaned up the whole include management - partially automatized - which lead to a build time decrease of approx. 20%.

Before I go into detail how that works, I would like to draw a distinction between different types of headers that can be found in Kaleidoscope.

* sketch-only headers (headers that are exclusively meant to be included by the sketch)
* library internal headers (included within Kaleidoscope and not meant to be included directly in the sketch)
* private headers (mostly in kaleidoscope_internal)

Next, some rules that are commonly regarded as good practice in C/C++ programming and if respected keep build times low and also re-build times (due to less unnecessary include dependencies).

* headers should only include other headers in very rare cases 
* forward declare whenever possible (therefore, prefer call by reference to call by value) to avoid unnecessary includes
* always try to include headers directly, not via other headers (prevents unnecessary dependencies and improves transparency (what lives where))
* name headers in a way that they reflect the content (simplifies include management and finding appropriate headers)

There are sometimes, for good reasons, exceptions to some of these rules. A typical example are the service-headers that many widely used C++ libraries support. Those are often named by the project and pull in a lot of stuff, sometimes all features, a library offers. This is meant to spare users finding out what symbols are defined where. The downside of this approach is that such headers are really costly on the including side, especially if only few features are required but the compiler sees and parses all of them.
This becomes even worse if such service-headers are included by other central headers of the own project which are in turn included by many files. Such service-headers could easily cause an explosion of build times when used carelessly. That's why it is recommended to use feature-headers instead and preferably include them only in source files (.cpp) and never in headers. This is especially important for the libraries that depend on other libraries.

In Kaleidoscope, an example for such a central service-header is `Kaleidoscope.h`. Also most of the headers directly living in `src`, that originally were the Arduino-library headers of individual plugins before the mono-repo fusion. All those headers are there for good reasons. The trade off between usability and build times should clearly be on the usability side. That's why no attempt is made to speed up sketch build time. 

Things are very much different for most other headers and source files. For those the good-practice rules of inclusion should be respected. Any other compilation units apart from the sketch should really build as fast as possible.

#### Include hell

Unfortunately, a include hell in Kaleidoscope comes from the fact that many compilation units depend on class `Kaleidoscope` that is defined in header `kaleidoscope/Kaleidoscope.h`. The big problem is that this header pulls in a huge lot of other stuff. That's why currently every compilation unit pulls in great parts of Kaleidoscope's headers without actually needing them to build.

#### Refactoring Kaleidoscope.h

The first step in refactoring was to move the definition of class `Kaleidoscope` to a separate header. I called it `Kaleidoscope_Class.h` due to a lack of better ideas. Both the central header `Kaleidoscope.h` but also the header of class `Kaleidoscope` deserve to be named `Kaleidoscope.h`. To remain backward compatible, we definitely have to stick with the name for the central header. Maybe we might consider ?another name for class `Kaleidoscope`? Just an idea that's fairly off topic.

After this change, all compilation units that only need class `Kaleidoscope` can include `Kaleidoscope_Class.h`. This already removes a lot of unnecessary dependencies.

#### Include-what-you-use

After factoring out class `Kaleidoscope` there are still a lot of unnecessary includes left as not all `#include "kaleidoscope/Kaleidoscope.h"` can be replaced by `#include "kaleidoscope/Kaleidoscope_Class.h"`. That's because a great number of such includes actually mean to pull in other stuff that is indirectly included by `Kaleidoscope.h`, e.g. `layer.h` or `hooks.h`. For authors it was probably tempting in the past to just include `Kaleidoscope.h` instead of finding out where a symbol or macro actually lives, knowing that one include would solve all problems.

Fortunately, there is a free tool named [include-what-you-use](https://include-what-you-use.org/) (IWYU), that helps to deal with such problems. It's clang based analyser that can serve as a drop-in replacement for the gcc or clang compiler.

IWYU compiles source files (and also headers if necessary) and provides suggestions about where to remove unnecessary includes or which indirect includes could be replaced by direct ones. Moreover, it also helps with replacing some includes by forward declarations. It is obvious that to provide suggestions about the latter, it needs to analyse the entire AST, which explains why it is based on clang in the first place.

Unfortunately, IWYU cannot be used to analyse Kaleidoscope directly. That's because IWYU cannot replace avr-gcc. There's just no avr-clang or avr-IWYU that could deal with all the Arduino/AVR specific compiler flags.

Luckily, we have virtual builds that already work with x86 compilers. With few changes to the code, Kaleidoscope also builds with latest clang.

I let IWYU run on all headers in `src/kaleidoscope` and `src/kaleidoscope_internal` and replaced include sections with what IWYU suggested. Only in rare cases I had to manually replace some of the suggested standard headers with those available with Arduino. That's because of the virtual build.

The result is a 20% build time reduction (determined by looking at the build time of the stock firmware).

I suggest to repeat this IWYU-procedure once in a while to keep the amount of unnecessary includes low.
FWIW, IWYU comes with a auto-replacement script but that cannot be used (with AVR builds) due to the need to manually replace specific header suggestions.

## Changes

This PR comes with two commits. The first one extracts header `Kaleidoscope_Class.h` from `Kaleidoscope.h`.  The second commit contains the IWYU optimization.

These changes mostly affect include directives being removed, changed or replaced by forward declarations. Any other changes part of the first commit were necessary to enable factoring out class `Kaleidoscope`.
