### PR TITLE
util/flasher/Base.h: Don't use an unnamed struct

### DIFF
--- a/src/kaleidoscope/util/flasher/Base.h
+++ b/src/kaleidoscope/util/flasher/Base.h
@@ -28,7 +28,7 @@ struct BaseProps {
   static constexpr uint8_t blank = 0xff;
   static constexpr uint8_t delay = 1;
 
-  static struct {
+  static struct command {
     static constexpr uint8_t page_address = 0x01;
     static constexpr uint8_t continue_page = 0x02;
     static constexpr uint8_t execute = 0x03;


### PR DESCRIPTION
While older GCC versions accept using an unnamed struct, gcc 7+ does not. Use a named one instead, to make both gcc versions happy.
