### PR TITLE
Fixed clang problems with member function pointers

### DIFF
--- a/src/kaleidoscope/layers.cpp
+++ b/src/kaleidoscope/layers.cpp
@@ -40,7 +40,7 @@ uint32_t Layer_::layer_state_;
 uint8_t Layer_::top_active_layer_;
 Key Layer_::live_composite_keymap_[Kaleidoscope.device().numKeys()];
 uint8_t Layer_::active_layers_[Kaleidoscope.device().numKeys()];
-Key(*Layer_::getKey)(uint8_t layer, KeyAddr key_addr) = Layer.getKeyFromPROGMEM;
+Layer_::GetKeyFunction Layer_::getKey = &Layer_::getKeyFromPROGMEM;
 
 void Layer_::handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState) {
   if (keymapEntry.getKeyCode() >= LAYER_SHIFT_OFFSET) {

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -116,7 +116,8 @@ class Layer_ {
     return eventHandler(mappedKey, KeyAddr(row, col), keyState);
   }
 
-  static Key(*getKey)(uint8_t layer, KeyAddr key_addr);
+  typedef Key(*GetKeyFunction)(uint8_t layer, KeyAddr key_addr);
+  static GetKeyFunction getKey;
 
   static Key getKeyFromPROGMEM(uint8_t layer, KeyAddr key_addr);
   DEPRECATED(ROW_COL_FUNC) static Key getKeyFromPROGMEM(uint8_t layer, byte row, byte col) {

--- a/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -130,7 +130,7 @@ EventHandlerResult EEPROMKeymap::onFocusEvent(const char *command) {
     // we actully want.
     //
     dumpKeymap(progmem_layers_,
-               static_cast<Key(*)(uint8_t, KeyAddr)>(Layer.getKeyFromPROGMEM));
+               static_cast<Key(*)(uint8_t, KeyAddr)>(Layer_::getKeyFromPROGMEM));
     return EventHandlerResult::EVENT_CONSUMED;
   }
 


### PR DESCRIPTION
Clang seems to have problem with recognizing that those
functions are actually static members. This change
makes it more obvious to the compiler, which functions we actually refer
to.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>