### PR TITLE
Removed an inaccessible private class member

### DIFF
--- a/src/kaleidoscope/plugin/LED-Wavepool.cpp
+++ b/src/kaleidoscope/plugin/LED-Wavepool.cpp
@@ -39,8 +39,7 @@ PROGMEM const uint8_t WavepoolEffect::TransientLEDMode::rc2pos[Kaleidoscope.devi
 };
 
 WavepoolEffect::TransientLEDMode::TransientLEDMode(const WavepoolEffect *parent)
-  : parent_(parent),
-    frames_since_event_(0),
+  : frames_since_event_(0),
     surface_{},
     page_(0)
 {}

--- a/src/kaleidoscope/plugin/LED-Wavepool.h
+++ b/src/kaleidoscope/plugin/LED-Wavepool.h
@@ -61,8 +61,6 @@ class WavepoolEffect : public Plugin,
 
    private:
 
-    const WavepoolEffect *parent_;
-
     uint8_t frames_since_event_;
     int8_t surface_[2][WP_WID * WP_HGT];
     uint8_t page_;


### PR DESCRIPTION
This caused a warning with clang 8.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>