### PR TITLE
Fixed missing instanciation of driver::leds::Base<...>::LEDs_

### DIFF
--- a/src/kaleidoscope/device/Base.h
+++ b/src/kaleidoscope/device/Base.h
@@ -90,8 +90,8 @@ class Base {
   static constexpr uint8_t matrix_rows = KeyScannerProps::matrix_rows;
   static constexpr uint8_t matrix_columns = KeyScannerProps::matrix_columns;
   static constexpr uint8_t led_count = LEDDriverProps::led_count;
-  static constexpr typename LEDDriver::LEDs &LEDs() {
-    return LEDDriver::LEDs_;
+  static constexpr auto LEDs() -> decltype(LEDDriver::LEDs()) & {
+    return LEDDriver::LEDs();
   }
 
   /**

--- a/src/kaleidoscope/device/virtual/Virtual.cpp
+++ b/src/kaleidoscope/device/virtual/Virtual.cpp
@@ -374,17 +374,6 @@ cRGB VirtualLEDDriver::getCrgbAt(uint8_t i) const {
 } // namespace virt
 } // namespace device
 
-
-namespace driver {
-namespace led {
-
-template<>
-Base<kaleidoscope::DeviceProps::LEDDriverProps>::LEDs
-Base<kaleidoscope::DeviceProps::LEDDriverProps>::LEDs_{};
-
-} // namespace led
-} // namespace driver
-
 } // namespace kaleidoscope
 
 

--- a/src/kaleidoscope/device/virtual/Virtual.h
+++ b/src/kaleidoscope/device/virtual/Virtual.h
@@ -99,8 +99,6 @@ class VirtualLEDDriver
   typedef driver::led::Base<kaleidoscope::DeviceProps::LEDDriverProps>
   ParentType;
 
-  using typename ParentType::LEDs;
-
   static constexpr uint8_t led_count = kaleidoscope::DeviceProps::LEDDriverProps::led_count;
 
   void setup();

--- a/src/kaleidoscope/driver/led/Base.h
+++ b/src/kaleidoscope/driver/led/Base.h
@@ -65,14 +65,14 @@ class Base {
     return pgm_read_byte(&_LEDDriverProps::key_led_map[key_offset]);
   }
 
-  static class LEDs {
+  class LEDRangeIterator {
    private:
     uint8_t offset_;
    public:
-    LEDs() : offset_(0) {}
-    LEDs(uint8_t offset) : offset_(offset) {}
+    LEDRangeIterator() : offset_(0) {}
+    LEDRangeIterator(uint8_t offset) : offset_(offset) {}
 
-    typedef LEDs ThisType;
+    typedef LEDRangeIterator ThisType;
 
     constexpr uint8_t offset() const {
       return offset_;
@@ -109,7 +109,7 @@ class Base {
     }
 
     struct Range {
-      typedef ThisType Iterator;
+      typedef LEDRangeIterator Iterator;
       static constexpr ThisType begin() {
         return ThisType(uint8_t(0));
       }
@@ -127,7 +127,12 @@ class Base {
     constexpr bool isValid(uint8_t index) const {
       return (_LEDDriverProps::led_count > 0 && index < _LEDDriverProps::led_count);
     }
-  } LEDs_;
+  };
+
+  static LEDRangeIterator &LEDs() {
+    static LEDRangeIterator leds;
+    return leds;
+  }
 
  protected:
   typedef _LEDDriverProps Props_;


### PR DESCRIPTION
This static member did not have an instance under
certain circumstances. A typical workaround for such
a situation is to make it a local static of an accessor
function. By this means the one definition rule is
not violated and the object always instanciated. It is still optimized
away by the compiler in case device::Base<...>::LEDs() is not called.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>