### PR TITLE
Added missing braces around the initialization list of a submember

### DIFF
--- a/src/kaleidoscope/plugin/HardwareTestMode.cpp
+++ b/src/kaleidoscope/plugin/HardwareTestMode.cpp
@@ -76,7 +76,7 @@ void HardwareTestMode::testLeds(void) {
 
 void HardwareTestMode::testMatrix() {
   // Reset bad keys from previous tests.
-  chatter_data state[Kaleidoscope.device().numKeys()] = {0, 0, 0};
+  chatter_data state[Kaleidoscope.device().numKeys()] = {{0, 0, 0}};
 
   constexpr cRGB red = CRGB(201, 0, 0);
   constexpr cRGB blue = CRGB(0, 0, 201);


### PR DESCRIPTION
The submember is a bitfield that needs its own braced list.
Gcc silently tolerates this clang warns about it.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>