### PR TITLE
device/Raise: Fix the column loop in actOnMatrixScan()

### DIFF
--- a/src/kaleidoscope/device/dygma/Raise.cpp
+++ b/src/kaleidoscope/device/dygma/Raise.cpp
@@ -297,8 +297,8 @@ void RaiseKeyScanner::readMatrix() {
 
 void RaiseKeyScanner::actOnMatrixScan() {
   for (byte row = 0; row < Props_::matrix_rows; row++) {
-    for (byte col = 0; col < Props_::matrix_columns; col++) {
-      uint8_t keynum = (row * Props_::matrix_rows) + (col);
+    for (byte col = 0; col < Props_::left_columns; col++) {
+      uint8_t keynum = (row * Props_::left_columns) + col;
       uint8_t keyState;
 
       // left


### PR DESCRIPTION
`RaiseKeyScanner::actOnMatrixScan()` erroneously looped through all the columns in the matrix, while we only wanted to loop through the left half, since we read the right half at the same time, not separately. This resulted in half the keys producing two events, due to overflow. We also calculated the key number incorrectly.

Both of these issues are fixed with this patch.
