### PR TITLE
Fixes linker order dependent choice of wrong HID library

### DIFF
--- a/src/kaleidoscope/device/virtual/HID.cpp
+++ b/src/kaleidoscope/device/virtual/HID.cpp
@@ -16,6 +16,8 @@
    SOFTWARE.
  */
 
+#ifdef KALEIDOSCOPE_VIRTUAL_BUILD
+
 // This is a modified version of the original HID.cpp from
 // library KeyboardioHID. It replaces all hardware related stuff
 // with stub implementations.
@@ -92,3 +94,5 @@ int HID_::begin(void) {
 }
 
 #endif /* if defined(USBCON) */
+
+#endif // #ifdef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/src/kaleidoscope/device/virtual/Logging.cpp
+++ b/src/kaleidoscope/device/virtual/Logging.cpp
@@ -14,6 +14,8 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef KALEIDOSCOPE_VIRTUAL_BUILD
+
 #include "Logging.h"
 
 namespace kaleidoscope {
@@ -31,3 +33,5 @@ bool verboseOutputEnabled() {
 
 } // namespace logging
 } // namespace kaleidoscope
+
+#endif // #ifdef KALEIDOSCOPE_VIRTUAL_BUILD


### PR DESCRIPTION
The virtual hid was recently included in the core firmware repo.
Due to missing `#ifdef KALEIDOSCOPE_VIRTUAL_BUILD` in some
files, two versions of the hid library, one for the virtual and one for
the physical device were build. The linker perferred the one that it
encountered first. That caused a link order dependency that possibly
renders some firmware builds without HID reports being send to the host.

This change adds thse missing `#ifdef KALEIDOSCOPE_VIRTUAL_BUILD`
clauses.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>