### PR TITLE
Sketch exploration fix for empty keymaps

### DIFF
--- a/src/kaleidoscope_internal/sketch_exploration/sketch_exploration.cpp
+++ b/src/kaleidoscope_internal/sketch_exploration/sketch_exploration.cpp
@@ -1,0 +1,28 @@
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace kaleidoscope {
+\
+namespace sketch_exploration {
+
+// This empty weak symbol is necessary if the KEYMAP(...) macro
+// is not used in the sketch.
+//
+__attribute__((weak))
+void pluginsExploreSketch() {}
+
+} // namespace sketch_exploration
+} // namespace kaleidoscope


### PR DESCRIPTION
This is a fix for https://github.com/keyboardio/Kaleidoscope/issues/758

Sketch exploration choked on the rare case that an empty keymap
was supplied with `KEYMAP()`.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>