### PR TITLE
Add HID short name overrides

### DIFF
--- a/src/kaleidoscope/device/ATmega32U4Keyboard.h
+++ b/src/kaleidoscope/device/ATmega32U4Keyboard.h
@@ -27,16 +27,17 @@
 #include "kaleidoscope/driver/storage/ATmega32U4EEPROMProps.h"
 #include "kaleidoscope/driver/storage/AVREEPROM.h"
 
-#define ATMEGA32U4_DEVICE_PROPS(BOARD_, BOOTLOADER_, ROW_PINS_, COL_PINS_)     \
-  struct BOARD_##Props : kaleidoscope::device::ATmega32U4KeyboardProps {       \
-    struct KeyScannerProps                                                     \
-       : public kaleidoscope::driver::keyscanner::ATmegaProps                  \
-    {                                                                          \
-      ATMEGA_KEYSCANNER_PROPS(ROW_PIN_LIST(ROW_PINS_),                         \
-                              COL_PIN_LIST(COL_PINS_));                        \
-    };                                                                         \
-    typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner;\
-    typedef kaleidoscope::driver::bootloader::avr::BOOTLOADER_ BootLoader;     \
+#define ATMEGA32U4_DEVICE_PROPS(BOARD_, BOOTLOADER_, NAME_, ROW_PINS_, COL_PINS_) \
+  struct BOARD_##Props : kaleidoscope::device::ATmega32U4KeyboardProps {          \
+    struct KeyScannerProps                                                        \
+       : public kaleidoscope::driver::keyscanner::ATmegaProps                     \
+    {                                                                             \
+      ATMEGA_KEYSCANNER_PROPS(ROW_PIN_LIST(ROW_PINS_),                            \
+                              COL_PIN_LIST(COL_PINS_));                           \
+    };                                                                            \
+    typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner; \
+    typedef kaleidoscope::driver::bootloader::avr::BOOTLOADER_ BootLoader;        \
+    static constexpr const char *short_name = NAME_;                             \
   };
 
 #define ATMEGA32U4_DEVICE(BOARD_)                                              \
@@ -46,15 +47,15 @@
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
-#define ATMEGA32U4_KEYBOARD(BOARD_, BOOTLOADER_, ROW_PINS_, COL_PINS_)         \
-  ATMEGA32U4_DEVICE_PROPS(BOARD_, BOOTLOADER_,                                 \
+#define ATMEGA32U4_KEYBOARD(BOARD_, BOOTLOADER_, NAME_, ROW_PINS_, COL_PINS_)  \
+  ATMEGA32U4_DEVICE_PROPS(BOARD_, BOOTLOADER_, NAME_,                          \
                           FORWARD(ROW_PINS_), FORWARD(COL_PINS_))              \
   ATMEGA32U4_DEVICE(BOARD_)
 
 #else // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
-#define ATMEGA32U4_KEYBOARD(BOARD_, BOOTLOADER_, ROW_PINS_, COL_PINS_)         \
-  ATMEGA32U4_DEVICE_PROPS(BOARD_, BOOTLOADER_,                                 \
+#define ATMEGA32U4_KEYBOARD(BOARD_, BOOTLOADER_, NAME_, ROW_PINS_, COL_PINS_)  \
+  ATMEGA32U4_DEVICE_PROPS(BOARD_, BOOTLOADER_, NAME_,                          \
                           FORWARD(ROW_PINS_), FORWARD(COL_PINS_))              \
   /* Device definition omitted for virtual device builds.                      \
    * We need to forward declare the device name, though, as there are          \

--- a/src/kaleidoscope/device/Base.h
+++ b/src/kaleidoscope/device/Base.h
@@ -60,6 +60,7 @@ struct BaseProps {
   typedef kaleidoscope::driver::bootloader::None Bootloader;
   typedef kaleidoscope::driver::storage::BaseProps StorageProps;
   typedef kaleidoscope::driver::storage::None Storage;
+  static constexpr const char *short_name = USB_PRODUCT;
 };
 
 template<typename _DeviceProps>
@@ -116,8 +117,8 @@ class Base {
   }
 
   /**
-     * Returns the key scanner used by the keyboard.
-     */
+   * Returns the key scanner used by the keyboard.
+   */
   KeyScanner &keyScanner() {
     return key_scanner_;
   }
@@ -127,6 +128,14 @@ class Base {
    */
   LEDDriver &ledDriver() {
     return led_driver_;
+  }
+
+  /**
+   * Returns the short name of the device.
+   */
+  static const uint8_t getShortName(char *name) {
+    memcpy(name, _DeviceProps::short_name, strlen(_DeviceProps::short_name));
+    return strlen(_DeviceProps::short_name);
   }
 
   /**
@@ -534,4 +543,3 @@ class Base {
 #define EXPORT_DEVICE(DEVICE)                                                  \
   typedef DEVICE##Props DeviceProps;
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-

--- a/src/kaleidoscope/device/dygma/Raise.h
+++ b/src/kaleidoscope/device/dygma/Raise.h
@@ -170,6 +170,7 @@ struct RaiseProps : kaleidoscope::device::BaseProps {
 
   typedef RaiseSideFlasherProps SideFlasherProps;
   typedef kaleidoscope::util::flasher::KeyboardioI2CBootloader<SideFlasherProps> SideFlasher;
+  static constexpr const char *short_name = "raise";
 };
 
 class Raise: public kaleidoscope::device::Base<RaiseProps> {

--- a/src/kaleidoscope/device/ez/ErgoDox.h
+++ b/src/kaleidoscope/device/ez/ErgoDox.h
@@ -53,6 +53,7 @@ struct ErgoDoxProps : public kaleidoscope::device::ATmega32U4KeyboardProps {
     KEYSCANNER_PROPS(14, 6);
   };
   typedef kaleidoscope::driver::bootloader::avr::HalfKay Bootloader;
+  static constexpr const char *short_name = "ErgoDox-EZ";
 };
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/src/kaleidoscope/device/kbdfans/KBD4x.h
+++ b/src/kaleidoscope/device/kbdfans/KBD4x.h
@@ -40,6 +40,7 @@ struct KBD4xProps : kaleidoscope::device::ATmega32U4KeyboardProps {
   };
   typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner;
   typedef kaleidoscope::driver::bootloader::avr::FLIP Bootloader;
+  static constexpr const char *short_name = "kbd4x";
 };
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/src/kaleidoscope/device/keyboardio/Imago.h
+++ b/src/kaleidoscope/device/keyboardio/Imago.h
@@ -84,6 +84,7 @@ struct ImagoProps : kaleidoscope::device::ATmega32U4KeyboardProps {
   typedef ImagoLEDDriverProps LEDDriverProps;
   typedef ImagoLEDDriver LEDDriver;
   typedef kaleidoscope::driver::bootloader::avr::Caterina BootLoader;
+  static constexpr const char *short_name = "imago";
 };
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/src/kaleidoscope/device/keyboardio/Model01.h
+++ b/src/kaleidoscope/device/keyboardio/Model01.h
@@ -120,6 +120,7 @@ struct Model01Props : public kaleidoscope::device::ATmega32U4KeyboardProps {
   typedef Model01KeyScannerProps KeyScannerProps;
   typedef Model01KeyScanner KeyScanner;
   typedef kaleidoscope::driver::bootloader::avr::Caterina BootLoader;
+  static constexpr const char *short_name = "kbio01";
 };
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/src/kaleidoscope/device/olkb/Planck.h
+++ b/src/kaleidoscope/device/olkb/Planck.h
@@ -29,7 +29,7 @@ namespace device {
 namespace olkb {
 
 ATMEGA32U4_KEYBOARD(
-  Planck, HalfKay,
+  Planck, HalfKay, "planck",
   ROW_PIN_LIST({ PIN_D0, PIN_D5, PIN_B5, PIN_B6 }),
   COL_PIN_LIST({ PIN_F1, PIN_F0, PIN_B0, PIN_C7, PIN_F4, PIN_F5, PIN_F6, PIN_F7, PIN_D4, PIN_D6, PIN_B4, PIN_D7 })
 );

--- a/src/kaleidoscope/device/softhruf/Splitography.h
+++ b/src/kaleidoscope/device/softhruf/Splitography.h
@@ -47,6 +47,7 @@ struct SplitographyProps : kaleidoscope::device::ATmega32U4KeyboardProps {
   };
   typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner;
   typedef kaleidoscope::driver::bootloader::avr::FLIP BootLoader;
+  static constexpr const char *short_name = "splitography";
 };
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/src/kaleidoscope/device/technomancy/Atreus.h
+++ b/src/kaleidoscope/device/technomancy/Atreus.h
@@ -36,7 +36,7 @@ namespace device {
 namespace technomancy {
 
 ATMEGA32U4_KEYBOARD(
-  Atreus, HalfKay,
+  Atreus, HalfKay, "atreus",
 #ifdef KALEIDOSCOPE_HARDWARE_ATREUS_PINOUT_ASTAR
   ROW_PIN_LIST({PIN_D0, PIN_D1, PIN_D3, PIN_D2}),
   COL_PIN_LIST({PIN_D7, PIN_C6, PIN_B5, PIN_B4, PIN_E6, PIN_D4, PIN_B6, PIN_F6, PIN_F7, PIN_D6, PIN_B7})

--- a/src/kaleidoscope/device/technomancy/Atreus2.h
+++ b/src/kaleidoscope/device/technomancy/Atreus2.h
@@ -30,7 +30,7 @@ namespace device {
 namespace technomancy {
 
 ATMEGA32U4_KEYBOARD(
-  Atreus2, Caterina,
+  Atreus2, Caterina, "atreus",
   ROW_PIN_LIST({PIN_F6, PIN_F5, PIN_F4, PIN_F1}),
   COL_PIN_LIST({PIN_F7, PIN_E2, PIN_C7, PIN_C6, PIN_B6, PIN_B5, PIN_D7, PIN_D6, PIN_D4, PIN_D5, PIN_D3, PIN_D2})
 );

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -22,6 +22,7 @@
 #include "kaleidoscope/device/device.h"
 #include "kaleidoscope_internal/device.h"
 #include "kaleidoscope_internal/sketch_exploration/sketch_exploration.h"
+#include "kaleidoscope_internal/shortname.h"
 
 // Macro for defining the keymap. This should be used in the sketch
 // file (*.ino) to define the keymap[] array that holds the user's
@@ -36,7 +37,8 @@
   */                                                                    __NL__ \
   kaleidoscope::internal::Keymaps2DInterface keymaps;                   __NL__ \
                                                                         __NL__ \
-  _INIT_SKETCH_EXPLORATION
+  _INIT_SKETCH_EXPLORATION                                              __NL__ \
+  _INIT_HID_GETSHORTNAME
 
 extern uint8_t layer_count;
 

--- a/src/kaleidoscope_internal/shortname.h
+++ b/src/kaleidoscope_internal/shortname.h
@@ -1,0 +1,32 @@
+/* kaleidoscope_internal::shortname -- HID short name override helper
+ * Copyright (C) 2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+/*
+ * We want to be able to override the short name of the device. For that, we
+ * currently need to override `HID_::getShortName`, but due to link ordering, we
+ * need to do that in the user sketch. For this reason, `_INIT_HID_GETSHORTNAME`
+ * gets called from the `KEYMAPS` macro.
+ *
+ * TODO(anyone): Once we have a better way to override the short name, remove
+ * this workaround.
+ */
+
+#define _INIT_HID_GETSHORTNAME                        __NL__ \
+  uint8_t HID_::getShortName(char *name) {            __NL__ \
+    return Kaleidoscope.device().getShortName(name);  __NL__ \
+  }


### PR DESCRIPTION
This is the other part of keyboardio/KeyboardioHID#61, implementing the Kaleidoscope-side override of `HID_::getShortName()`. In practice, this allows device plugins to set their short name in their own device props, and Kaleidoscope will then do the rest of the magic to make it happen.

The first commit adds the building blocks, the second updates all supported keyboards to have their own short names. For compatibility's sake, the Model01 remained `kbio01`.