### PR TITLE
Adds sketch header and footer include files

### DIFF
--- a/src/kaleidoscope_internal/sketch_preprocessing/sketch_footer.h
+++ b/src/kaleidoscope_internal/sketch_preprocessing/sketch_footer.h
@@ -1,0 +1,1 @@
+// Any code that appears here is added to the bottom of the preprocessed sketch file.

--- a/src/kaleidoscope_internal/sketch_preprocessing/sketch_header.h
+++ b/src/kaleidoscope_internal/sketch_preprocessing/sketch_header.h
@@ -1,0 +1,1 @@
+// Any code that appears here is added to the top of the preprocessed sketch file.


### PR DESCRIPTION
The two files kaleidoscope_internal/sketch_preprocessing/sketch_header.h
and kaleidoscope_internal/sketch_preprocessing/sketch_footer.h
are automatically included at the very top and bottom of the
preprocessed sketch.

**Please note:** This will only become effective once https://github.com/keyboardio/Kaleidoscope-Bundle-Keyboardio/pull/23 has been merged.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>