### PR TITLE
examples/AppSwitcher: Do not use dynamic  vars in MACRO()

### DIFF
--- a/examples/Features/AppSwitcher/Macros.cpp
+++ b/examples/Features/AppSwitcher/Macros.cpp
@@ -27,18 +27,20 @@ static bool appSwitchActive = false;
 
 const macro_t *macroAppSwitch(uint8_t keyState) {
   appSwitchActive = true;
-  Key mod = Key_LeftAlt;
-
-  if (HostOS.os() == H::OSX)
-    mod = Key_LeftGui;
 
   // Key was just pressed, or is being held
   if (keyIsPressed(keyState)) {
-    return MACRO(Dr(mod), D(Tab));
+    if (HostOS.os() == H::OSX)
+      return MACRO(Dr(Key_LeftGui), D(Tab));
+    else
+      return MACRO(Dr(Key_LeftAlt), D(Tab));
   }
   // Key was just released
   if (keyToggledOff(keyState)) {
-    return MACRO(U(Tab), Dr(mod));
+    if (HostOS.os() == H::OSX)
+      return MACRO(U(Tab), Dr(Key_LeftGui));
+    else
+      return MACRO(U(Tab), Dr(Key_LeftAlt));
   }
   // otherwise we do nothing
   return MACRO_NONE;


### PR DESCRIPTION
The `MACRO(...)` macro stores the macro in progmem, and as such, needs to use constants only. Rework the logic in `macroAppSwitch()` so that we keep that requirement.

For some reason, the previous version of the code worked with gcc 5.4, but not with gcc 7+, and the latter is right to complain.
