### PR TITLE
Fixed builds on msys2

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -304,7 +304,7 @@ compile () {
 	      -ide-version "${ARDUINO_IDE_VERSION}" \
 	      -built-in-libraries "${ARDUINO_PATH}/libraries" \
 	      -prefs "compiler.cpp.extra_flags=-std=c++11 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
-	      -prefs compiler.path=${COMPILER_PATH} \
+	      -prefs "compiler.path=${COMPILER_PATH}" \
 	      -prefs "compiler.c.cmd=${COMPILER_PREFIX}${C_COMPILER_BASENAME}" \
 	      -prefs "compiler.cpp.cmd=${COMPILER_PREFIX}${CXX_COMPILER_BASENAME}" \
 	      $CCACHE_ENABLE \

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -53,7 +53,7 @@ find_max_prog_size() {
     ${ARDUINO_TOOLS_FLAG:+"${ARDUINO_TOOLS_FLAG}"} ${ARDUINO_TOOLS_PARAM:+"${ARDUINO_TOOLS_PARAM}"} \
     -tools "${ARDUINO_PATH}/tools-builder" \
     -fqbn "${FQBN}" \
-    -build-path ${ARDUINO_PATH} \
+    -build-path "${ARDUINO_PATH}" \
     -dump-prefs "${SKETCH_DIR}/${SKETCH}.ino" | grep "upload\.maximum_size=")
     MAX_PROG_SIZE=${MAX_PROG_SIZE:-$(echo "${VPIDS}" | grep upload.maximum_size | head -n 1 | cut -d= -f2)}
 }
@@ -67,7 +67,7 @@ find_device_vid_pid() {
 		${ARDUINO_TOOLS_FLAG:+"${ARDUINO_TOOLS_FLAG}"} ${ARDUINO_TOOLS_PARAM:+"${ARDUINO_TOOLS_PARAM}"} \
 		-tools "${ARDUINO_PATH}/tools-builder" \
 		-fqbn "${FQBN}" \
-	 	-build-path ${ARDUINO_PATH} \
+	 	-build-path "${ARDUINO_PATH}" \
    		-dump-prefs  "${SKETCH_DIR}/${SKETCH}.ino" | grep "\.[vp]id=")
     VID=${VID:-$(echo "${VPIDS}" | grep build.vid= | cut -dx -f2)}
     SKETCH_PID=${SKETCH_PID:-$(echo "${VPIDS}" | grep build.pid= | cut -dx -f2)}
@@ -103,7 +103,7 @@ find_bootloader_path() {
 		            ${ARDUINO_TOOLS_FLAG:+"${ARDUINO_TOOLS_FLAG}"} ${ARDUINO_TOOLS_PARAM:+"${ARDUINO_TOOLS_PARAM}"} \
 		            -tools "${ARDUINO_PATH}/tools-builder" \
 		            -fqbn "${FQBN}" \
-	 	            -build-path ${ARDUINO_PATH} \
+	 	            -build-path "${ARDUINO_PATH}" \
    		          -dump-prefs  "${SKETCH_DIR}/${SKETCH}.ino" | grep "bootloader\.file=" | cut -d= -f2)
 
     BOOTLOADER_FILE="${BOOTLOADER_FILE:-caterina/Caterina.hex}"


### PR DESCRIPTION
This adds some quotes to various paths used in Kaleidoscope's build system.
This fixes builds on msys2 that failed due to whitespaces in system paths.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>