### PR TITLE
Replace the HID facade with a HID driver

### DIFF
--- a/doc/plugin/OneShot.md
+++ b/doc/plugin/OneShot.md
@@ -54,7 +54,6 @@ plugin:
 ```c++
 #include <Kaleidoscope.h>
 #include <Kaleidoscope-OneShot.h>
-#include <kaleidoscope/hid.h>
 
 // somewhere in the keymap...
 OSM(LeftControl), OSL(_FN)
@@ -108,8 +107,8 @@ modifiers and one-shot layer keys. It has the following methods:
 ### `.isModifierActive(key)`
 
 > Returns if the modifier `key` has a one-shot state active. Use this together
-> with `hid::isModifierKeyActive` to catch cases where a one-shot modifier is
-> active, but not registered yet.
+> with `Kaleidoscope.hid().keyboard().isModifierKeyActive` to catch cases where
+> a one-shot modifier is active, but not registered yet.
 
 ### `.cancel([with_stickies])`
 

--- a/doc/plugin/Syster.md
+++ b/doc/plugin/Syster.md
@@ -20,7 +20,6 @@ will handle the symbol actions:
 #include <Kaleidoscope-HostOS.h>
 #include <Kaleidoscope-Syster.h>
 #include <Kaleidoscope-Unicode.h>
-#include <kaleidoscope/hid.h>
 
 void systerAction(kaleidoscope::plugin::Syster::action_t action, const char *symbol) {
   switch (action) {
@@ -29,9 +28,9 @@ void systerAction(kaleidoscope::plugin::Syster::action_t action, const char *sym
     break;
   case kaleidoscope::plugin::Syster::EndAction:
     handleKeyswitchEvent (Key_Backspace, UnknownKeyswitchLocation, IS_PRESSED | INJECTED);
-    kaleidoscope::hid::sendKeyboardReport ();
+    Kaleidoscope.hid().keyboard().sendReport();
     handleKeyswitchEvent (Key_Backspace, UnknownKeyswitchLocation, WAS_PRESSED | INJECTED);
-    kaleidoscope::hid::sendKeyboardReport ();
+    Kaleidoscope.hid().keyboard().sendReport();
     break;
   case kaleidoscope::plugin::Syster::SymbolAction:
     Kaleidoscope.serialPort().print ("systerAction: symbol=");

--- a/examples/Keystrokes/Syster/Syster.ino
+++ b/examples/Keystrokes/Syster/Syster.ino
@@ -20,7 +20,6 @@
 #include <Kaleidoscope-HostOS.h>
 #include <Kaleidoscope-Syster.h>
 #include <Kaleidoscope-Unicode.h>
-#include <kaleidoscope/hid.h>
 
 // *INDENT-OFF*
 KEYMAPS(
@@ -51,9 +50,9 @@ void systerAction(kaleidoscope::plugin::Syster::action_t action, const char *sym
     break;
   case kaleidoscope::plugin::Syster::EndAction:
     handleKeyswitchEvent(Key_Backspace, UnknownKeyswitchLocation, IS_PRESSED | INJECTED);
-    kaleidoscope::hid::sendKeyboardReport();
+    Kaleidoscope.hid().keyboard().sendReport();
     handleKeyswitchEvent(Key_Backspace, UnknownKeyswitchLocation, WAS_PRESSED | INJECTED);
-    kaleidoscope::hid::sendKeyboardReport();
+    Kaleidoscope.hid().keyboard().sendReport();
     break;
   case kaleidoscope::plugin::Syster::SymbolAction:
     Kaleidoscope.serialPort().print("systerAction: symbol=");

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -58,7 +58,6 @@ static constexpr DEPRECATED(LED_COUNT) uint8_t LED_COUNT = kaleidoscope_internal
 
 #include "kaleidoscope/KeyAddr.h"
 #include "kaleidoscope/key_events.h"
-#include "kaleidoscope/hid.h"
 #include "kaleidoscope/layers.h"
 #include "kaleidoscope_internal/sketch_exploration/sketch_exploration.h"
 #include "kaleidoscope/macro_map.h"

--- a/src/kaleidoscope/Runtime.cpp
+++ b/src/kaleidoscope/Runtime.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "kaleidoscope/Runtime.h"
-#include "kaleidoscope/hid.h"
 #include "kaleidoscope/layers.h"
 #include "kaleidoscope/keyswitch_state.h"
 
@@ -43,10 +42,6 @@ Runtime_::setup(void) {
 
   device().setup();
 
-  kaleidoscope::hid::initializeKeyboard();
-  kaleidoscope::hid::initializeConsumerControl();
-  kaleidoscope::hid::initializeSystemControl();
-
   // Update the keymap cache, so we start with a non-empty state.
   Layer.updateActiveLayers();
   for (auto key_addr : KeyAddr::all()) {
@@ -64,8 +59,8 @@ Runtime_::loop(void) {
 
   kaleidoscope::Hooks::beforeReportingState();
 
-  kaleidoscope::hid::sendKeyboardReport();
-  kaleidoscope::hid::releaseAllKeys();
+  device().hid().keyboard().sendReport();
+  device().hid().keyboard().releaseAllKeys();
 
   kaleidoscope::Hooks::afterEachCycle();
 }

--- a/src/kaleidoscope/Runtime.h
+++ b/src/kaleidoscope/Runtime.h
@@ -70,6 +70,10 @@ class Runtime_ {
     return device().storage();
   }
 
+  auto hid() -> decltype(device().hid()) & {
+    return device().hid();
+  }
+
   void rebootBootloader() {
     device().rebootBootloader();
   }

--- a/src/kaleidoscope/device/Base.h
+++ b/src/kaleidoscope/device/Base.h
@@ -25,6 +25,7 @@
 #include "kaleidoscope_internal/deprecations.h"
 #include "kaleidoscope/macro_helpers.h"
 
+#include "kaleidoscope/driver/hid/Keyboardio.h"
 #include "kaleidoscope/driver/keyscanner/None.h"
 #include "kaleidoscope/driver/led/None.h"
 #include "kaleidoscope/driver/mcu/None.h"
@@ -52,6 +53,8 @@ namespace kaleidoscope {
 namespace device {
 
 struct BaseProps {
+  typedef kaleidoscope::driver::hid::KeyboardioProps HIDProps;
+  typedef kaleidoscope::driver::hid::Keyboardio<HIDProps> HID;
   typedef kaleidoscope::driver::keyscanner::BaseProps KeyScannerProps;
   typedef kaleidoscope::driver::keyscanner::None KeyScanner;
   typedef kaleidoscope::driver::led::BaseProps LEDDriverProps;
@@ -78,6 +81,8 @@ class Base {
 
   typedef _DeviceProps Props;
 
+  typedef typename _DeviceProps::HIDProps HIDProps;
+  typedef typename _DeviceProps::HID HID;
   typedef typename _DeviceProps::KeyScanner KeyScanner;
   typedef typename _DeviceProps::KeyScannerProps KeyScannerProps;
   typedef typename _DeviceProps::KeyScannerProps::KeyAddr KeyAddr;
@@ -100,6 +105,13 @@ class Base {
    */
   static constexpr int8_t numKeys() {
     return matrix_columns * matrix_rows;
+  }
+
+  /**
+   * Returns the HID driver used by the keyboard.
+   */
+  HID &hid() {
+    return hid_;
   }
 
   /**
@@ -483,6 +495,7 @@ class Base {
   void setup() {
     bootloader_.setup();
     mcu_.setup();
+    hid_.setup();
     storage_.setup();
     key_scanner_.setup();
     led_driver_.setup();
@@ -516,6 +529,7 @@ class Base {
   /** @} */
 
  protected:
+  HID hid_;
   KeyScanner key_scanner_;
   LEDDriver led_driver_;
   MCU mcu_;

--- a/src/kaleidoscope/device/dygma/Raise.cpp
+++ b/src/kaleidoscope/device/dygma/Raise.cpp
@@ -24,7 +24,6 @@
 #include <KeyboardioHID.h>
 #include <Wire.h>
 
-#include "kaleidoscope/hid.h"
 #include "kaleidoscope/util/crc16.h"
 #include "kaleidoscope/driver/color/GammaCorrection.h"
 #include "kaleidoscope/driver/keyscanner/Base_Impl.h"
@@ -418,8 +417,8 @@ void RaiseKeyScanner::setup() {
 void RaiseKeyScanner::reset() {
   leftHandState.all = 0;
   rightHandState.all = 0;
-  kaleidoscope::hid::releaseAllKeys();
-  kaleidoscope::hid::sendKeyboardReport();
+  Kaleidoscope.hid().keyboard().releaseAllKeys();
+  Kaleidoscope.hid().keyboard().sendReport();
 }
 
 /********* Hardware plugin *********/

--- a/src/kaleidoscope/device/dygma/Raise.h
+++ b/src/kaleidoscope/device/dygma/Raise.h
@@ -21,7 +21,6 @@
 #ifdef ARDUINO_SAMD_RAISE
 #include <Arduino.h>
 
-#include "Kaleidoscope-HIDAdaptor-KeyboardioHID.h"
 #include "kaleidoscope/device/dygma/raise/Hand.h"
 
 #define CRGB(r,g,b) (cRGB){b, g, r}

--- a/src/kaleidoscope/device/ez/ErgoDox.cpp
+++ b/src/kaleidoscope/device/ez/ErgoDox.cpp
@@ -28,7 +28,6 @@
 #ifdef ARDUINO_AVR_ERGODOX
 
 #include "kaleidoscope/Runtime.h"
-#include <KeyboardioHID.h>
 #include <avr/wdt.h>
 #include "kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.h"
 #include "kaleidoscope/key_events.h"
@@ -78,6 +77,8 @@ void ErgoDox::setup(void) {
   ICR1 = cycles;
   TCCR1B = _BV(WGM13) | _BV(CS10);
   TIMSK1 = _BV(TOIE1);
+
+  hid_.setup();
 }
 
 ISR(TIMER1_OVF_vect) {

--- a/src/kaleidoscope/device/ez/ErgoDox.h
+++ b/src/kaleidoscope/device/ez/ErgoDox.h
@@ -29,8 +29,6 @@
 
 #include <Arduino.h>
 
-#include "Kaleidoscope-HIDAdaptor-KeyboardioHID.h"
-
 struct cRGB {
   uint8_t r, g, b;
 };

--- a/src/kaleidoscope/device/keyboardio/Model01.cpp
+++ b/src/kaleidoscope/device/keyboardio/Model01.cpp
@@ -285,8 +285,8 @@ uint8_t Model01KeyScanner::previousPressedKeyswitchCount() {
 /********* Hardware plugin *********/
 
 void Model01::setup() {
-  KeyScanner::setup();
   Model01Hands::setup();
+  kaleidoscope::device::Base<Model01Props>::setup();
 
   TWBR = 12; // This is 400mhz, which is the fastest we can drive the ATTiny
 }

--- a/src/kaleidoscope/device/keyboardio/Model01.h
+++ b/src/kaleidoscope/device/keyboardio/Model01.h
@@ -127,7 +127,7 @@ struct Model01Props : public kaleidoscope::device::ATmega32U4KeyboardProps {
 
 class Model01 : public kaleidoscope::device::ATmega32U4Keyboard<Model01Props> {
  public:
-  static void setup();
+  void setup();
 
   static void enableHardwareTestMode();
 };

--- a/src/kaleidoscope/device/keyboardio/Model01.h
+++ b/src/kaleidoscope/device/keyboardio/Model01.h
@@ -33,7 +33,6 @@ struct cRGB {
 
 #include "kaleidoscope/driver/keyscanner/Base.h"
 #include "kaleidoscope/driver/led/Base.h"
-#include "Kaleidoscope-HIDAdaptor-KeyboardioHID.h"
 #include "kaleidoscope/driver/bootloader/avr/Caterina.h"
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/src/kaleidoscope/driver/hid/Base.h
+++ b/src/kaleidoscope/driver/hid/Base.h
@@ -1,0 +1,68 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <Arduino.h>
+#include "kaleidoscope/key_defs.h"
+
+#include "base/Keyboard.h"
+#include "base/Mouse.h"
+#include "base/AbsoluteMouse.h"
+
+namespace kaleidoscope {
+namespace driver {
+namespace hid {
+
+struct BaseProps {
+  typedef base::KeyboardProps KeyboardProps;
+  typedef base::Keyboard<KeyboardProps> Keyboard;
+  typedef base::MouseProps MouseProps;
+  typedef base::Mouse<MouseProps> Mouse;
+  typedef base::AbsoluteMouseProps AbsoluteMouseProps;
+  typedef base::AbsoluteMouse<AbsoluteMouseProps> AbsoluteMouse;
+};
+
+template <typename _Props>
+class Base {
+ private:
+  typename _Props::Keyboard keyboard_;
+  typename _Props::Mouse mouse_;
+  typename _Props::AbsoluteMouse absolute_mouse_;
+
+ public:
+  Base() {}
+
+  void setup() {
+    keyboard().setup();
+  }
+
+  auto keyboard() -> decltype(keyboard_) & {
+    return keyboard_;
+  }
+
+  auto mouse() -> decltype(mouse_) & {
+    return mouse_;
+  }
+
+  auto absoluteMouse() -> decltype(absolute_mouse_) & {
+    return absolute_mouse_;
+  }
+};
+
+}
+}
+}

--- a/src/kaleidoscope/driver/hid/Keyboardio.h
+++ b/src/kaleidoscope/driver/hid/Keyboardio.h
@@ -1,0 +1,47 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <Arduino.h>
+#include <KeyboardioHID.h>
+#include "kaleidoscope/key_defs.h"
+
+#include "kaleidoscope/driver/hid/Base.h"
+
+#include "keyboardio/Keyboard.h"
+#include "keyboardio/Mouse.h"
+#include "keyboardio/AbsoluteMouse.h"
+
+namespace kaleidoscope {
+namespace driver {
+namespace hid {
+
+struct KeyboardioProps: public BaseProps {
+  typedef keyboardio::KeyboardProps KeyboardProps;
+  typedef keyboardio::Keyboard<KeyboardProps> Keyboard;
+  typedef keyboardio::MouseProps MouseProps;
+  typedef keyboardio::Mouse<MouseProps> Mouse;
+  typedef keyboardio::AbsoluteMouseProps AbsoluteMouseProps;
+  typedef keyboardio::AbsoluteMouse<AbsoluteMouseProps> AbsoluteMouse;
+};
+
+template <typename _Props>
+class Keyboardio: public Base<_Props> {};
+
+}
+}
+}

--- a/src/kaleidoscope/driver/hid/base/AbsoluteMouse.h
+++ b/src/kaleidoscope/driver/hid/base/AbsoluteMouse.h
@@ -1,0 +1,76 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <Arduino.h>
+
+namespace kaleidoscope {
+namespace driver {
+namespace hid {
+namespace base {
+
+class NoAbsoluteMouse {
+ public:
+  NoAbsoluteMouse() {}
+
+  void begin() {}
+  void move(int8_t x, int8_t y, int8_t wheel) {}
+  void moveTo(uint16_t x, uint16_t y, uint8_t wheel) {}
+
+  void click(uint8_t buttons) {}
+  void press(uint8_t buttons) {}
+  void release(uint8_t buttons) {}
+};
+
+struct AbsoluteMouseProps {
+  typedef NoAbsoluteMouse AbsoluteMouse;
+};
+
+template <typename _Props>
+class AbsoluteMouse {
+ private:
+  typename _Props::AbsoluteMouse absolute_mouse_;
+ public:
+  AbsoluteMouse() {}
+
+  void setup() {
+    absolute_mouse_.begin();
+  }
+
+  void move(int8_t x, int8_t y, int8_t wheel) {
+    absolute_mouse_.move(x, y, wheel);
+  }
+  void moveTo(uint16_t x, uint16_t y, uint8_t wheel) {
+    absolute_mouse_.moveTo(x, y, wheel);
+  }
+
+  void clickButtons(uint8_t buttons) {
+    absolute_mouse_.click(buttons);
+  }
+  void pressButtons(uint8_t buttons) {
+    absolute_mouse_.press(buttons);
+  }
+  void releaseButtons(uint8_t buttons) {
+    absolute_mouse_.release(buttons);
+  }
+};
+
+}
+}
+}
+}

--- a/src/kaleidoscope/driver/hid/base/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/base/Keyboard.h
@@ -1,0 +1,485 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <Arduino.h>
+
+#include "kaleidoscope/key_defs.h"
+
+namespace kaleidoscope {
+namespace driver {
+namespace hid {
+namespace base {
+
+class NoBootKeyboard {
+ public:
+  NoBootKeyboard() {}
+  void begin() {}
+
+  uint8_t getProtocol() {
+    return 1;
+  }
+  void setProtocol(uint8_t protocol) {}
+  void setDefaultProtocol(uint8_t protocol) {}
+
+  void sendReport();
+
+  void press(uint8_t code) {}
+  void release(uint8_t code) {}
+  void releaseAll() {}
+
+  bool isModifierActive(uint8_t code) {
+    return false;
+  }
+  bool wasModifierActive(uint8_t code) {
+    return false;
+  }
+  bool isAnyModifierActive() {
+    return false;
+  }
+  bool wasAnyModifierActive() {
+    return false;
+  }
+
+  uint8_t getLeds() {
+    return 0;
+  }
+};
+
+class NoNKROKeyboard {
+ public:
+  NoNKROKeyboard() {}
+  void begin() {}
+
+  void sendReport() {}
+
+  void press(uint8_t code) {}
+  void release(uint8_t code) {}
+  void releaseAll() {}
+
+  bool isModifierActive(Key key) {
+    return false;
+  }
+  bool wasModifierActive(Key key) {
+    return false;
+  }
+  bool isAnyModifierActive() {
+    return false;
+  }
+  bool wasAnyModifierActive() {
+    return false;
+  }
+
+  uint8_t getLeds() {
+    return 0;
+  }
+};
+
+class NoConsumerControl {
+ public:
+  NoConsumerControl() {}
+  void begin() {}
+
+  void sendReport() {}
+  void releaseAll() {}
+
+  void press(uint8_t code) {}
+  void release(uint8_t code) {}
+};
+
+class NoSystemControl {
+ public:
+  NoSystemControl() {}
+  void begin() {}
+
+  void press(uint8_t code) {}
+  void release() {}
+};
+
+struct KeyboardProps {
+  typedef NoBootKeyboard BootKeyboard;
+  typedef NoNKROKeyboard NKROKeyboard;
+  typedef NoConsumerControl ConsumerControl;
+  typedef NoSystemControl SystemControl;
+};
+
+template <typename _Props>
+class Keyboard {
+ private:
+  typename _Props::BootKeyboard boot_keyboard_;
+  typename _Props::NKROKeyboard nkro_keyboard_;
+  typename _Props::ConsumerControl consumer_control_;
+  typename _Props::SystemControl system_control_;
+ public:
+  Keyboard() {}
+
+  void setup() __attribute__((noinline)) {
+    boot_keyboard_.begin();
+    nkro_keyboard_.begin();
+    consumer_control_.begin();
+    system_control_.begin();
+  }
+
+  void sendReport() __attribute__((noinline)) {
+    // Before sending the report, we add any modifier flags that are currently
+    // allowed, based on the latest keypress:
+    pressModifiers(requested_modifier_flags & modifier_flag_mask);
+
+    // If a key has been toggled on in this cycle, we might need to send an extra
+    // HID report to the host, because that key might have the same keycode as
+    // another key that was already in the report on the previous cycle. For
+    // example, a user could have two `Key_E` keys in their keymap, in order to
+    // avoid repeating the same key with one finger. Or one might have a
+    // `LCTRL(Key_S)` and a plain `Key_S`, and have a reason to press them in
+    // rapid succession. In order to make this work, we need to call `release()` &
+    // `sendReport()` to send a release event to the host so that its normal
+    // repeat-rate-limiting behaviour won't effectively mask the second keypress.
+    // Then we call `press()` to add the keycode back in before sending the normal
+    // report.
+    //
+    // In most cases, this won't result in any difference from the previous report
+    // (because the newly-toggled-on keycode won't be in the previous report), so
+    // no extra report will be sent (because we suppress duplicate reports in
+    // KeyboardioHID). If there is a difference in the modifiers byte, an extra
+    // report would be sent later, regardless (also in KeyboardioHID).
+    //
+    // Furthermore, we need to send a report without the keycode for the
+    // newly-toggled-on key, but with any masked modifiers from flags removed. For
+    // example, if we roll over from `LSHIFT(Key_A)` to `Key_B`, we need to first
+    // send a report without the `shift`, then a second report with the `B`. If
+    // both of those bits are changed in the same report, at least one major OS
+    // processes the `B` keypress first, and we end up with `AB` instead of `Ab`
+    // in the output.
+
+    if (boot_keyboard_.getProtocol() == HID_BOOT_PROTOCOL) {
+      if (last_keycode_toggled_on) {
+        boot_keyboard_.release(last_keycode_toggled_on);
+        boot_keyboard_.sendReport();
+        boot_keyboard_.press(last_keycode_toggled_on);
+        last_keycode_toggled_on = 0;
+      }
+      boot_keyboard_.sendReport();
+      return;
+    }
+
+    if (last_keycode_toggled_on) {
+      // It would be good if KeyboardioHID's Keyboard object offered a way to
+      // compare the modifiers bytes of the current and previous key reports. That
+      // would allow us to only send these extra reports when either
+      // `last_keycode_toggled_on` was already held, or the modifiers byte
+      // changed. Likewise for BootKeyboard above.
+      nkro_keyboard_.release(last_keycode_toggled_on);
+      nkro_keyboard_.sendReport();
+      nkro_keyboard_.press(last_keycode_toggled_on);
+      last_keycode_toggled_on = 0;
+    }
+
+    nkro_keyboard_.sendReport();
+    consumer_control_.sendReport();
+  }
+  void releaseAllKeys() __attribute__((noinline)) {
+    resetModifierTracking();
+    nkro_keyboard_.releaseAll();
+    consumer_control_.releaseAll();
+  }
+  void pressConsumerControl(Key mapped_key) {
+    consumer_control_.press(CONSUMER(mapped_key));
+  }
+  void releaseConsumerControl(Key mapped_key) {
+    consumer_control_.release(CONSUMER(mapped_key));
+  }
+  void pressSystemControl(Key mapped_key) {
+    system_control_.press(mapped_key.getKeyCode());
+  }
+  void releaseSystemControl(Key mapped_key) {
+    system_control_.release();
+  }
+
+  // pressKey takes a Key, as well as optional boolean 'toggledOn' which defaults
+  // to 'true'
+
+  // If toggled_on is not set to false, this routine adds the modifier flags on
+  // this key to the bitmask of modifiers that are allowed to be added to the
+  // upcoming report. We do this so that when we roll over from a key with a
+  // modifier flag to one without it, that modifier flag won't affect the new
+  // keypress.
+
+  // If the key we're processing is a modifier key, any modifier flags attached to
+  // it are added directly to the report along with the modifier from its keycode
+  // byte.
+  //
+  // (A 'modifier key' is one of the eight modifier keys defined by the HID
+  // standard: left and right variants of Control, Shift, Alt, and GUI.)
+
+  // Eventually it calls pressRawKey.
+
+  void pressKey(Key pressed_key, boolean toggled_on = true) __attribute__((noinline)) {
+    if (toggled_on) {
+      // If two keys are toggled on during the same USB report, we would ideally
+      // send an extra USB report to help the host handle each key correctly, but
+      // this is problematic.
+
+      // If we simply allow modifiers associated with the second newly-pressed
+      // key, it is possible to drop a modifier before the report is sent.
+      // Instead, we send modifiers associated with any newly-pressed keys.
+
+      // The downside of this behavior is that in cases where the user presses
+      // down keys with conflicting modifiers at the exact same moment, they may
+      // get unexpected behavior.
+
+      // If this is the first 'new' keycode being pressed in this cycle, reset the
+      // bitmask of modifiers we're willing to attach to USB HID keyboard reports
+      if (!last_keycode_toggled_on) {
+        modifier_flag_mask = 0;
+      }
+
+      // Add any modifiers attached to this key to the bitmask of modifiers we're
+      // willing to attach to USB HID keyboard reports
+      modifier_flag_mask |= pressed_key.getFlags();
+
+      if (!isModifierKey(pressed_key)) {
+        last_keycode_toggled_on = pressed_key.getKeyCode();
+      }
+    }
+
+
+    if (isModifierKey(pressed_key)) {
+      // If the key is a modifier key with additional modifiers attached to it as
+      // flags (as one might when creating a 'Hyper' key or a "Control Alt" key,
+      // we assume that all those modifiers are intended to modify other keys
+      // pressed while this key is held, so they are never masked out.
+      pressModifiers(pressed_key.getFlags());
+    } else {
+      // If, instead, the modifiers are attached to a 'printable' or non-modifier
+      // key, we assume that they're not intended to modify other keys, so we add
+      // them to requested_modifier_flags, and only allow them to affect the report if
+      // the most recent keypress includes those modifiers.
+      requestModifiers(pressed_key.getFlags());
+    }
+
+    pressRawKey(pressed_key);
+  }
+
+  // pressRawKey takes a Key object and calles KeyboardioHID's ".press" method
+  // with its keycode. It does no processing of any flags or modifiers on the key
+  void pressRawKey(Key pressed_key) {
+    if (boot_keyboard_.getProtocol() == HID_BOOT_PROTOCOL) {
+      boot_keyboard_.press(pressed_key.getKeyCode());
+      return;
+    }
+
+    nkro_keyboard_.press(pressed_key.getKeyCode());
+  }
+
+  void releaseRawKey(Key released_key) {
+    if (boot_keyboard_.getProtocol() == HID_BOOT_PROTOCOL) {
+      boot_keyboard_.release(released_key.getKeyCode());
+      return;
+    }
+
+    nkro_keyboard_.release(released_key.getKeyCode());
+  }
+
+  void releaseKey(Key released_key) {
+    // Remove any modifiers attached to this key from the bitmask of modifiers we're
+    // willing to attach to USB HID keyboard reports
+    modifier_flag_mask ^= released_key.getFlags();
+
+    if (!isModifierKey(released_key)) {
+
+      // TODO: this code is incomplete, but is better than nothing
+      // If we're toggling off the most recently toggled on key, clear
+      // last_keycode_toggled_on
+      if (last_keycode_toggled_on == released_key.getKeyCode()) {
+        last_keycode_toggled_on = 0;
+      }
+
+      // If the modifiers are attached to a 'printable' or non-modifier
+      // key, we need to clean up after the key press which would have requested
+      // the modifiers be pressed if the most recent keypress includes those modifiers.
+      cancelModifierRequest(released_key.getFlags());
+    }
+
+    releaseModifiers(released_key.getFlags());
+    releaseRawKey(released_key);
+  }
+
+  boolean isModifierKeyActive(Key modifier_key) {
+    if (boot_keyboard_.getProtocol() == HID_BOOT_PROTOCOL) {
+      return boot_keyboard_.isModifierActive(modifier_key.getKeyCode());
+    }
+
+    return nkro_keyboard_.isModifierActive(modifier_key.getKeyCode());
+  }
+
+  boolean wasModifierKeyActive(Key modifier_key) {
+    if (boot_keyboard_.getProtocol() == HID_BOOT_PROTOCOL) {
+      return boot_keyboard_.wasModifierActive(modifier_key.getKeyCode());
+    }
+
+    return nkro_keyboard_.wasModifierActive(modifier_key.getKeyCode());
+  }
+
+  boolean isAnyModifierKeyActive() {
+    if (boot_keyboard_.getProtocol() == HID_BOOT_PROTOCOL) {
+      return boot_keyboard_.isAnyModifierActive();
+    }
+
+    return nkro_keyboard_.isAnyModifierActive();
+  }
+
+  boolean wasAnyModifierKeyActive() {
+    if (boot_keyboard_.getProtocol() == HID_BOOT_PROTOCOL) {
+      return boot_keyboard_.wasAnyModifierActive();
+    }
+
+    return nkro_keyboard_.wasAnyModifierActive();
+  }
+
+  uint8_t getKeyboardLEDs() {
+    if (boot_keyboard_.getProtocol() == HID_BOOT_PROTOCOL) {
+      return boot_keyboard_.getLeds();
+    }
+
+    return nkro_keyboard_.getLeds();
+  }
+
+  uint8_t getProtocol() {
+    return boot_keyboard_.getProtocol();
+  }
+  void setProtocol(uint8_t protocol) {
+    boot_keyboard_.setProtocol(protocol);
+  }
+  void setDefaultProtocol(uint8_t protocol) {
+    boot_keyboard_.setDefaultProtocol(protocol);
+  }
+
+ private:
+  // modifier_flag_mask is a bitmask of modifiers that we found attached to
+  // keys that were newly pressed down during the most recent cycle with any new
+  // keypresses.
+
+  // This is used to determine which modifier flags will be allowed to be added to
+  // the current keyboard HID report. It gets set during any cycle where one or
+  // more new keys is toggled on and presists until the next cycle with a newly
+  // detected keypress.
+
+  uint8_t modifier_flag_mask = 0;
+
+  // The functions in this namespace are primarily to solve the problem of
+  // rollover from a key with a modifier flag (e.g. `LSHIFT(Key_T)`) to one
+  // without (e.g. `Key_H`), which used to result in the mod flag being applied to
+  // keys other than the one with the flag. By using `modifier_flag_mask`, we can
+  // mask out any modifier flags that aren't attached to modifier keys or keys
+  // pressed or held in the most recent cycle, mitigating the rollover problem,
+  //  and getting the intended `The` instead of `THe`.
+
+  // requested_modifier_flags is bitmap of the modifiers attached to any non-modifier
+  // key found to be pressed during the most recent cycle. For example, it would
+  // include modifiers attached to Key_A, but not modifiers attached to
+  // Key_LeftControl
+
+  uint8_t requested_modifier_flags = 0;
+
+  // last_keycode_toggled_on is the keycode of the key most recently toggled on
+  // for this report.  This is set when a keypress is first detected and cleared
+  // after the report is sent. If multiple keys are toggled on during a single
+  // cycle, this contains the most recently handled one.
+
+  uint8_t last_keycode_toggled_on = 0;
+
+  void resetModifierTracking(void) {
+    last_keycode_toggled_on = 0;
+    requested_modifier_flags = 0;
+  }
+
+  // isModifierKey takes a Key and returns true if the key is a
+  // keyboard key corresponding to a modifier like Control, Alt or Shift
+  // TODO: This function should be lifted to the Kaleidoscope core, somewhere.
+
+  bool isModifierKey(Key key) {
+    // If it's not a keyboard key, return false
+    if (key.getFlags() & (SYNTHETIC | RESERVED)) return false;
+
+    return (key.getKeyCode() >= HID_KEYBOARD_FIRST_MODIFIER &&
+            key.getKeyCode() <= HID_KEYBOARD_LAST_MODIFIER);
+  }
+
+  // requestModifiers takes a bitmap of modifiers that might apply
+  // to the next USB HID report and adds them to a bitmap of all such modifiers.
+
+  void requestModifiers(byte flags) {
+    requested_modifier_flags |= flags;
+  }
+
+  // cancelModifierRequest takes a bitmap of modifiers that should no longer apply
+  // to the next USB HID report and removes them from the bitmap of all such modifiers.
+
+  void cancelModifierRequest(byte flags) {
+    requested_modifier_flags ^= flags;
+  }
+
+  // pressModifiers takes a bitmap of modifier keys that must be included in
+  // the upcoming USB HID report and passes them through to KeyboardioHID
+  // immediately
+
+  void pressModifiers(byte flags) {
+    if (flags & SHIFT_HELD) {
+      pressRawKey(Key_LeftShift);
+    }
+    if (flags & CTRL_HELD) {
+      pressRawKey(Key_LeftControl);
+    }
+    if (flags & LALT_HELD) {
+      pressRawKey(Key_LeftAlt);
+    }
+    if (flags & RALT_HELD) {
+      pressRawKey(Key_RightAlt);
+    }
+    if (flags & GUI_HELD) {
+      pressRawKey(Key_LeftGui);
+    }
+  }
+
+  // releaseModifiers takes a bitmap of modifier keys that must not be included in
+  // the upcoming USB HID report and passes them through to KeyboardioHID
+  // immediately
+
+  void releaseModifiers(byte flags) {
+    if (flags & SHIFT_HELD) {
+      releaseRawKey(Key_LeftShift);
+    }
+    if (flags & CTRL_HELD) {
+      releaseRawKey(Key_LeftControl);
+    }
+    if (flags & LALT_HELD) {
+      releaseRawKey(Key_LeftAlt);
+    }
+    if (flags & RALT_HELD) {
+      releaseRawKey(Key_RightAlt);
+    }
+    if (flags & GUI_HELD) {
+      releaseRawKey(Key_LeftGui);
+    }
+  }
+
+};
+
+}
+}
+}
+}

--- a/src/kaleidoscope/driver/hid/base/Mouse.h
+++ b/src/kaleidoscope/driver/hid/base/Mouse.h
@@ -1,0 +1,95 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <Arduino.h>
+
+namespace kaleidoscope {
+namespace driver {
+namespace hid {
+namespace base {
+
+class NoMouse {
+ public:
+  NoMouse() {}
+
+  void begin() {}
+  void sendReport() {}
+  void move(int8_t x, int8_t y, int8_t vWheel, int8_t hWheel) {}
+  void releaseAll() {}
+  void press(uint8_t buttons) {}
+  void release(uint8_t buttons) {}
+  void click(uint8_t buttons) {}
+  HID_MouseReport_Data_t getReport() {
+    static HID_MouseReport_Data_t report;
+    return report;
+  }
+};
+
+struct MouseProps {
+  typedef NoMouse Mouse;
+};
+
+template <typename _Props>
+class Mouse {
+ private:
+  typename _Props::Mouse mouse_;
+ public:
+  Mouse() {}
+
+  void setup() {
+    mouse_.begin();
+  }
+
+  void sendReport() {
+    mouse_.sendReport();
+  }
+
+  void move(int8_t x, int8_t y, int8_t vWheel = 0, int8_t hWheel = 0) {
+    mouse_.move(x, y, vWheel, hWheel);
+  }
+  void stop(bool x, bool y, bool vWheel = false, bool hWheel = false) {
+    HID_MouseReport_Data_t report = mouse_.getReport();
+
+    if (x)
+      report.xAxis = 0;
+    if (y)
+      report.yAxis = 0;
+    if (vWheel)
+      report.vWheel = 0;
+    if (hWheel)
+      report.hWheel = 0;
+    move(report.xAxis, report.yAxis, report.vWheel, report.hWheel);
+  }
+  void releaseAllButtons() {
+    mouse_.releaseAll();
+  }
+  void pressButtons(uint8_t buttons) {
+    mouse_.press(buttons);
+  }
+  void releaseButtons(uint8_t buttons) {
+    mouse_.release(buttons);
+  }
+  void clickButtons(uint8_t buttons) {
+    mouse_.click(buttons);
+  }
+};
+
+}
+}
+}
+}

--- a/src/kaleidoscope/driver/hid/keyboardio/AbsoluteMouse.h
+++ b/src/kaleidoscope/driver/hid/keyboardio/AbsoluteMouse.h
@@ -1,0 +1,75 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <Arduino.h>
+#include <KeyboardioHID.h>
+
+#include "kaleidoscope/driver/hid/base/AbsoluteMouse.h"
+
+namespace kaleidoscope {
+namespace driver {
+namespace hid {
+namespace keyboardio {
+
+/*
+ * We are wrapping `SingleAbsoluteMouse` here, instead of directly using the
+ * class in `AbsoluteMouseProps` below. We do this, because this lets the linker
+ * optimize this whole thing out if it is unused. It can do that because
+ * instantiating `SingleAbsoluteMouse` is in a separate compilation unit.
+ *
+ * While it would have been cleaner and shorter to instantiate them here, and
+ * drop the global objects, that prevents optimizing them out, and that's a cost
+ * we do not want to pay.
+ */
+class AbsoluteMouseWrapper {
+ public:
+  AbsoluteMouseWrapper() {}
+
+  void begin() {
+    SingleAbsoluteMouse.begin();
+  }
+  void move(int8_t x, int8_t y, int8_t wheel) {
+    SingleAbsoluteMouse.move(x, y, wheel);
+  }
+  void moveTo(uint16_t x, uint16_t y, uint8_t wheel) {
+    SingleAbsoluteMouse.moveTo(x, y, wheel);
+  }
+
+  void click(uint8_t buttons) {
+    SingleAbsoluteMouse.click(buttons);
+  }
+  void press(uint8_t buttons) {
+    SingleAbsoluteMouse.press(buttons);
+  }
+  void release(uint8_t buttons) {
+    SingleAbsoluteMouse.release(buttons);
+  }
+};
+
+struct AbsoluteMouseProps: public base::AbsoluteMouseProps {
+  typedef AbsoluteMouseWrapper AbsoluteMouse;
+};
+
+template <typename _Props>
+class AbsoluteMouse: public base::AbsoluteMouse<_Props> {};
+
+}
+}
+}
+}

--- a/src/kaleidoscope/driver/hid/keyboardio/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/keyboardio/Keyboard.h
@@ -1,0 +1,179 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <Arduino.h>
+#include <KeyboardioHID.h>
+
+#include "kaleidoscope/driver/hid/base/Keyboard.h"
+
+namespace kaleidoscope {
+namespace driver {
+namespace hid {
+namespace keyboardio {
+
+/*
+ * We are wrapping a few keyboard-related objects here, instead of directly
+ * using the classes in `KeyboardProps` below. We do this, because this lets the
+ * linker optimize this whole thing out if it is unused. It can do that because
+ * instantiating `Keyboard_` & co is in a separate compilation unit.
+ *
+ * While it would have been cleaner and shorter to instantiate them here, and
+ * drop the global objects, that prevents optimizing them out, and that's a cost
+ * we do not want to pay.
+ */
+
+class BootKeyboardWrapper {
+ public:
+  BootKeyboardWrapper() {}
+  void begin() {
+    BootKeyboard.begin();
+  }
+
+  uint8_t getProtocol() {
+    return BootKeyboard.getProtocol();
+  }
+  void setProtocol(uint8_t protocol) {
+    BootKeyboard.setProtocol(protocol);
+  }
+  void setDefaultProtocol(uint8_t protocol) {
+    BootKeyboard.default_protocol = protocol;
+    setProtocol(protocol);
+  }
+
+  void sendReport() {
+    BootKeyboard.sendReport();
+  }
+
+  void press(uint8_t code) {
+    BootKeyboard.press(code);
+  }
+  void release(uint8_t code) {
+    BootKeyboard.release(code);
+  }
+  void releaseAll() {
+    BootKeyboard.releaseAll();
+  }
+
+  bool isModifierActive(uint8_t code) {
+    return BootKeyboard.isModifierActive(code);
+  }
+  bool wasModifierActive(uint8_t code) {
+    return BootKeyboard.wasModifierActive(code);
+  }
+  bool isAnyModifierActive() {
+    return BootKeyboard.isAnyModifierActive();
+  }
+  bool wasAnyModifierActive() {
+    return BootKeyboard.wasAnyModifierActive();
+  }
+
+  uint8_t getLeds() {
+    return BootKeyboard.getLeds();
+  }
+};
+
+class NKROKeyboardWrapper {
+ public:
+  NKROKeyboardWrapper() {}
+  void begin() {
+    Keyboard.begin();
+  }
+
+  void sendReport() {
+    Keyboard.sendReport();
+  }
+
+  void press(uint8_t code) {
+    Keyboard.press(code);
+  }
+  void release(uint8_t code) {
+    Keyboard.release(code);
+  }
+  void releaseAll() {
+    Keyboard.releaseAll();
+  }
+
+  bool isModifierActive(uint8_t code) {
+    return Keyboard.isModifierActive(code);
+  }
+  bool wasModifierActive(uint8_t code) {
+    return Keyboard.wasModifierActive(code);
+  }
+  bool isAnyModifierActive() {
+    return Keyboard.isAnyModifierActive();
+  }
+  bool wasAnyModifierActive() {
+    return Keyboard.wasAnyModifierActive();
+  }
+
+  uint8_t getLeds() {
+    return Keyboard.getLEDs();
+  }
+};
+
+class ConsumerControlWrapper {
+ public:
+  ConsumerControlWrapper() {}
+  void begin() {
+    ConsumerControl.begin();
+  }
+
+  void sendReport() {
+    ConsumerControl.sendReport();
+  }
+  void releaseAll() {
+    ConsumerControl.releaseAll();
+  }
+
+  void press(uint8_t code) {
+    ConsumerControl.press(code);
+  }
+  void release(uint8_t code) {
+    ConsumerControl.release(code);
+  }
+};
+
+class SystemControlWrapper {
+ public:
+  SystemControlWrapper() {}
+  void begin() {
+    SystemControl.begin();
+  }
+
+  void press(uint8_t code) {
+    SystemControl.press(code);
+  }
+  void release() {
+    SystemControl.release();
+  }
+};
+
+struct KeyboardProps: public base::KeyboardProps {
+  typedef BootKeyboardWrapper BootKeyboard;
+  typedef NKROKeyboardWrapper NKROKeyboard;
+  typedef ConsumerControlWrapper ConsumerControl;
+  typedef SystemControlWrapper SystemControl;
+};
+
+template <typename _Props>
+class Keyboard: public base::Keyboard<_Props> {};
+
+}
+}
+}
+}

--- a/src/kaleidoscope/driver/hid/keyboardio/Mouse.h
+++ b/src/kaleidoscope/driver/hid/keyboardio/Mouse.h
@@ -1,0 +1,80 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <Arduino.h>
+#include <KeyboardioHID.h>
+
+#include "kaleidoscope/driver/hid/base/Mouse.h"
+
+namespace kaleidoscope {
+namespace driver {
+namespace hid {
+namespace keyboardio {
+
+/*
+ * We are wrapping `Mouse` here, instead of directly using the class in
+ * `MouseProps` below. We do this, because this lets the linker optimize this
+ * whole thing out if it is unused. It can do that because instantiating `Mouse`
+ * is in a separate compilation unit.
+ *
+ * While it would have been cleaner and shorter to instantiate them here, and
+ * drop the global objects, that prevents optimizing them out, and that's a cost
+ * we do not want to pay.
+ */
+
+class MouseWrapper {
+ public:
+  MouseWrapper() {}
+
+  void begin() {
+    Mouse.begin();
+  }
+  void sendReport() {
+    Mouse.sendReport();
+  }
+  void move(int8_t x, int8_t y, int8_t vWheel, int8_t hWheel) {
+    Mouse.move(x, y, vWheel, hWheel);
+  }
+  void releaseAll() {
+    Mouse.releaseAll();
+  }
+  void press(uint8_t buttons) {
+    Mouse.press(buttons);
+  }
+  void release(uint8_t buttons) {
+    Mouse.release(buttons);
+  }
+  void click(uint8_t buttons) {
+    Mouse.click(buttons);
+  }
+  HID_MouseReport_Data_t getReport() {
+    return Mouse.getReport();
+  }
+};
+
+struct MouseProps: public base::MouseProps {
+  typedef MouseWrapper Mouse;
+};
+
+template <typename _Props>
+class Mouse: public base::Mouse<_Props> {};
+
+}
+}
+}
+}

--- a/src/kaleidoscope/driver/keyscanner/ATmega.h
+++ b/src/kaleidoscope/driver/keyscanner/ATmega.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <Arduino.h>
-#include "Kaleidoscope-HIDAdaptor-KeyboardioHID.h"
 
 #include "kaleidoscope/macro_helpers.h"
 #include "kaleidoscope/driver/keyscanner/Base.h"

--- a/src/kaleidoscope/hid.h
+++ b/src/kaleidoscope/hid.h
@@ -1,5 +1,5 @@
 /* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2018  Keyboard.io, Inc.
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -16,44 +16,44 @@
 
 #pragma once
 #include <Arduino.h>
+
+#include <Kaleidoscope-HIDAdaptor-KeyboardioHID.h>
 #include "kaleidoscope/key_defs.h"
+#include "kaleidoscope_internal/deprecations.h"
 
 namespace kaleidoscope {
 namespace hid {
 
-// A facade on top of our HID implementation
-
-extern void initializeKeyboard();
-
-extern void pressKey(Key mappedKey, boolean toggledOn = true);
-extern void releaseKey(Key mappedKey);
-extern void releaseAllKeys();
-extern void pressRawKey(Key mappedKey);
-extern void releaseRawKey(Key mappedKey);
+extern void initializeKeyboard() DEPRECATED(HID_FACADE);
+extern void pressKey(Key mappedKey, boolean toggledOn = true) DEPRECATED(HID_FACADE);
+extern void releaseKey(Key mappedKey) DEPRECATED(HID_FACADE);
+extern void releaseAllKeys() DEPRECATED(HID_FACADE);
+extern void pressRawKey(Key mappedKey) DEPRECATED(HID_FACADE);
+extern void releaseRawKey(Key mappedKey) DEPRECATED(HID_FACADE);
 /** Flushes any pending regular key switch events and sends them out */
-extern void sendKeyboardReport();
+extern void sendKeyboardReport() DEPRECATED(HID_FACADE);
 
-extern boolean isModifierKeyActive(Key mappedKey);
-extern boolean wasModifierKeyActive(Key mappedKey);
+extern boolean isModifierKeyActive(Key mappedKey) DEPRECATED(HID_FACADE);
+extern boolean wasModifierKeyActive(Key mappedKey) DEPRECATED(HID_FACADE);
 
-extern boolean isAnyModifierKeyActive();
-extern boolean wasAnyModifierKeyActive();
+extern boolean isAnyModifierKeyActive() DEPRECATED(HID_FACADE);
+extern boolean wasAnyModifierKeyActive() DEPRECATED(HID_FACADE);
 
-extern uint8_t getKeyboardLEDs();
+extern uint8_t getKeyboardLEDs() DEPRECATED(HID_FACADE);
 
-extern void initializeConsumerControl();
+extern void initializeConsumerControl() DEPRECATED(HID_FACADE);
 
-extern void pressConsumerControl(Key mappedKey);
-extern void releaseConsumerControl(Key mappedKey);
+extern void pressConsumerControl(Key mappedKey) DEPRECATED(HID_FACADE);
+extern void releaseConsumerControl(Key mappedKey) DEPRECATED(HID_FACADE);
 
-extern void initializeSystemControl();
+extern void initializeSystemControl() DEPRECATED(HID_FACADE);
 
-extern void pressSystemControl(Key mappedKey);
-extern void releaseSystemControl(Key mappedKey);
+extern void pressSystemControl(Key mappedKey) DEPRECATED(HID_FACADE);
+extern void releaseSystemControl(Key mappedKey) DEPRECATED(HID_FACADE);
 
-extern void initializeMouse();
+extern void initializeMouse() DEPRECATED(HID_FACADE);
 
-extern void moveMouse(signed char x, signed char y, signed char vWheel = 0, signed char hWheel = 0);
+extern void moveMouse(signed char x, signed char y, signed char vWheel = 0, signed char hWheel = 0) DEPRECATED(HID_FACADE);
 /** stopMouse() stops mouse and/or mouse wheel movement in given directions.
  *
  * Counterpart of moveMouse(), this function allows us to undo whatever movement
@@ -64,20 +64,20 @@ extern void moveMouse(signed char x, signed char y, signed char vWheel = 0, sign
  * Any of the arguments that is set to true, will be cleared from the report to
  * be sent by the next call to sendMouseReport().
  */
-extern void stopMouse(bool x, bool y, bool vWheel = false, bool hWheel = false);
-extern void clickMouseButtons(uint8_t buttons);
-extern void pressMouseButtons(uint8_t buttons);
-extern void releaseMouseButtons(uint8_t buttons);
-extern void releaseAllMouseButtons(void);
-extern void sendMouseReport(void);
+extern void stopMouse(bool x, bool y, bool vWheel = false, bool hWheel = false) DEPRECATED(HID_FACADE);
+extern void clickMouseButtons(uint8_t buttons) DEPRECATED(HID_FACADE);
+extern void pressMouseButtons(uint8_t buttons) DEPRECATED(HID_FACADE);
+extern void releaseMouseButtons(uint8_t buttons) DEPRECATED(HID_FACADE);
+extern void releaseAllMouseButtons(void) DEPRECATED(HID_FACADE);
+extern void sendMouseReport(void) DEPRECATED(HID_FACADE);
 
-extern void initializeAbsoluteMouse();
+extern void initializeAbsoluteMouse() DEPRECATED(HID_FACADE);
 
-extern void moveAbsoluteMouse(signed char x, signed char y, signed char wheel);
-extern void moveAbsoluteMouseTo(uint16_t x, uint16_t y, signed char wheel);
-extern void clickAbsoluteMouseButtons(uint8_t buttons);
-extern void pressAbsoluteMouseButtons(uint8_t buttons);
-extern void releaseAbsoluteMouseButtons(uint8_t buttons);
+extern void moveAbsoluteMouse(signed char x, signed char y, signed char wheel) DEPRECATED(HID_FACADE);
+extern void moveAbsoluteMouseTo(uint16_t x, uint16_t y, signed char wheel) DEPRECATED(HID_FACADE);
+extern void clickAbsoluteMouseButtons(uint8_t buttons) DEPRECATED(HID_FACADE);
+extern void pressAbsoluteMouseButtons(uint8_t buttons) DEPRECATED(HID_FACADE);
+extern void releaseAbsoluteMouseButtons(uint8_t buttons) DEPRECATED(HID_FACADE);
 
 }
 };

--- a/src/kaleidoscope/key_defs.h
+++ b/src/kaleidoscope/key_defs.h
@@ -26,8 +26,6 @@
 
 #include "kaleidoscope/key_defs_aliases.h"
 
-#include "KeyboardioHID.h"
-
 namespace kaleidoscope {
 
 class Key {

--- a/src/kaleidoscope/key_events.cpp
+++ b/src/kaleidoscope/key_events.cpp
@@ -17,7 +17,6 @@
 #include "kaleidoscope/Runtime.h"
 #include "kaleidoscope/hooks.h"
 #include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/hid.h"
 #include "kaleidoscope/layers.h"
 
 static bool handleSyntheticKeyswitchEvent(Key mappedKey, uint8_t keyState) {
@@ -27,14 +26,16 @@ static bool handleSyntheticKeyswitchEvent(Key mappedKey, uint8_t keyState) {
   if (!(mappedKey.getFlags() & SYNTHETIC))
     return false;
 
+  using kaleidoscope::Runtime;
+
   if (mappedKey.getFlags() & IS_CONSUMER) {
     if (keyIsPressed(keyState))
-      kaleidoscope::hid::pressConsumerControl(mappedKey);
+      Runtime.hid().keyboard().pressConsumerControl(mappedKey);
   } else if (mappedKey.getFlags() & IS_SYSCTL) {
     if (keyIsPressed(keyState)) {
     } else if (keyWasPressed(keyState)) {
-      kaleidoscope::hid::pressSystemControl(mappedKey);
-      kaleidoscope::hid::releaseSystemControl(mappedKey);
+      Runtime.hid().keyboard().pressSystemControl(mappedKey);
+      Runtime.hid().keyboard().releaseSystemControl(mappedKey);
     }
   } else if (mappedKey.getFlags() & IS_INTERNAL) {
     return false;
@@ -46,17 +47,18 @@ static bool handleSyntheticKeyswitchEvent(Key mappedKey, uint8_t keyState) {
 }
 
 static bool handleKeyswitchEventDefault(Key mappedKey, KeyAddr key_addr, uint8_t keyState) {
+  using kaleidoscope::Runtime;
   //for every newly pressed button, figure out what logical key it is and send a key down event
   // for every newly released button, figure out what logical key it is and send a key up event
 
   if (mappedKey.getFlags() & SYNTHETIC) {
     handleSyntheticKeyswitchEvent(mappedKey, keyState);
   } else if (keyToggledOn(keyState)) {
-    kaleidoscope::hid::pressKey(mappedKey);
+    Runtime.hid().keyboard().pressKey(mappedKey);
   } else if (keyIsPressed(keyState)) {
-    kaleidoscope::hid::pressKey(mappedKey, false);
+    Runtime.hid().keyboard().pressKey(mappedKey, false);
   } else if (keyToggledOff(keyState) && (keyState & INJECTED)) {
-    kaleidoscope::hid::releaseKey(mappedKey);
+    Runtime.hid().keyboard().releaseKey(mappedKey);
   }
   return true;
 }

--- a/src/kaleidoscope/plugin/Cycle.cpp
+++ b/src/kaleidoscope/plugin/Cycle.cpp
@@ -17,7 +17,6 @@
 
 #include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Cycle.h>
-#include "kaleidoscope/hid.h"
 #include "kaleidoscope/keyswitch_state.h"
 #include "kaleidoscope/key_events.h"
 
@@ -36,14 +35,14 @@ uint8_t Cycle::cycle_count_;
 
 void Cycle::replace(Key key) {
   handleKeyswitchEvent(Key_Backspace, UnknownKeyswitchLocation, IS_PRESSED | INJECTED);
-  hid::sendKeyboardReport();
+  kaleidoscope::Runtime.hid().keyboard().sendReport();
   handleKeyswitchEvent(Key_Backspace, UnknownKeyswitchLocation, WAS_PRESSED | INJECTED);
-  hid::sendKeyboardReport();
+  kaleidoscope::Runtime.hid().keyboard().sendReport();
 
   handleKeyswitchEvent(key, UnknownKeyswitchLocation, IS_PRESSED | INJECTED);
-  hid::sendKeyboardReport();
+  kaleidoscope::Runtime.hid().keyboard().sendReport();
   handleKeyswitchEvent(key, UnknownKeyswitchLocation, WAS_PRESSED | INJECTED);
-  hid::sendKeyboardReport();
+  kaleidoscope::Runtime.hid().keyboard().sendReport();
 }
 
 void Cycle::replace(uint8_t cycle_size, const Key cycle_steps[]) {

--- a/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "Kaleidoscope-DynamicMacros.h"
-#include "kaleidoscope/hid.h"
 #include "Kaleidoscope-FocusSerial.h"
 #include "kaleidoscope/keyswitch_state.h"
 #include "kaleidoscope/key_events.h"
@@ -35,8 +34,8 @@ static void playMacroKeyswitchEvent(Key key, uint8_t keyswitch_state, bool expli
   if (explicit_report)
     return;
 
-  kaleidoscope::hid::sendKeyboardReport();
-  kaleidoscope::hid::sendMouseReport();
+  kaleidoscope::Runtime.hid().keyboard().sendReport();
+  kaleidoscope::Runtime.hid().mouse().sendReport();
 }
 
 static void playKeyCode(Key key, uint8_t keyStates, bool explicit_report) {
@@ -137,8 +136,8 @@ void DynamicMacros::play(uint8_t macro_id) {
       explicit_report = false;
       break;
     case MACRO_ACTION_STEP_SEND_REPORT:
-      kaleidoscope::hid::sendKeyboardReport();
-      kaleidoscope::hid::sendMouseReport();
+      kaleidoscope::Runtime.hid().keyboard().sendReport();
+      kaleidoscope::Runtime.hid().mouse().sendReport();
       break;
     case MACRO_ACTION_STEP_INTERVAL:
       interval = Runtime.storage().read(pos++);

--- a/src/kaleidoscope/plugin/DynamicTapDance.cpp
+++ b/src/kaleidoscope/plugin/DynamicTapDance.cpp
@@ -17,7 +17,6 @@
 
 #include "Kaleidoscope-DynamicTapDance.h"
 
-#include "kaleidoscope/hid.h"
 #include <Kaleidoscope-EEPROM-Settings.h>
 #include "Kaleidoscope-FocusSerial.h"
 
@@ -79,7 +78,7 @@ bool DynamicTapDance::dance(uint8_t tap_dance_index, KeyAddr key_addr,
     handleKeyswitchEvent(key, key_addr, IS_PRESSED | WAS_PRESSED | INJECTED);
     break;
   case TapDance::Release:
-    hid::sendKeyboardReport();
+    kaleidoscope::Runtime.hid().keyboard().sendReport();
     handleKeyswitchEvent(key, key_addr, WAS_PRESSED | INJECTED);
     break;
   }

--- a/src/kaleidoscope/plugin/HardwareTestMode.cpp
+++ b/src/kaleidoscope/plugin/HardwareTestMode.cpp
@@ -17,7 +17,6 @@
 #include "kaleidoscope/Runtime.h"
 #include "Kaleidoscope-HardwareTestMode.h"
 #include "Kaleidoscope-LEDEffect-Rainbow.h"
-#include "kaleidoscope/hid.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -123,8 +122,8 @@ void HardwareTestMode::testMatrix() {
 void HardwareTestMode::runTests() {
   // When we start test mode, we -may- have some keys held, so empty it
   // out and send a new report
-  kaleidoscope::hid::releaseAllKeys();
-  kaleidoscope::hid::sendKeyboardReport();
+  kaleidoscope::Runtime.hid().keyboard().releaseAllKeys();
+  kaleidoscope::Runtime.hid().keyboard().sendReport();
   Runtime.device().enableHardwareTestMode();
   testLeds();
   testMatrix();

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -17,7 +17,6 @@
 
 #include <Kaleidoscope-LED-ActiveModColor.h>
 #include <Kaleidoscope-OneShot.h>
-#include <kaleidoscope/hid.h>
 #include "kaleidoscope/layers.h"
 
 namespace kaleidoscope {
@@ -71,7 +70,7 @@ EventHandlerResult ActiveModColorEffect::beforeReportingState() {
       else
         ::LEDControl.refreshAt(key_addr);
     } else if (k >= Key_LeftControl && k <= Key_RightGui) {
-      if (hid::isModifierKeyActive(k))
+      if (kaleidoscope::Runtime.hid().keyboard().isModifierKeyActive(k))
         ::LEDControl.setCrgbAt(key_addr, highlight_color);
       else
         ::LEDControl.refreshAt(key_addr);

--- a/src/kaleidoscope/plugin/Macros.cpp
+++ b/src/kaleidoscope/plugin/Macros.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "Kaleidoscope-Macros.h"
-#include "kaleidoscope/hid.h"
 #include "kaleidoscope/keyswitch_state.h"
 #include "kaleidoscope/key_events.h"
 
@@ -37,8 +36,8 @@ void playMacroKeyswitchEvent(Key key, uint8_t keyswitch_state, bool explicit_rep
   if (explicit_report)
     return;
 
-  kaleidoscope::hid::sendKeyboardReport();
-  kaleidoscope::hid::sendMouseReport();
+  kaleidoscope::Runtime.hid().keyboard().sendReport();
+  kaleidoscope::Runtime.hid().mouse().sendReport();
 }
 
 static void playKeyCode(Key key, uint8_t keyStates, bool explicit_report) {
@@ -75,8 +74,8 @@ void Macros_::play(const macro_t *macro_p) {
       explicit_report = false;
       break;
     case MACRO_ACTION_STEP_SEND_REPORT:
-      kaleidoscope::hid::sendKeyboardReport();
-      kaleidoscope::hid::sendMouseReport();
+      kaleidoscope::Runtime.hid().keyboard().sendReport();
+      kaleidoscope::Runtime.hid().mouse().sendReport();
       break;
     case MACRO_ACTION_STEP_INTERVAL:
       interval = pgm_read_byte(macro_p++);

--- a/src/kaleidoscope/plugin/MouseKeys.cpp
+++ b/src/kaleidoscope/plugin/MouseKeys.cpp
@@ -18,7 +18,6 @@
 
 #include "kaleidoscope/Runtime.h"
 #include "Kaleidoscope-MouseKeys.h"
-#include "kaleidoscope/hid.h"
 #include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
@@ -54,18 +53,18 @@ void MouseKeys_::scrollWheel(uint8_t keyCode) {
   wheel_start_time_ = Runtime.millisAtCycleStart();
 
   if (keyCode & KEY_MOUSE_UP)
-    kaleidoscope::hid::moveMouse(0, 0, wheelSpeed);
+    kaleidoscope::Runtime.hid().mouse().move(0, 0, wheelSpeed);
   else if (keyCode & KEY_MOUSE_DOWN)
-    kaleidoscope::hid::moveMouse(0, 0, -wheelSpeed);
+    kaleidoscope::Runtime.hid().mouse().move(0, 0, -wheelSpeed);
   else if (keyCode & KEY_MOUSE_LEFT)
-    kaleidoscope::hid::moveMouse(0, 0, 0, -wheelSpeed);
+    kaleidoscope::Runtime.hid().mouse().move(0, 0, 0, -wheelSpeed);
   else if (keyCode & KEY_MOUSE_RIGHT)
-    kaleidoscope::hid::moveMouse(0, 0, 0, wheelSpeed);
+    kaleidoscope::Runtime.hid().mouse().move(0, 0, 0, wheelSpeed);
 }
 
 EventHandlerResult MouseKeys_::afterEachCycle() {
-  kaleidoscope::hid::sendMouseReport();
-  kaleidoscope::hid::releaseAllMouseButtons();
+  kaleidoscope::Runtime.hid().mouse().sendReport();
+  kaleidoscope::Runtime.hid().mouse().releaseAllButtons();
   mouseMoveIntent = 0;
 
   return EventHandlerResult::OK;
@@ -120,9 +119,10 @@ EventHandlerResult MouseKeys_::onKeyswitchEvent(Key &mappedKey, KeyAddr key_addr
         MouseWrapper.reset_warping();
       }
 
-      MouseWrapper.pressButton(button);
+      kaleidoscope::Runtime.hid().mouse().pressButtons(button);
     } else if (keyToggledOff(keyState)) {
-      MouseWrapper.release_button(button);
+      kaleidoscope::Runtime.hid().mouse().releaseButtons(button);
+      MouseWrapper.end_warping();
     }
   } else if (!(mappedKey.getKeyCode() & KEY_MOUSE_WARP)) {
     if (keyToggledOn(keyState)) {
@@ -163,7 +163,7 @@ EventHandlerResult MouseKeys_::onKeyswitchEvent(Key &mappedKey, KeyAddr key_addr
         }
       }
 
-      kaleidoscope::hid::stopMouse(x, y, vWheel, hWheel);
+      kaleidoscope::Runtime.hid().mouse().stop(x, y, vWheel, hWheel);
     }
   } else if (keyToggledOn(keyState)) {
     if (mappedKey.getKeyCode() & KEY_MOUSE_WARP && mappedKey.getFlags() & IS_MOUSE_KEY) {
@@ -179,7 +179,8 @@ EventHandlerResult MouseKeys_::onKeyswitchEvent(Key &mappedKey, KeyAddr key_addr
 }
 
 EventHandlerResult MouseKeys_::onSetup(void) {
-  MouseWrapper.begin();
+  kaleidoscope::Runtime.hid().mouse().setup();
+  kaleidoscope::Runtime.hid().absoluteMouse().setup();
 
   return EventHandlerResult::OK;
 }

--- a/src/kaleidoscope/plugin/MouseKeys/MouseWrapper.cpp
+++ b/src/kaleidoscope/plugin/MouseKeys/MouseWrapper.cpp
@@ -18,8 +18,8 @@
 // Mouse-related methods
 //
 //
+#include <Kaleidoscope.h>
 #include "kaleidoscope/plugin/MouseKeys/MouseWrapper.h"
-#include "kaleidoscope/hid.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -35,27 +35,10 @@ uint8_t MouseWrapper_::accelStep;
 uint8_t MouseWrapper_::speedLimit = 127;
 uint8_t MouseWrapper_::subpixelsPerPixel = 16;
 
-MouseWrapper_::MouseWrapper_(void) {
-}
-
-void MouseWrapper_::begin(void) {
-  kaleidoscope::hid::initializeMouse();
-  kaleidoscope::hid::initializeAbsoluteMouse();
-}
-
-void MouseWrapper_::pressButton(uint8_t button) {
-  kaleidoscope::hid::pressMouseButtons(button);
-}
-
-void MouseWrapper_::release_button(uint8_t button) {
-  kaleidoscope::hid::releaseMouseButtons(button);
-  end_warping();
-}
-
 void MouseWrapper_::warp_jump(uint16_t left, uint16_t top, uint16_t height, uint16_t width) {
   uint16_t x_center = left + width / 2;
   uint16_t y_center = top + height / 2;
-  kaleidoscope::hid::moveAbsoluteMouseTo(x_center, y_center, 0);
+  Kaleidoscope.hid().absoluteMouse().moveTo(x_center, y_center, 0);
 }
 
 void MouseWrapper_::begin_warping() {
@@ -166,7 +149,7 @@ void MouseWrapper_::move(int8_t x, int8_t y) {
 
   end_warping();
   // move by whole pixels, not subpixels
-  kaleidoscope::hid::moveMouse(moveX / subpixelsPerPixel, moveY / subpixelsPerPixel, 0);
+  Kaleidoscope.hid().mouse().move(moveX / subpixelsPerPixel, moveY / subpixelsPerPixel, 0);
   // save leftover subpixel movements for later
   remainderX = moveX - moveX / subpixelsPerPixel * subpixelsPerPixel;
   remainderY = moveY - moveY / subpixelsPerPixel * subpixelsPerPixel;

--- a/src/kaleidoscope/plugin/MouseKeys/MouseWrapper.h
+++ b/src/kaleidoscope/plugin/MouseKeys/MouseWrapper.h
@@ -43,14 +43,13 @@ namespace plugin {
 
 class MouseWrapper_ {
  public:
-  MouseWrapper_(void);
+  MouseWrapper_() {}
 
-  static void begin(void);
   static void move(int8_t x, int8_t y);
   static void warp(uint8_t warp_cmd);
+  static void end_warping();
   static void reset_warping();
-  static void pressButton(uint8_t button);
-  static void release_button(uint8_t button);
+
   static uint8_t accelStep;
   static uint8_t speedLimit;
   static uint8_t subpixelsPerPixel;
@@ -65,7 +64,6 @@ class MouseWrapper_ {
 
   static uint8_t acceleration(uint8_t cycles);
   static void begin_warping();
-  static void end_warping();
   static void warp_jump(uint16_t left, uint16_t top, uint16_t height, uint16_t width);
 };
 }

--- a/src/kaleidoscope/plugin/ShapeShifter.cpp
+++ b/src/kaleidoscope/plugin/ShapeShifter.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <Kaleidoscope-ShapeShifter.h>
-#include <kaleidoscope/hid.h>
 
 namespace kaleidoscope {
 namespace plugin {
@@ -25,8 +24,8 @@ const ShapeShifter::dictionary_t *ShapeShifter::dictionary = NULL;
 bool ShapeShifter::mod_active_;
 
 EventHandlerResult ShapeShifter::beforeReportingState() {
-  mod_active_ = hid::isModifierKeyActive(Key_LeftShift) ||
-                hid::isModifierKeyActive(Key_RightShift);
+  mod_active_ = kaleidoscope::Runtime.hid().keyboard().isModifierKeyActive(Key_LeftShift) ||
+                kaleidoscope::Runtime.hid().keyboard().isModifierKeyActive(Key_RightShift);
   return EventHandlerResult::OK;
 }
 

--- a/src/kaleidoscope/plugin/SpaceCadet.cpp
+++ b/src/kaleidoscope/plugin/SpaceCadet.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <Kaleidoscope-SpaceCadet.h>
-#include <kaleidoscope/hid.h>
 #include "kaleidoscope/keyswitch_state.h"
 #include "kaleidoscope/key_events.h"
 

--- a/src/kaleidoscope/plugin/Syster.cpp
+++ b/src/kaleidoscope/plugin/Syster.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <Kaleidoscope-Syster.h>
-#include <kaleidoscope/hid.h>
 #include "kaleidoscope/keyswitch_state.h"
 #include "kaleidoscope/key_events.h"
 
@@ -72,9 +71,9 @@ EventHandlerResult Syster::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, u
     if (mapped_key == Key_Spacebar) {
       for (uint8_t i = 0; i <= symbol_pos_; i++) {
         handleKeyswitchEvent(Key_Backspace, UnknownKeyswitchLocation, IS_PRESSED | INJECTED);
-        hid::sendKeyboardReport();
+        kaleidoscope::Runtime.hid().keyboard().sendReport();
         handleKeyswitchEvent(Key_Backspace, UnknownKeyswitchLocation, WAS_PRESSED | INJECTED);
-        hid::sendKeyboardReport();
+        kaleidoscope::Runtime.hid().keyboard().sendReport();
       }
 
       systerAction(EndAction, NULL);

--- a/src/kaleidoscope/plugin/TapDance.cpp
+++ b/src/kaleidoscope/plugin/TapDance.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <Kaleidoscope-TapDance.h>
-#include <kaleidoscope/hid.h>
 #include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
@@ -40,8 +39,8 @@ void TapDance::interrupt(KeyAddr key_addr) {
   last_tap_dance_key_ = Key_NoKey;
 
   Runtime.device().maskKey(key_addr);
-  kaleidoscope::hid::sendKeyboardReport();
-  kaleidoscope::hid::releaseAllKeys();
+  Runtime.hid().keyboard().sendReport();
+  Runtime.hid().keyboard().releaseAllKeys();
 
   if (state_[idx].pressed)
     return;
@@ -99,7 +98,7 @@ void TapDance::actionKeys(uint8_t tap_count, ActionType tap_dance_action, uint8_
     handleKeyswitchEvent(key, last_tap_dance_addr_, IS_PRESSED | WAS_PRESSED | INJECTED);
     break;
   case Release:
-    hid::sendKeyboardReport();
+    kaleidoscope::Runtime.hid().keyboard().sendReport();
     handleKeyswitchEvent(key, last_tap_dance_addr_, WAS_PRESSED | INJECTED);
     break;
   }

--- a/src/kaleidoscope/plugin/TopsyTurvy.cpp
+++ b/src/kaleidoscope/plugin/TopsyTurvy.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <Kaleidoscope-TopsyTurvy.h>
-#include "kaleidoscope/hid.h"
 #include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
@@ -62,8 +61,8 @@ EventHandlerResult TopsyTurvy::onKeyswitchEvent(Key &mapped_key, KeyAddr key_add
   }
 
   if (keyIsPressed(key_state)) {
-    hid::releaseKey(Key_LeftShift);
-    hid::releaseKey(Key_RightShift);
+    kaleidoscope::Runtime.hid().keyboard().releaseKey(Key_LeftShift);
+    kaleidoscope::Runtime.hid().keyboard().releaseKey(Key_RightShift);
 
     return EventHandlerResult::OK;
   }

--- a/src/kaleidoscope/plugin/Turbo.cpp
+++ b/src/kaleidoscope/plugin/Turbo.cpp
@@ -19,7 +19,6 @@
 #include <Kaleidoscope-LEDControl.h>
 #include "kaleidoscope/layers.h"
 #include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/hid.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -105,7 +104,7 @@ EventHandlerResult Turbo::onKeyswitchEvent(Key &key, KeyAddr key_addr, uint8_t k
 EventHandlerResult Turbo::afterEachCycle() {
   if (enable) {
     if (Runtime.millisAtCycleStart() - startTime > interval_) {
-      kaleidoscope::hid::sendKeyboardReport();
+      kaleidoscope::Runtime.hid().keyboard().sendReport();
       startTime = Runtime.millisAtCycleStart();
     }
 

--- a/src/kaleidoscope/plugin/Unicode.cpp
+++ b/src/kaleidoscope/plugin/Unicode.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <Kaleidoscope-Unicode.h>
-#include "kaleidoscope/hid.h"
 
 namespace kaleidoscope {
 namespace plugin {
@@ -26,25 +25,25 @@ uint8_t Unicode::input_delay_;
 void Unicode::start(void) {
   switch (::HostOS.os()) {
   case hostos::LINUX:
-    hid::pressRawKey(Key_LeftControl);
-    hid::pressRawKey(Key_LeftShift);
-    hid::pressRawKey(Key_U);
-    hid::sendKeyboardReport();
-    hid::releaseRawKey(Key_LeftControl);
-    hid::releaseRawKey(Key_LeftShift);
-    hid::releaseRawKey(Key_U);
-    hid::sendKeyboardReport();
+    kaleidoscope::Runtime.hid().keyboard().pressRawKey(Key_LeftControl);
+    kaleidoscope::Runtime.hid().keyboard().pressRawKey(Key_LeftShift);
+    kaleidoscope::Runtime.hid().keyboard().pressRawKey(Key_U);
+    kaleidoscope::Runtime.hid().keyboard().sendReport();
+    kaleidoscope::Runtime.hid().keyboard().releaseRawKey(Key_LeftControl);
+    kaleidoscope::Runtime.hid().keyboard().releaseRawKey(Key_LeftShift);
+    kaleidoscope::Runtime.hid().keyboard().releaseRawKey(Key_U);
+    kaleidoscope::Runtime.hid().keyboard().sendReport();
     break;
   case hostos::WINDOWS:
-    hid::pressRawKey(Key_LeftAlt);
-    hid::sendKeyboardReport();
-    hid::pressRawKey(Key_KeypadAdd);
-    hid::sendKeyboardReport();
-    hid::releaseRawKey(Key_KeypadAdd);
-    hid::sendKeyboardReport();
+    kaleidoscope::Runtime.hid().keyboard().pressRawKey(Key_LeftAlt);
+    kaleidoscope::Runtime.hid().keyboard().sendReport();
+    kaleidoscope::Runtime.hid().keyboard().pressRawKey(Key_KeypadAdd);
+    kaleidoscope::Runtime.hid().keyboard().sendReport();
+    kaleidoscope::Runtime.hid().keyboard().releaseRawKey(Key_KeypadAdd);
+    kaleidoscope::Runtime.hid().keyboard().sendReport();
     break;
   case hostos::OSX:
-    hid::pressRawKey(Key_LeftAlt);
+    kaleidoscope::Runtime.hid().keyboard().pressRawKey(Key_LeftAlt);
     break;
   default:
     unicodeCustomStart();
@@ -58,7 +57,7 @@ void Unicode::input(void) {
     break;
   case hostos::WINDOWS:
   case hostos::OSX:
-    hid::pressRawKey(Key_LeftAlt);
+    kaleidoscope::Runtime.hid().keyboard().pressRawKey(Key_LeftAlt);
     break;
   default:
     unicodeCustomInput();
@@ -70,15 +69,15 @@ void Unicode::input(void) {
 void Unicode::end(void) {
   switch (::HostOS.os()) {
   case hostos::LINUX:
-    hid::pressRawKey(Key_Spacebar);
-    hid::sendKeyboardReport();
-    hid::releaseRawKey(Key_Spacebar);
-    hid::sendKeyboardReport();
+    kaleidoscope::Runtime.hid().keyboard().pressRawKey(Key_Spacebar);
+    kaleidoscope::Runtime.hid().keyboard().sendReport();
+    kaleidoscope::Runtime.hid().keyboard().releaseRawKey(Key_Spacebar);
+    kaleidoscope::Runtime.hid().keyboard().sendReport();
     break;
   case hostos::WINDOWS:
   case hostos::OSX:
-    hid::releaseRawKey(Key_LeftAlt);
-    hid::sendKeyboardReport();
+    kaleidoscope::Runtime.hid().keyboard().releaseRawKey(Key_LeftAlt);
+    kaleidoscope::Runtime.hid().keyboard().sendReport();
     break;
   default:
     unicodeCustomEnd();
@@ -102,11 +101,11 @@ void Unicode::typeCode(uint32_t unicode) {
           key = hexToKey(digit);
         }
         input();
-        hid::pressRawKey(key);
-        hid::sendKeyboardReport();
+        kaleidoscope::Runtime.hid().keyboard().pressRawKey(key);
+        kaleidoscope::Runtime.hid().keyboard().sendReport();
         input();
-        hid::releaseRawKey(key);
-        hid::sendKeyboardReport();
+        kaleidoscope::Runtime.hid().keyboard().releaseRawKey(key);
+        kaleidoscope::Runtime.hid().keyboard().sendReport();
       }
     } else {
       Key key;
@@ -116,11 +115,11 @@ void Unicode::typeCode(uint32_t unicode) {
         key = hexToKey(digit);
       }
       input();
-      hid::pressRawKey(key);
-      hid::sendKeyboardReport();
+      kaleidoscope::Runtime.hid().keyboard().pressRawKey(key);
+      kaleidoscope::Runtime.hid().keyboard().sendReport();
       input();
-      hid::releaseRawKey(key);
-      hid::sendKeyboardReport();
+      kaleidoscope::Runtime.hid().keyboard().releaseRawKey(key);
+      kaleidoscope::Runtime.hid().keyboard().sendReport();
       on_zero_start = false;
     }
     delay(5);

--- a/src/kaleidoscope_internal/deprecations.h
+++ b/src/kaleidoscope_internal/deprecations.h
@@ -27,6 +27,10 @@
 
 /* Messages */
 
+#define _DEPRECATED_MESSAGE_HID_FACADE                                   __NL__ \
+  "The HID facade in the `kaleidoscope::hid` namespace is deprecated.\n" __NL__ \
+  "Please use `Kaleidoscope.hid()` instead."
+
 #define _DEPRECATED_MESSAGE_NAMED_HARDWARE              __NL__ \
   "Named hardware objects are deprecated, please use\n" __NL__ \
   "`Kaleidoscope.device()` instead."


### PR DESCRIPTION
To make it easier to configure which HID implementation - and which parts of it - a particular board uses, we turn our current HID facade (`kaleidoscope::hid`) into a proper, Props-supported driver. This also allows us to get rid of the `Kaleidoscope-HIDAdaptor-KeyboardioHID` library.

As such, the old facade gets deprecated too.