### PR TITLE
WIP: Fixed build warnings with gcc 7 in Layer_::getKeyFromPROGMEM(...)

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
-set -e
+#set -e
 
 ######
 ###### Build and output configuration

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -312,6 +312,10 @@ compile () {
         ${ARDUINO_VERBOSE} \
 	      ${ARDUINO_AVR_GCC_PREFIX_PARAM} \
 	      "${SKETCH_DIR}/${SKETCH}.ino"
+	      
+    preprocessed_sketch="${BUILD_PATH}/sketch/${SKETCH}.ino.cpp"
+    echo "Dumping preprocessed sketch ${preprocessed_sketch}"
+    cat "${preprocessed_sketch}"
 
     cp "${BUILD_PATH}/${SKETCH}.ino.hex" "${HEX_FILE_PATH}"
     cp "${BUILD_PATH}/${SKETCH}.ino.elf" "${ELF_FILE_PATH}"

--- a/src/kaleidoscope/layers.cpp
+++ b/src/kaleidoscope/layers.cpp
@@ -103,10 +103,6 @@ Key Layer_::eventHandler(Key mappedKey, KeyAddr key_addr, uint8_t keyState) {
   return Key_NoKey;
 }
 
-Key Layer_::getKeyFromPROGMEM(uint8_t layer, KeyAddr key_addr) {
-  return keyFromKeymap(layer, key_addr);
-}
-
 void Layer_::updateLiveCompositeKeymap(KeyAddr key_addr) {
   int8_t layer = active_layers_[key_addr.toInt()];
   live_composite_keymap_[key_addr.toInt()] = (*getKey)(layer, key_addr);

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -119,6 +119,9 @@ class Layer_ {
   typedef Key(*GetKeyFunction)(uint8_t layer, KeyAddr key_addr);
   static GetKeyFunction getKey;
 
+  // Due to an issue with gcc 7, getKeyFromPROGMEM(...) is currently implemented
+  // in kaleidoscope_internal/sketch_preprocessing/sketch_footer.h.
+  //
   static Key getKeyFromPROGMEM(uint8_t layer, KeyAddr key_addr);
   DEPRECATED(ROW_COL_FUNC) static Key getKeyFromPROGMEM(uint8_t layer, byte row, byte col) {
     return getKeyFromPROGMEM(layer, KeyAddr(row, col));

--- a/src/kaleidoscope_internal/sketch_preprocessing/sketch_footer.h
+++ b/src/kaleidoscope_internal/sketch_preprocessing/sketch_footer.h
@@ -1,1 +1,17 @@
 // Any code that appears here is added to the bottom of the preprocessed sketch file.
+
+#include "kaleidoscope/layers.h"
+
+namespace kaleidoscope {
+
+// gcc 7 (Arduino > 1.8.10) has a problem with the layer dimension of
+// keymap_linear, as used by keyFromKeymap(...) being undefined.
+// By moving the implemenation here,
+// we can be sure that the array dimensions are known and no spurious
+// warnings will result.
+//
+Key Layer_::getKeyFromPROGMEM(uint8_t layer, KeyAddr key_addr) {
+  return keyFromKeymap(layer, key_addr);
+}
+
+} // namespace kaleidoscope


### PR DESCRIPTION
This fixes https://github.com/keyboardio/Kaleidoscope/issues/773

The method has been moved to the sketch footer to allow the
compiler to see the correct array dimensions of keymap_linear.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>