### PR TITLE
Added a compiler/Arduino version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you're just getting started with the Keyboardio Model 01, the [introductory d
 
 ## Setup the Arduino IDE
 
-Setup the Arduino IDE on your system. Make sure you install at least version 1.6, since older version may not support all required features.
+Setup the Arduino IDE on your system. Make sure you install at least version 1.8.6, since older version may not support all required features.
 
 * On Linux, follow the instructions [on the wiki](https://github.com/keyboardio/Kaleidoscope/wiki/Install-Arduino-support-on-Linux).
 * On macOS, install using [homebrew](http://brew.sh/) [cask](https://caskroom.github.io/) with `brew cask install arduino` or download the application from [the official website](https://www.arduino.cc/en/Main/Software) and move it to your `/Applications` folder.

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -36,6 +36,7 @@ void setup();
 #include <math.h>
 #include <stdint.h>
 
+#include "kaleidoscope/version.h"
 #include "kaleidoscope/device/device.h"
 #include "kaleidoscope/device/key_indexes.h"
 #include "kaleidoscope_internal/device.h"

--- a/src/kaleidoscope/version.h
+++ b/src/kaleidoscope/version.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#define KALEIDOSCOPE_AVR_GCC_MINIMAL_VERSION 5
+#define KALEIDOSCOPE_AVR_GCC_MINIMAL_MINOR 4
+
+#if   (__GNUC__  < KALEIDOSCOPE_AVR_GCC_MINIMAL_VERSION) \
+  ||  (    (__GNUC__ == KALEIDOSCOPE_AVR_GCC_MINIMAL_VERSION) \
+        && (__GNUC_MINOR__ < KALEIDOSCOPE_AVR_GCC_MINIMAL_MINOR) \
+      )
+#error Kaleidoscope requires Arduino version >= 1.8.6 to build. Please upgrade.
+#endif


### PR DESCRIPTION
Kaleidoscope fails to build with gcc version 4.8 that comes with Arduino 1.8.5. Arduino 1.8.6 comes with gcc 5.4 and builds fine.

This PR adds a compiler version check. The build fails if the avr-gcc version is too old.
A verbose error message reports Arduino upgrade information.

This is meant to prevent issues like https://github.com/keyboardio/Kaleidoscope/issues/773.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>