### PR TITLE
C++ standard bumped to c++14

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -303,7 +303,7 @@ compile () {
 	      -build-path "${BUILD_PATH}" \
 	      -ide-version "${ARDUINO_IDE_VERSION}" \
 	      -built-in-libraries "${ARDUINO_PATH}/libraries" \
-	      -prefs "compiler.cpp.extra_flags=-std=c++11 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
+	      -prefs "compiler.cpp.extra_flags=-std=c++14 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers -Wno-sized-deallocation ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
 	      -prefs "compiler.path=${COMPILER_PATH}" \
 	      -prefs "compiler.c.cmd=${COMPILER_PREFIX}${C_COMPILER_BASENAME}" \
 	      -prefs "compiler.cpp.cmd=${COMPILER_PREFIX}${CXX_COMPILER_BASENAME}" \

--- a/test/MatrixAddr/Makefile
+++ b/test/MatrixAddr/Makefile
@@ -1,2 +1,2 @@
 test: test.cpp ../../src/kaleidoscope/MatrixAddr.h
-	g++ -std=c++11 -o test test.cpp
+	g++ -std=c++14 -o test test.cpp


### PR DESCRIPTION
Since a recent commit we require Arduino 1.8.6 and, thus, gcc 5.4 to build Kaleidoscope.
Gcc 5.4 comes with full support for c++14 (see
https://gcc.gnu.org/projects/cxx-status.html).

This also fixes compiler warning
"warning: the program should also define 'void operator delete(void*, unsigned int)' [-Wsized-deallocation]"
resulting from arduino-1.8.6/hardware/arduino/avr/cores/arduino/new.cpp

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>