### PR TITLE
Tweak blazing trail decay

### DIFF
--- a/src/kaleidoscope/plugin/LED-Stalker.cpp
+++ b/src/kaleidoscope/plugin/LED-Stalker.cpp
@@ -105,8 +105,8 @@ cRGB Haunt::compute(uint8_t *step) {
 // BlazingTrail
 BlazingTrail::BlazingTrail(void) {
 }
-uint8_t hue_start = 50.0 / 360 * 0xff;
-uint8_t hue_end = 0;
+constexpr uint8_t hue_start = 50.0 / 360 * 0xff;
+constexpr uint8_t hue_end = 0;
 
 cRGB BlazingTrail::compute(uint8_t *step) {
   cRGB color;

--- a/src/kaleidoscope/plugin/LED-Stalker.cpp
+++ b/src/kaleidoscope/plugin/LED-Stalker.cpp
@@ -105,27 +105,28 @@ cRGB Haunt::compute(uint8_t *step) {
 // BlazingTrail
 BlazingTrail::BlazingTrail(void) {
 }
+uint8_t hue_start = 50.0 / 360 * 0xff;
+uint8_t hue_end = 0;
 
 cRGB BlazingTrail::compute(uint8_t *step) {
   cRGB color;
 
-  if (*step >= 0xff - 30) {
-    color = hsvToRgb(0xff - *step, 255, 255);
-  } else {
-    color = hsvToRgb(30, 255, 255);
+  // Get a float from 0 to 1 for our position in the animation
+  float pos = (0xff - *step) / (float) 0xff;
 
-    color.r = min(*step * color.r / 255, 255);
-    color.g = min(*step * color.g / 255, 255);
-  }
+  // Fade hue linearly from orange to red
+  uint8_t hue = hue_start + pos * (hue_end - hue_start);
 
-  if (*step >= 0xff - 30)
-    *step -= 1;
-  else if (*step >= 0x40)
-    *step -= 16;
-  else if (*step >= 32)
-    *step -= 32;
-  else
+  // Fade value from full following a -x^4+1 curve
+  uint8_t val = 0xff * (1 - pos * pos * pos * pos);
+
+  color = hsvToRgb(hue, 0xff, val);
+
+  if (*step < 4) {
     *step = 0;
+  } else {
+    *step -= 4;
+  }
 
   return color;
 }


### PR DESCRIPTION
This patch alters the LED-Stalker plugin.

- Rewrite decay code to fade brightness smoothly with an x^4
  relationship
- Fade hue linearly from orange to red rather than for a subset of
  time from red to orange

I can't find it any more, but when I originally wrote this someone pointed out that this requires floating point logic, which is in some way expensive.

I'm submitting it again in case that's no longer an issue for whatever reason.

In my opinion the effect looks *much* nicer with these tweaks! Maybe it's worth it? ☺