### PR TITLE
Atreus2: Layer naming and toggling the Upper layer

### DIFF
--- a/examples/Devices/Technomancy/Atreus2/Atreus2.ino
+++ b/examples/Devices/Technomancy/Atreus2/Atreus2.ino
@@ -48,8 +48,8 @@ enum {
 
 enum {
   QWERTY,
-  NUMPAD,
-  NAV
+  FUN,
+  UPPER
 };
 
 /* *INDENT-OFF* */
@@ -64,15 +64,15 @@ KEYMAPS(
                      ,Key_Y     ,Key_U      ,Key_I     ,Key_O      ,Key_P
                      ,Key_H     ,Key_J      ,Key_K     ,Key_L      ,Key_Semicolon
        ,Key_Backslash,Key_N     ,Key_M      ,Key_Comma ,Key_Period ,Key_Slash
-       ,Key_LeftAlt  ,Key_Space ,MO(NUMPAD) ,Key_Minus ,Key_Quote  ,Key_Enter
+       ,Key_LeftAlt  ,Key_Space ,MO(FUN)    ,Key_Minus ,Key_Quote  ,Key_Enter
   ),
 
-  [NUMPAD] = KEYMAP_STACKED
+  [FUN] = KEYMAP_STACKED
   (
        Key_Exclamation ,Key_At           ,Key_UpArrow   ,Key_Dollar           ,Key_Percent
       ,Key_LeftParen   ,Key_LeftArrow    ,Key_DownArrow ,Key_RightArrow       ,Key_RightParen
       ,Key_LeftBracket ,Key_RightBracket ,Key_Hash      ,Key_LeftCurlyBracket ,Key_RightCurlyBracket ,Key_Caret
-      ,TG(NAV)         ,Key_Insert       ,Key_LeftGui   ,Key_LeftShift        ,Key_Backspace         ,Key_LeftControl
+      ,TG(UPPER)       ,Key_Insert       ,Key_LeftGui   ,Key_LeftShift        ,Key_Backspace         ,Key_LeftControl
 
                    ,Key_PageUp   ,Key_7 ,Key_8      ,Key_9 ,Key_Backspace
                    ,Key_PageDown ,Key_4 ,Key_5      ,Key_6 ,___
@@ -80,7 +80,7 @@ KEYMAPS(
       ,Key_LeftAlt ,Key_Space    ,___   ,Key_Period ,Key_0 ,Key_Equals
    ),
 
-  [NAV] = KEYMAP_STACKED
+  [UPPER] = KEYMAP_STACKED
   (
        Key_Insert ,Key_Home                 ,Key_UpArrow   ,Key_End        ,Key_PageUp
       ,Key_Delete ,Key_LeftArrow            ,Key_DownArrow ,Key_RightArrow ,Key_PageDown

--- a/examples/Devices/Technomancy/Atreus2/Atreus2.ino
+++ b/examples/Devices/Technomancy/Atreus2/Atreus2.ino
@@ -85,7 +85,7 @@ KEYMAPS(
        Key_Insert ,Key_Home                 ,Key_UpArrow   ,Key_End        ,Key_PageUp
       ,Key_Delete ,Key_LeftArrow            ,Key_DownArrow ,Key_RightArrow ,Key_PageDown
       ,XXX        ,Consumer_VolumeIncrement ,XXX           ,XXX            ,___ ,___
-      ,XXX        ,Consumer_VolumeDecrement ,___           ,___            ,___  ,___
+      ,M(QWERTY)  ,Consumer_VolumeDecrement ,___           ,___            ,___ ,___
 
                 ,Key_UpArrow   ,Key_F7 ,Key_F8          ,Key_F9         ,Key_F10
                 ,Key_DownArrow ,Key_F4 ,Key_F5          ,Key_F6         ,Key_F11


### PR DESCRIPTION
This PR has two parts: the first one simply updates the layer naming to match the layout card, and should be a safe change. The second one is something I felt important, while reviewing the layout card: it adds another way to go back to the `QWERTY` layer from `Upper`, hitting the same key we used to get to `Upper`.

At the moment, to get to upper, one needs to press `Fun + Esc`, and then it locks onto that layer. To get back to `QWERTY`, one needs to tap `Fun`. This makes sense, if one knows the layout. It's hard to express on the layout card in a good way, though, and might be very surprising for first-timer users (it certainly was for me).

In most layouts, the position that is used to lock onto a layer is usually used to unlock it too. So the second commit of this PR does just that, and turns the `Upper` position on that layer into the same macro that the `Fun` position uses to get back to `QWERTY`.

I'd love to have @technomancy's opinion on this.