### PR TITLE
LEDControl: Implement global brightness controls

### DIFF
--- a/examples/LEDs/LED-Brightness/LED-Brightness.ino
+++ b/examples/LEDs/LED-Brightness/LED-Brightness.ino
@@ -1,0 +1,77 @@
+/* -*- mode: c++ -*-
+ * LED-Brightness.ino -- Example to show LED brightness control
+ * Copyright (C) 2020  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-LEDEffect-Rainbow.h>
+#include <Kaleidoscope-Macros.h>
+
+// *INDENT-OFF*
+KEYMAPS(
+  [0] = KEYMAP_STACKED
+  (
+    Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext,
+    Key_Backtick,      Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+    Key_PageUp,        Key_A, Key_S, Key_D, Key_F, Key_G,
+    Key_PageDown,      Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+
+    Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+    M(0),
+
+    Key_skip,  Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
+    Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
+               Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
+    Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
+
+    Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
+    M(1)),
+)
+// *INDENT-ON*
+
+KALEIDOSCOPE_INIT_PLUGINS(LEDControl,
+                          Macros,
+                          LEDRainbowWaveEffect);
+
+const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
+  if (keyToggledOn(keyState)) {
+    uint8_t brightness = LEDControl.getBrightness();
+
+    if (macroIndex == 0) {
+      if (brightness > 10)
+        brightness -= 10;
+      else
+        brightness = 0;
+    } else if (macroIndex == 1) {
+      if (brightness < 245)
+        brightness += 10;
+      else
+        brightness = 255;
+    }
+
+    LEDControl.setBrightness(brightness);
+  }
+
+  return MACRO_NONE;
+}
+
+void setup() {
+  Kaleidoscope.setup();
+  LEDRainbowWaveEffect.brightness(255);
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/src/kaleidoscope/device/dygma/Raise.cpp
+++ b/src/kaleidoscope/device/dygma/Raise.cpp
@@ -1,7 +1,7 @@
 /* -*- mode: c++ -*-
  * kaleidoscope::device::dygma::Raise -- Kaleidoscope device plugin for Dygma Raise
- * Copyright (C) 2017-2019  Keyboard.io, Inc
- * Copyright (C) 2017-2019  Dygma Lab S.L.
+ * Copyright (C) 2017-2020  Keyboard.io, Inc
+ * Copyright (C) 2017-2020  Dygma Lab S.L.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -143,6 +143,19 @@ cRGB RaiseLEDDriver::neuronLED;
 constexpr uint8_t RaiseLEDDriver::led_map[][RaiseLEDDriverProps::led_count + 1];
 
 constexpr uint8_t RaiseLEDDriverProps::key_led_map[];
+
+void RaiseLEDDriver::setBrightness(uint8_t brightness) {
+  RaiseHands::leftHand.setBrightness(brightness);
+  RaiseHands::rightHand.setBrightness(brightness);
+  for (uint8_t i = 0; i < LED_BANKS; i++) {
+    isLEDChangedLeft[i] = true;
+    isLEDChangedRight[i] = true;
+  }
+}
+
+uint8_t RaiseLEDDriver::getBrightness() {
+  return RaiseHands::leftHand.getBrightness();
+}
 
 void RaiseLEDDriver::syncLeds() {
   // left and right sides

--- a/src/kaleidoscope/device/dygma/Raise.h
+++ b/src/kaleidoscope/device/dygma/Raise.h
@@ -1,7 +1,7 @@
 /* -*- mode: c++ -*-
  * kaleidoscope::device::dygma::Raise -- Kaleidoscope device plugin for Dygma Raise
- * Copyright (C) 2017-2019  Keyboard.io, Inc
- * Copyright (C) 2017-2019  Dygma Lab S.L.
+ * Copyright (C) 2017-2020  Keyboard.io, Inc
+ * Copyright (C) 2017-2020  Dygma Lab S.L.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -61,6 +61,8 @@ class RaiseLEDDriver : public kaleidoscope::driver::led::Base<RaiseLEDDriverProp
   static void syncLeds();
   static void setCrgbAt(uint8_t i, cRGB crgb);
   static cRGB getCrgbAt(uint8_t i);
+  static void setBrightness(uint8_t brightness);
+  static uint8_t getBrightness();
 
   static void updateNeuronLED();
  private:

--- a/src/kaleidoscope/device/dygma/raise/Hand.cpp
+++ b/src/kaleidoscope/device/dygma/raise/Hand.cpp
@@ -223,7 +223,13 @@ void Hand::sendLEDBank(uint8_t bank) {
   uint8_t data[LED_BYTES_PER_BANK + 1]; // + 1 for the update LED command itself
   data[0]  = TWI_CMD_LED_BASE + bank;
   for (uint8_t i = 0 ; i < LED_BYTES_PER_BANK; i++) {
-    data[i + 1] = pgm_read_byte(&gamma8[led_data.bytes[bank][i]]);
+    uint8_t c = led_data.bytes[bank][i];
+    if (c > brightness_adjustment_)
+      c -= brightness_adjustment_;
+    else
+      c = 0;
+
+    data[i + 1] = pgm_read_byte(&gamma8[c]);
   }
   uint8_t result = twi_.writeTo(data, ELEMENTS(data));
 }

--- a/src/kaleidoscope/device/dygma/raise/Hand.cpp
+++ b/src/kaleidoscope/device/dygma/raise/Hand.cpp
@@ -228,25 +228,6 @@ void Hand::sendLEDBank(uint8_t bank) {
   uint8_t result = twi_.writeTo(data, ELEMENTS(data));
 }
 
-void Hand::setAllLEDsTo(cRGB color) {
-  uint8_t data[] = {TWI_CMD_LED_SET_ALL_TO,
-                    pgm_read_byte(&gamma8[color.r]),
-                    pgm_read_byte(&gamma8[color.g]),
-                    pgm_read_byte(&gamma8[color.b])
-                   };
-  twi_.writeTo(data, ELEMENTS(data));
-}
-
-void Hand::setOneLEDTo(byte led, cRGB color) {
-  uint8_t data[] = {TWI_CMD_LED_SET_ONE_TO,
-                    led,
-                    pgm_read_byte(&gamma8[color.r]),
-                    pgm_read_byte(&gamma8[color.g]),
-                    pgm_read_byte(&gamma8[color.b])
-                   };
-  twi_.writeTo(data, ELEMENTS(data));
-}
-
 }
 }
 }

--- a/src/kaleidoscope/device/dygma/raise/Hand.h
+++ b/src/kaleidoscope/device/dygma/raise/Hand.h
@@ -81,10 +81,18 @@ class Hand {
     return twi_.crc_errors();
   }
 
+  void setBrightness(uint8_t brightness) {
+    brightness_adjustment_ = 255 - brightness;
+  }
+  uint8_t getBrightness() {
+    return 255 - brightness_adjustment_;
+  }
+
   LEDData_t led_data;
   bool online = false;
 
  private:
+  uint8_t brightness_adjustment_ = 0;
   int ad01_;
   TWI twi_;
   keydata_t key_data_;

--- a/src/kaleidoscope/device/dygma/raise/Hand.h
+++ b/src/kaleidoscope/device/dygma/raise/Hand.h
@@ -74,8 +74,6 @@ class Hand {
   bool moreKeysWaiting();
   void sendLEDData();
   void sendLEDBank(uint8_t bank);
-  void setOneLEDTo(byte led, cRGB color);
-  void setAllLEDsTo(cRGB color);
   keydata_t getKeyData();
   bool readKeys();
   uint8_t controllerAddress();

--- a/src/kaleidoscope/device/keyboardio/Imago.cpp
+++ b/src/kaleidoscope/device/keyboardio/Imago.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Hardware-Keyboardio-Imago -- Imago hardware support for Kaleidoscope
- * Copyright (C) 2018, 2019  Keyboard.io, Inc
+ * Copyright (C) 2018, 2019, 2020  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of version 3 of the GNU General Public License as
@@ -98,6 +98,15 @@ cRGB ImagoLEDDriver::getCrgbAt(uint8_t i) {
   return led_data[i];
 }
 
+uint8_t ImagoLEDDriver::adjustBrightness(uint8_t value) {
+  if (value > brightness_adjustment_)
+    value -= brightness_adjustment;
+  else
+    value = 0;
+
+  return value;
+}
+
 void ImagoLEDDriver::syncLeds() {
 //  if (!isLEDChanged)
 //   return;
@@ -110,9 +119,9 @@ void ImagoLEDDriver::syncLeds() {
   selectRegister(LED_REGISTER_DATA0);
 
   for (auto i = 1; i < LED_REGISTER_DATA0_SIZE; i += 3) {
-    data[i] = led_data[last_led].b;
-    data[i + 1] = led_data[last_led].g;
-    data[i + 2] = led_data[last_led].r;
+    data[i] = adjustBrightness(led_data[last_led].b);
+    data[i + 1] = adjustBrightness(led_data[last_led].g);
+    data[i + 2] = adjustBrightness(led_data[last_led].r);
     last_led++;
   }
 
@@ -130,9 +139,9 @@ void ImagoLEDDriver::syncLeds() {
   selectRegister(LED_REGISTER_DATA1);
 
   for (auto i = 1; i < LED_REGISTER_DATA1_SIZE; i += 3) {
-    data[i] = led_data[last_led].b;
-    data[i + 1] = led_data[last_led].g;
-    data[i + 2] = led_data[last_led].r;
+    data[i] = adjustBrightness(led_data[last_led].b);
+    data[i + 1] = adjustBrightness(led_data[last_led].g);
+    data[i + 2] = adjustBrightness(led_data[last_led].r);
     last_led++;
   }
 

--- a/src/kaleidoscope/device/keyboardio/Imago.h
+++ b/src/kaleidoscope/device/keyboardio/Imago.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Hardware-Keyboardio-Imago -- Imago hardware support for Kaleidoscope
- * Copyright (C) 2018, 2019  Keyboard.io, Inc
+ * Copyright (C) 2018, 2019, 2020  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of version 3 of the GNU General Public License as
@@ -58,12 +58,22 @@ class ImagoLEDDriver : public kaleidoscope::driver::led::Base<ImagoLEDDriverProp
   static void syncLeds();
   static void setCrgbAt(uint8_t i, cRGB crgb);
   static cRGB getCrgbAt(uint8_t i);
+  static void setBrightness(uint8_t brightness) {
+    brightness_adjustment_ = 255 - brightness;
+    isLEDChanged = true;
+  }
+  static uint8_t getBrightness() {
+    return 255 - brightness_adjustment_;
+  }
 
   static cRGB led_data[117]; // 117 is the number of LEDs the chip drives
   // until we clean stuff up a bit, it's easiest to just have the whole struct around
 
  private:
+  static uint8_t brightness_adjustment_;
   static bool isLEDChanged;
+
+  static uint8_t adjustBrightness(uint8_t value);
   static void selectRegister(uint8_t);
   static void unlockRegister();
   static void setAllPwmTo(uint8_t);

--- a/src/kaleidoscope/device/keyboardio/Model01.cpp
+++ b/src/kaleidoscope/device/keyboardio/Model01.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Hardware-Model01 -- Keyboard.io Model01 hardware support for Kaleidoscope
- * Copyright (C) 2017-2018  Keyboard.io, Inc
+ * Copyright (C) 2017-2020  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -63,6 +63,16 @@ void Model01Hands::setup(void) {
 
 /********* LED Driver *********/
 bool Model01LEDDriver::isLEDChanged = true;
+
+void Model01LEDDriver::setBrightness(uint8_t brightness) {
+  Model01Hands::leftHand.setBrightness(brightness);
+  Model01Hands::rightHand.setBrightness(brightness);
+  isLEDChanged = true;
+}
+
+uint8_t Model01LEDDriver::getBrightness() {
+  return Model01Hands::leftHand.getBrightness();
+}
 
 void Model01LEDDriver::setCrgbAt(uint8_t i, cRGB crgb) {
   if (i < 32) {

--- a/src/kaleidoscope/device/keyboardio/Model01.h
+++ b/src/kaleidoscope/device/keyboardio/Model01.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Hardware-Model01 -- Keyboard.io Model01 hardware support for Kaleidoscope
- * Copyright (C) 2017-2019  Keyboard.io, Inc
+ * Copyright (C) 2017-2020  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -59,6 +59,8 @@ class Model01LEDDriver : public kaleidoscope::driver::led::Base<Model01LEDDriver
   static void syncLeds();
   static void setCrgbAt(uint8_t i, cRGB crgb);
   static cRGB getCrgbAt(uint8_t i);
+  static void setBrightness(uint8_t brightness);
+  static uint8_t getBrightness();
 
   static void enableHighPowerLeds();
   static boolean ledPowerFault();

--- a/src/kaleidoscope/driver/led/Base.h
+++ b/src/kaleidoscope/driver/led/Base.h
@@ -49,6 +49,9 @@ class Base {
     };
     return c;
   }
+  void setBrightness(uint8_t brightness) {}
+  uint8_t getBrightness() { return 255; }
+
   static uint8_t getLedIndex(uint8_t key_offset) {
 
     // Give the compiler the oportunity to optimize

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -120,6 +120,13 @@ class LEDControl : public kaleidoscope::Plugin {
     return enabled_;
   }
 
+  static void setBrightness(uint8_t brightness) {
+    Runtime.device().ledDriver().setBrightness(brightness);
+  }
+  static uint8_t getBrightness() {
+    return Runtime.device().ledDriver().getBrightness();
+  }
+
   // The data proxy objects are required to only emit deprecation
   // messages when the `paused` property is accessed directly.
   //


### PR DESCRIPTION
The new `.setBrightness()` and `.getBrightness()` methods control the brightness of the LEDs, by dispatching them to the LED drivers. We dispatch to the drivers so that nothing else needs to be aware of brightness control. Plugins will always set the unadjusted colors, and anything and anyone who reads colors, will also get the unadjusted values.

Pushing the adjustment down to the driver level makes everything smooth, and since we do gamma correction there anyway, it makes sense to do brightness adjustment at the same place, too.

Fixes #775.

Depends on keyboardio/KeyboardioScanner#19.