### PR TITLE
IdleLEDs: Be smarter about re-enabling LEDs

### DIFF
--- a/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -26,6 +26,7 @@ namespace plugin {
 
 uint32_t IdleLEDs::idle_time_limit = 600000; // 10 minutes
 uint32_t IdleLEDs::start_time_     = 0;
+bool IdleLEDs::idle_;
 
 uint32_t IdleLEDs::idleTimeoutSeconds() {
   return idle_time_limit / 1000;
@@ -39,6 +40,7 @@ EventHandlerResult IdleLEDs::beforeEachCycle() {
   if (::LEDControl.isEnabled() &&
       Runtime.hasTimeExpired(start_time_, idle_time_limit)) {
     ::LEDControl.disable();
+    idle_ = true;
   }
 
   return EventHandlerResult::OK;
@@ -46,8 +48,9 @@ EventHandlerResult IdleLEDs::beforeEachCycle() {
 
 EventHandlerResult IdleLEDs::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
 
-  if (!::LEDControl.isEnabled()) {
+  if (idle_) {
     ::LEDControl.enable();
+    idle_ = false;
   }
 
   start_time_ = Runtime.millisAtCycleStart();

--- a/src/kaleidoscope/plugin/IdleLEDs.h
+++ b/src/kaleidoscope/plugin/IdleLEDs.h
@@ -36,6 +36,7 @@ class IdleLEDs: public kaleidoscope::Plugin {
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 
  private:
+  static bool idle_;
   static uint32_t start_time_;
 };
 


### PR DESCRIPTION
This changes the IdleLEDs plugin to only re-enable LEDs if they were disabled due to idleness. If they were turned off any other way, the plugin will not re-enable them. This makes it play better with the `Key_LEDToggle` key.

Fixes #790.
