### PR TITLE
IdleLEDs: Allow temporarily disabling the functionality

### DIFF
--- a/docs/plugins/IdleLEDs.md
+++ b/docs/plugins/IdleLEDs.md
@@ -87,6 +87,9 @@ the following properties and methods.
 
 > Sets the amount of time (in seconds) that can pass without a single key being
 > pressed before the plugin considers the keyboard idle and turns off the LEDs.
+>
+> Setting the timeout to 0 will disable the plugin until it is set to a higher
+> value.
 
 ## Focus commands
 
@@ -99,6 +102,9 @@ the `PersistentIdleLEDs` variant:
 
 > Sets the idle time limit to `seconds`, when called with an argument. Returns
 > the current limit (in seconds) when called without any.
+>
+> Setting the timeout to 0 will disable the plugin until it is set to a higher
+> value.
 
 ## Dependencies
 

--- a/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -37,6 +37,9 @@ void IdleLEDs::setIdleTimeoutSeconds(uint32_t new_limit) {
 }
 
 EventHandlerResult IdleLEDs::beforeEachCycle() {
+  if (idle_time_limit == 0)
+    return EventHandlerResult::OK;
+
   if (::LEDControl.isEnabled() &&
       Runtime.hasTimeExpired(start_time_, idle_time_limit)) {
     ::LEDControl.disable();


### PR DESCRIPTION
When setting the idle timeout to zero, stop checking for idleness, and never turn the LEDs off. Setting the timeout to a higher value again will resume the plugin's functionality.