### PR TITLE
Enables definition of default plugins

### DIFF
--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -119,3 +119,38 @@ typedef kaleidoscope::Runtime_  Kaleidoscope_;
 // Kaleidoscope in global namespace.
 //
 extern kaleidoscope::Runtime_ &Kaleidoscope;
+
+// Have a list of plugins that are always added.
+// Those plugins might be configured by macros defined at the top of the sketch.
+// Plugins can thus be turned into complete no-ops.
+
+// For the sketch compilation unit, we pretend that there is a NoOpPlugin
+// symbol. This is intented to be passed to the KALEIDOSCOPE_INIT_PLUGINS(...)
+// function macro. As no existing non-inline functions of this macro are called
+// for this plugin instance, it does not hurt that the instance is not
+// actually instanciated in no other compilation unit.
+//
+#ifdef KALEIDOSCOPE_SKETCH
+namespace kaleidoscope {
+extern Plugin NoOpPlugin; // This is on purpose not instanciated in any
+// compilation unit.
+} // namespace kaleidoscope
+#endif
+
+// Plugins leading the list passed to KALEIDOSCOPE_INIT_PLUGINS
+//
+// Note: As long as we do not actually pass a plugin to
+//       KALEIDOSCOPE_STANDARD_PLUGINS_START, we need to pass at least
+//       a no-op plugin to satisfy the interface. The NoOpPlugin
+//       can be replaced as soon as other plugins are added.
+//
+#define KALEIDOSCOPE_STANDARD_PLUGINS_START kaleidoscope::NoOpPlugin
+
+// Plugins trailing the list passed to KALEIDOSCOPE_INIT_PLUGINS
+//
+// Note: As long as we do not actually pass a plugin to
+//       KALEIDOSCOPE_STANDARD_PLUGINS_END, we need to pass at least
+//       a no-op plugin to satisfy the interface. The NoOpPlugin
+//       can be replaced as soon as other plugins are added.
+//
+#define KALEIDOSCOPE_STANDARD_PLUGINS_END kaleidoscope::NoOpPlugin

--- a/src/kaleidoscope_internal/event_dispatch.h
+++ b/src/kaleidoscope_internal/event_dispatch.h
@@ -191,7 +191,19 @@
     static kaleidoscope::EventHandlerResult apply(Args__&&... hook_args) {    __NL__ \
                                                                               __NL__ \
       kaleidoscope::EventHandlerResult result;                                __NL__ \
+                                                                              __NL__ \
+      /* KALEIDOSCOPE_STANDARD_PLUGINS_START is defined in Kaleidoscope.h */  __NL__ \
+      /**/                                                                    __NL__ \
+      MAP(_INLINE_EVENT_HANDLER_FOR_PLUGIN,                                   __NL__ \
+          KALEIDOSCOPE_STANDARD_PLUGINS_START)                                __NL__ \
+                                                                              __NL__ \
       MAP(_INLINE_EVENT_HANDLER_FOR_PLUGIN, __VA_ARGS__)                      __NL__ \
+                                                                              __NL__ \
+      /* KALEIDOSCOPE_STANDARD_PLUGINS_END is defined in Kaleidoscope.h */    __NL__ \
+      /**/                                                                    __NL__ \
+      MAP(_INLINE_EVENT_HANDLER_FOR_PLUGIN,                                   __NL__ \
+          KALEIDOSCOPE_STANDARD_PLUGINS_END)                                  __NL__ \
+                                                                              __NL__ \
                                                                               __NL__ \
       return result;                                                          __NL__ \
     }                                                                         __NL__ \


### PR DESCRIPTION
Default plugins are those that are automatically added to the list
of plugins considered by KALEIDOSCOPE_INIT_PLUGINS(...).

They can either be defined to precede or trail the list defined by
KALEIDOSCOPE_INIT_PLUGINS(...).

This commit adds the necessary infrastructure but does not add any
default plugins by itself.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>