### PR TITLE
Adds a KALEIDOSCOPE_SKETCH macro definition to sketch header

### DIFF
--- a/src/kaleidoscope_internal/sketch_preprocessing/sketch_header.h
+++ b/src/kaleidoscope_internal/sketch_preprocessing/sketch_header.h
@@ -1,1 +1,3 @@
 // Any code that appears here is added to the top of the preprocessed sketch file.
+
+#define KALEIDOSCOPE_SKETCH


### PR DESCRIPTION
By means of this macro, headers can check if they are compiled
in the sketch compilation unit or in any other compilation unit.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>