### PR TITLE
Implement a LayerSelect plugin

### DIFF
--- a/docs/plugins/LayerSelect.md
+++ b/docs/plugins/LayerSelect.md
@@ -1,0 +1,39 @@
+# LayerSelect
+
+The `LayerSelect` plugin implements a new key, with which you can switch layers
+like you use modifiers: hold the select key, and press the layer number to move
+there. For example, to switch to layer three, one would hold `LayerSelect + 3`.
+
+## Using the plugin
+
+To use the plugin, we need to include the header, and let the firmware know we
+want to use it:
+
+```c++
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-LayerSelect.h>
+
+KALEIDOSCOPE_INIT_PLUGINS(
+  LayerSelect
+);
+```
+
+Then, we need to place the `Key_LayerSelect` key somewhere on our keymap.
+
+## Keymap markup
+
+The plugin provides a single new key: `Key_LayerSelect`, with the functionality
+described above.
+
+## Overrideable methods
+
+### `LayerSelect::layerSelect(mapped_key, key_addr)`
+
+> This method decides whether a key - or key address, or a combination of both -
+> should be considered a layer trigger, when pressed together with the layer
+> select key. It should return the layer to switch to, or
+> `LayerSelect::NOT_A_SELECTION` if what we have should not be treated as a
+> trigger.
+>
+> The default implementation treats the numbers between 0 and 9 as triggers,
+> targeting the appropriate layer.

--- a/src/Kaleidoscope-LayerSelect.h
+++ b/src/Kaleidoscope-LayerSelect.h
@@ -1,0 +1,21 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-LayerSelect -- Modifier-like layer selection
+ * Copyright (C) 2020  Keyboard.io, Inc
+ * Copyright (C) 2020  DygmaLab, SE.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <kaleidoscope/plugin/LayerSelect.h>

--- a/src/Kaleidoscope-Ranges.h
+++ b/src/Kaleidoscope-Ranges.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Ranges -- Common ranges, used by a number of Kaleidoscope plugins.
- * Copyright (C) 2016, 2017, 2019  Keyboard.io, Inc
+ * Copyright (C) 2016, 2017, 2019, 2020  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -51,6 +51,7 @@ enum : uint16_t {
   TURBO,
   DYNAMIC_MACRO_FIRST,
   DYNAMIC_MACRO_LAST = DYNAMIC_MACRO_FIRST + 31,
+  LAYER_SELECT,
 
   SAFE_START,
   KALEIDOSCOPE_SAFE_START = SAFE_START

--- a/src/kaleidoscope/plugin/LayerSelect.cpp
+++ b/src/kaleidoscope/plugin/LayerSelect.cpp
@@ -1,0 +1,66 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-LayerSelect -- Modifier-like layer selection
+ * Copyright (C) 2020  Keyboard.io, Inc
+ * Copyright (C) 2020  DygmaLab, SE.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope-LayerSelect.h>
+#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/layers.h"
+
+namespace kaleidoscope {
+namespace plugin {
+
+bool LayerSelect::selector_held_;
+
+EventHandlerResult LayerSelect::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
+  if (mapped_key == Key_LayerSelect) {
+    selector_held_ = keyIsPressed(key_state);
+    return EventHandlerResult::EVENT_CONSUMED;
+  }
+
+  if (!selector_held_)
+    return EventHandlerResult::OK;
+
+  uint8_t layer;
+  if ((layer = layerSelect(mapped_key, key_addr)) == NOT_A_SELECTION)
+    return EventHandlerResult::OK;
+
+  if (keyToggledOn(key_state)) {
+    Layer.move(layer);
+    Runtime.device().maskKey(key_addr);
+  }
+
+  return EventHandlerResult::EVENT_CONSUMED;
+}
+
+__attribute__((weak))
+uint8_t LayerSelect::layerSelect(Key mapped_key, KeyAddr key_addr) {
+  if (mapped_key < Key_1 || mapped_key > Key_0)
+    return NOT_A_SELECTION;
+
+  uint8_t layer;
+  if (mapped_key == Key_0)
+    layer = 0;
+  else
+    layer = mapped_key.getRaw() - Key_1.getRaw() + 1;
+
+  return layer;
+}
+
+}
+}
+
+kaleidoscope::plugin::LayerSelect LayerSelect;

--- a/src/kaleidoscope/plugin/LayerSelect.h
+++ b/src/kaleidoscope/plugin/LayerSelect.h
@@ -1,0 +1,44 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-LayerSelect -- Modifier-like layer selection
+ * Copyright (C) 2020  Keyboard.io, Inc
+ * Copyright (C) 2020  DygmaLab, SE.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "kaleidoscope/Runtime.h"
+#include <Kaleidoscope-Ranges.h>
+
+namespace kaleidoscope {
+namespace plugin {
+
+#define Key_LayerSelect Key(kaleidoscope::ranges::LAYER_SELECT)
+
+class LayerSelect: public Plugin {
+ public:
+  static constexpr uint8_t NOT_A_SELECTION = 255;
+
+  EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
+
+  uint8_t layerSelect(Key mapped_key, KeyAddr key_addr);
+
+ private:
+  static bool selector_held_;
+};
+
+}
+}
+
+extern kaleidoscope::plugin::LayerSelect LayerSelect;


### PR DESCRIPTION
The new plugin gives us a new key, that works similarly to modifiers, but for layers: hold it, and it has the chance to turn other keys into layer moving keys. By default, the numbers between 0 and 9 will be treated as triggers, but the method can be replaced with custom decision making.

Fixes #804.
