### PR TITLE
travis: Make sure we use the current Kaleidoscope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ addons:
       - shellcheck
 install:
   - git clone --depth 1 --recurse-submodules https://github.com/keyboardio/Kaleidoscope-Bundle-Keyboardio hardware/keyboardio
-## We delete the library.properties of the Bundle's Kaleidoscope.
-## We do this to force Arduino to use the current one instead of the bundled version.
-  - rm -f hardware/keyboardio/avr/libraries/Kaleidoscope/library.properties
+## We delete the Bundle's version of Kaleidoscope, and symlink ourselves in.
+## This makes sure we're using the current version of the library.
+  - rm -rf hardware/keyboardio/avr/libraries/Kaleidoscope
+  - ln -s $(pwd) hardware/keyboardio/avr/libraries/Kaleidoscope
 script:
   - make travis-test KALEIDOSCOPE_TEMP_PATH=$(pwd)/.kaleidoscope-build-cache BOARD_HARDWARE_PATH=$(pwd)/hardware
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ addons:
     packages:
       - shellcheck
 install:
-  - git clone --depth 1 --recurse-submodules https://github.com/keyboardio/Kaleidoscope-Bundle-Keyboardio hardware/keyboardio
+  - git clone --depth 1 --recurse-submodules https://github.com/keyboardio/Kaleidoscope-Bundle-Keyboardio ../hardware/keyboardio
 ## We delete the Bundle's version of Kaleidoscope, and symlink ourselves in.
 ## This makes sure we're using the current version of the library.
-  - rm -rf hardware/keyboardio/avr/libraries/Kaleidoscope
-  - ln -s $(pwd) hardware/keyboardio/avr/libraries/Kaleidoscope
+  - rm -rf ../hardware/keyboardio/avr/libraries/Kaleidoscope
+  - ln -s $(pwd) ../hardware/keyboardio/avr/libraries/Kaleidoscope
 script:
-  - make travis-test KALEIDOSCOPE_TEMP_PATH=$(pwd)/.kaleidoscope-build-cache BOARD_HARDWARE_PATH=$(pwd)/hardware
+  - make travis-test KALEIDOSCOPE_TEMP_PATH=$(pwd)/.kaleidoscope-build-cache BOARD_HARDWARE_PATH=$(pwd)/../hardware
 notifications:
   email:
     on_success: change


### PR DESCRIPTION
As it turns out, simply removing the `library.properties` from the Bundle's Kaleidoscope is not enough to discard it completely. So instead, to make sure we're using the right version of it, remove the copy from the bundle, and symlink ourselves back in.
