### PR TITLE
Enable predefined DEVICE_PORT

### DIFF
--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -79,7 +79,11 @@ find_device_port() {
     find_device_vid_pid
     DIR=$(dirname "$(readlink -f "$0")")
     DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
-    DEVICE_PORT="$(perl ${DEVICE_PORT_PROBER} ${VID} ${SKETCH_PID})"
+    if [[ "${DEVICE_PORT}" = "" ]]; then
+      DEVICE_PORT="$(perl ${DEVICE_PORT_PROBER} ${VID} ${SKETCH_PID})"
+    else
+      echo "DEVICE_PORT=\"${DEVICE_PORT}\" predefined."
+    fi
 }
 
 reset_device_cmd() {
@@ -93,7 +97,11 @@ find_bootloader_ports() {
     DIR=$(dirname "$(readlink -f "$0")")
     BOOTLOADER_VID="${BOOTLOADER_VID:-${VID}}"
     DEVICE_PORT_PROBER="${DIR}/find-device-port-linux-udev"
-    DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${BOOTLOADER_VID} ${BOOTLOADER_PID})"
+    if [[ "${DEVICE_PORT_BOOTLOADER}" = "" ]]; then
+      DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${BOOTLOADER_VID} ${BOOTLOADER_PID})"
+    else
+      echo "DEVICE_PORT_BOOTLOADER=\"${DEVICE_PORT_BOOTLOADER}\" predefined."
+    fi
 }
 
 find_bootloader_path() {


### PR DESCRIPTION
Kaleidoscope builder has its own port autodetection. Although fairly
robus, this mechanism sometimes fails under certain circumstances
on some Linux systems (e.g. Ubuntu 18.04).

As a workaround this change enables the variable DEVICE_PORT
being predefined, e.g. as

DEVICE_PORT=/dev/ttyACM0 make flash

which will disable the port autodetection.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>