### PR TITLE
Interrupt guards

### DIFF
--- a/src/kaleidoscope/driver/keyscanner/ATmega.h
+++ b/src/kaleidoscope/driver/keyscanner/ATmega.h
@@ -47,16 +47,16 @@
   constexpr uint8_t kaleidoscope::Device::KeyScannerProps::matrix_row_pins[matrix_rows];                \
   constexpr uint8_t kaleidoscope::Device::KeyScannerProps::matrix_col_pins[matrix_columns];             \
   template<>                                                                                            \
-  uint16_t kaleidoscope::Device::KeyScanner::previousKeyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {}; \
+  volatile uint16_t kaleidoscope::Device::KeyScanner::previousKeyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {}; \
   template<>                                                                                            \
-  uint16_t kaleidoscope::Device::KeyScanner::keyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};         \
+  volatile uint16_t kaleidoscope::Device::KeyScanner::keyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};         \
   template<>                                                                                            \
   uint16_t kaleidoscope::Device::KeyScanner::masks_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};            \
   template<>                                                                               \
   uint8_t kaleidoscope::Device::KeyScanner::debounce_matrix_[kaleidoscope::Device::KeyScannerProps::matrix_rows][kaleidoscope::Device::KeyScannerProps::matrix_columns] = {}; \
                                                                                            \
   ISR(TIMER1_OVF_vect) {                                                                   \
-    Runtime.device().keyScanner().do_scan_ = true;                                         \
+    Runtime.device().readMatrix();                                              \
   }
 
 namespace kaleidoscope {
@@ -130,10 +130,6 @@ class ATmega: public kaleidoscope::driver::keyscanner::Base<_KeyScannerProps> {
   }
 
   void scanMatrix() {
-    if (do_scan_) {
-      do_scan_ = false;
-      readMatrix();
-    }
     actOnMatrixScan();
   }
 
@@ -196,12 +192,10 @@ class ATmega: public kaleidoscope::driver::keyscanner::Base<_KeyScannerProps> {
                    key_addr.col());
   }
 
-  bool do_scan_;
-
  private:
   typedef _KeyScannerProps KeyScannerProps_;
-  static uint16_t previousKeyState_[_KeyScannerProps::matrix_rows];
-  static uint16_t keyState_[_KeyScannerProps::matrix_rows];
+  static volatile uint16_t previousKeyState_[_KeyScannerProps::matrix_rows];
+  static volatile uint16_t keyState_[_KeyScannerProps::matrix_rows];
   static uint16_t masks_[_KeyScannerProps::matrix_rows];
   static uint8_t debounce_matrix_[_KeyScannerProps::matrix_rows][_KeyScannerProps::matrix_columns];
 

--- a/src/kaleidoscope/driver/keyscanner/ATmega.h
+++ b/src/kaleidoscope/driver/keyscanner/ATmega.h
@@ -140,7 +140,7 @@ class ATmega: public kaleidoscope::driver::keyscanner::Base<_KeyScannerProps> {
      * interrupts, we might end up in a situation where the state is updated in
      * the middle of our check, making us misdetect state changes.
      */
-    cli();
+    noInterrupts();
     for (byte row = 0; row < _KeyScannerProps::matrix_rows; row++) {
       for (byte col = 0; col < _KeyScannerProps::matrix_columns; col++) {
         uint8_t keyState = (bitRead(previousKeyState_[row], col) << 0) |
@@ -152,7 +152,7 @@ class ATmega: public kaleidoscope::driver::keyscanner::Base<_KeyScannerProps> {
       }
       previousKeyState_[row] = keyState_[row];
     }
-    sei();
+    interrupts();
   }
 
   uint8_t pressedKeyswitchCount() {

--- a/src/kaleidoscope/plugin/HardwareTestMode.cpp
+++ b/src/kaleidoscope/plugin/HardwareTestMode.cpp
@@ -31,6 +31,12 @@ void HardwareTestMode::setActionKey(uint8_t key) {
 }
 
 void HardwareTestMode::waitForKeypress() {
+  /*
+   * Note: we disable interrupts here, because we want to take over matrix
+   * scanning and reaction completely. As such, it makes no sense to run the
+   * matrix scanning in the interrupt handler at the same time.
+   */
+  cli();
   while (1) {
     Runtime.device().readMatrix();
     if (Runtime.device().isKeyswitchPressed(actionKey) &&
@@ -38,6 +44,7 @@ void HardwareTestMode::waitForKeypress() {
       break;
     }
   }
+  sei();
 }
 
 void HardwareTestMode::setLeds(cRGB color) {
@@ -84,6 +91,12 @@ void HardwareTestMode::testMatrix() {
   constexpr cRGB yellow = CRGB(201, 100, 0);
 
   while (1) {
+    /*
+     * Note: we disable interrupts here, because we want to take over matrix
+     * scanning and reaction completely. As such, it makes no sense to run the
+     * matrix scanning in the interrupt handler at the same time.
+     */
+    cli();
     Runtime.device().readMatrix();
     for (auto key_addr : KeyAddr::all()) {
       uint8_t keynum = key_addr.toInt();
@@ -115,6 +128,7 @@ void HardwareTestMode::testMatrix() {
         Runtime.device().setCrgbAt(key_addr, blue);
       }
     }
+    sei();
     ::LEDControl.syncLeds();
   }
 }

--- a/src/kaleidoscope/plugin/HardwareTestMode.cpp
+++ b/src/kaleidoscope/plugin/HardwareTestMode.cpp
@@ -36,7 +36,7 @@ void HardwareTestMode::waitForKeypress() {
    * scanning and reaction completely. As such, it makes no sense to run the
    * matrix scanning in the interrupt handler at the same time.
    */
-  cli();
+  noInterrupts();
   while (1) {
     Runtime.device().readMatrix();
     if (Runtime.device().isKeyswitchPressed(actionKey) &&
@@ -44,7 +44,7 @@ void HardwareTestMode::waitForKeypress() {
       break;
     }
   }
-  sei();
+  interrupts();
 }
 
 void HardwareTestMode::setLeds(cRGB color) {
@@ -96,7 +96,7 @@ void HardwareTestMode::testMatrix() {
      * scanning and reaction completely. As such, it makes no sense to run the
      * matrix scanning in the interrupt handler at the same time.
      */
-    cli();
+    noInterrupts();
     Runtime.device().readMatrix();
     for (auto key_addr : KeyAddr::all()) {
       uint8_t keynum = key_addr.toInt();
@@ -128,7 +128,7 @@ void HardwareTestMode::testMatrix() {
         Runtime.device().setCrgbAt(key_addr, blue);
       }
     }
-    sei();
+    interrupts();
     ::LEDControl.syncLeds();
   }
 }

--- a/src/kaleidoscope/plugin/MagicCombo.cpp
+++ b/src/kaleidoscope/plugin/MagicCombo.cpp
@@ -28,6 +28,16 @@ EventHandlerResult MagicCombo::beforeReportingState() {
     bool match = true;
     byte j;
 
+    /*
+     * Note: we're disabling interrupts here so we see a consistent state for
+     * every combo checked. We're not disabling them for the entire
+     * `beforeReportingState`, because we're ok with state changes between
+     * individual combo checks. We only need consistent state for each combo,
+     * not all of them.
+     */
+
+    cli();
+
     for (j = 0; j < MAX_COMBO_LENGTH; j++) {
       int8_t comboKey = pgm_read_byte(&(magiccombo::combos[i].keys[j]));
 
@@ -41,6 +51,8 @@ EventHandlerResult MagicCombo::beforeReportingState() {
 
     if (j != Runtime.device().pressedKeyswitchCount())
       match = false;
+
+    sei();
 
     if (match && Runtime.hasTimeExpired(start_time_, min_interval)) {
       ComboAction action = (ComboAction) pgm_read_ptr((void const **) & (magiccombo::combos[i].action));

--- a/src/kaleidoscope/plugin/MagicCombo.cpp
+++ b/src/kaleidoscope/plugin/MagicCombo.cpp
@@ -36,7 +36,7 @@ EventHandlerResult MagicCombo::beforeReportingState() {
      * not all of them.
      */
 
-    cli();
+    noInterrupts();
 
     for (j = 0; j < MAX_COMBO_LENGTH; j++) {
       int8_t comboKey = pgm_read_byte(&(magiccombo::combos[i].keys[j]));
@@ -52,7 +52,7 @@ EventHandlerResult MagicCombo::beforeReportingState() {
     if (j != Runtime.device().pressedKeyswitchCount())
       match = false;
 
-    sei();
+    interrupts();
 
     if (match && Runtime.hasTimeExpired(start_time_, min_interval)) {
       ComboAction action = (ComboAction) pgm_read_ptr((void const **) & (magiccombo::combos[i].action));


### PR DESCRIPTION
This reverts #815, and fixes #812 in a different way: Instead of moving the key scanning out of the interrupt handler, we guard _all_ places that need a consistent view by disabling/enabling interrupts around them.