### PR TITLE
Feature/flash qmk

### DIFF
--- a/bin/find-device-port-macos
+++ b/bin/find-device-port-macos
@@ -66,8 +66,9 @@ sub try_for_location_id {
     my $location_id = shift;
 
     # Here, also, the final character is always a "1", so if macOS ever stops doing that, this
-    # will need an update, as well.
-    my $loc = substr($location_id, 2, 3);
+    # will need an update, as well. 
+    my $len = index($location_id, "0", 2) - 2;
+    my $loc = substr($location_id, 2, $len);
     exit_with_port_if_exists("/dev/cu.usbmodem" . $loc . 1);
 }
 

--- a/bin/find-device-port-macos
+++ b/bin/find-device-port-macos
@@ -10,6 +10,8 @@ use strict;
 my $vid = shift @ARGV;
 my $pid = shift @ARGV;
 
+exit 0 unless defined $vid && defined $pid;
+
 # ioreg might be more machine-readable than system_profiler, but I haven't been able to
 # get it to produce useful output
 my @output = qx(/usr/sbin/system_profiler SPUSBDataType 2> /dev/null);
@@ -52,14 +54,13 @@ sub try_for_raw_serialnum {
     # filename. I'm not sure why, but system_profiler has a serial number ending in "E",
     # whereas the device filename ends in "1". In fact, when I change HID.getShortName()
     # to return "kbio02", the final character is replaced with a "1", so we should do the
-    # same here. If the serial number doesn't end in a digit, however, we may want to append
-    # rather than replace the last character with a 1.
-    if ($serial_port_name =~ /\d$/) {
-        $serial_port_name =~ s/.$/1/;
-    } else {
-        $serial_port_name .= "1";
-    }
+    # same here. 
+    exit_with_port_if_exists($serial_port_name . "1");
+    
+    # now try with the last character chop-ped off 
+    chop $serial_port_name;
     exit_with_port_if_exists($serial_port_name);
+    exit_with_port_if_exists($serial_port_name . "1");
 }
 
 sub try_for_location_id {
@@ -67,18 +68,19 @@ sub try_for_location_id {
 
     # Here, also, the final character is always a "1", so if macOS ever stops doing that, this
     # will need an update, as well. 
-    my $len = index($location_id, "0", 2) - 2;
-    my $loc = substr($location_id, 2, $len);
-    exit_with_port_if_exists("/dev/cu.usbmodem" . $loc . 1);
+    if ($location_id =~ /0x(\d+?)0*\b/) { 
+        exit_with_port_if_exists("/dev/cu.usbmodem" . $1 . 1);
+    }
 }
 
 sub try_for_sn_prefix {
     my $sn = shift;
+    chop $sn if length $sn > 1; 
 
     # If none of the above tests succeeds, just list the directory and see if there are any
     # files that have the device shortname that we expect:
     foreach my $line (qx(ls /dev/cu.usbmodem*)) {
-        if ($line =~ /${sn}/) {
+        if ($line =~ /${sn}.{0,2}\b/) {
             chomp $line;
             print $line;
             exit 0;

--- a/bin/find-device-port-macos
+++ b/bin/find-device-port-macos
@@ -10,7 +10,9 @@ use strict;
 my $vid = shift @ARGV;
 my $pid = shift @ARGV;
 
-exit 0 unless defined $vid && defined $pid;
+if (!defined $vid || !defined $pid) {
+  die "$0 has two required parameters, VID and PID";
+}
 
 # ioreg might be more machine-readable than system_profiler, but I haven't been able to
 # get it to produce useful output
@@ -53,11 +55,11 @@ sub try_for_raw_serialnum {
     # High Sierra sometimes has a mismatch between the serial number and the device
     # filename. I'm not sure why, but system_profiler has a serial number ending in "E",
     # whereas the device filename ends in "1". In fact, when I change HID.getShortName()
-    # to return "kbio02", the final character is replaced with a "1", so we should do the
-    # same here. 
+    # to return "kbio02", the final character is replaced with a "1". 
+    # We try adding a "1" here. 
     exit_with_port_if_exists($serial_port_name . "1");
     
-    # now try with the last character chop-ped off 
+    # and if that didn't work, replace the last character with a "1" 
     chop $serial_port_name;
     exit_with_port_if_exists($serial_port_name);
     exit_with_port_if_exists($serial_port_name . "1");
@@ -66,21 +68,24 @@ sub try_for_raw_serialnum {
 sub try_for_location_id {
     my $location_id = shift;
 
-    # Here, also, the final character is always a "1", so if macOS ever stops doing that, this
-    # will need an update, as well. 
-    if ($location_id =~ /0x(\d+?)0*\b/) { 
-        exit_with_port_if_exists("/dev/cu.usbmodem" . $1 . 1);
+    # MacOs truncates the string of "0"s from the right of the location id.
+    # Here, also, the final character is an appended "1", so if macOS ever stops doing that,
+    # this will need an update, as well. 
+    if ($location_id =~ /0x(\d+?)0*\b/) {
+        my $loc = $1;
+        exit_with_port_if_exists("/dev/cu.usbmodem" . $loc . "1");
     }
 }
 
 sub try_for_sn_prefix {
     my $sn = shift;
+    # Assuming MacOs has appended 'E', take it off to maximise our chances of a match.
     chop $sn if length $sn > 1; 
 
     # If none of the above tests succeeds, just list the directory and see if there are any
     # files that have the device shortname that we expect:
     foreach my $line (qx(ls /dev/cu.usbmodem*)) {
-        if ($line =~ /${sn}.{0,2}\b/) {
+        if ($line =~ /${sn}/) {
             chomp $line;
             print $line;
             exit 0;

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -163,11 +163,11 @@ prompt_before_flashing () {
 flash () {
     maybe_build "$@"
       
-    if [ -z "${QMK_FLASH}" ]; then
-        # Check to see if we can see a keyboard bootloader port. 
-        # If we -can-, then we should skip over the "reset to bootloader" thing
-        find_bootloader_ports
-        if [ -z "${DEVICE_PORT_BOOTLOADER}" ]; then
+    # Check to see if we can see a keyboard bootloader port. 
+    # If we -can-, then we should skip over the "reset to bootloader" thing
+    find_bootloader_ports
+    if [ -z "${DEVICE_PORT_BOOTLOADER}" ]; then
+        if [ -z "${QMK_FLASH}" ]; then
             prompt_before_flashing
           
             # This is defined in the (optional) user config.
@@ -177,17 +177,15 @@ flash () {
             reset_device
             sleep 2
             find_bootloader_ports
+        else
+            # This is defined in the (optional) user config.
+            # shellcheck disable=SC2154
+            ${preFlash_HOOKS}
+        
+            # Keyboards with QMK firmware must be reset manually to enter bootloader mode.
+            echo "Reset your keyboard now to initiate flashing."
+            wait_for_bootloader_port
         fi
-    else
-        # For keyboards that require a reset before ports are visible
-        # i.e. QMK firmware
-        echo "Reset your keyboard now to initiate flashing."
-        
-        # This is defined in the (optional) user config.
-        # shellcheck disable=SC2154
-        ${preFlash_HOOKS}
-        
-        wait_for_bootloader_port
     fi
     
     check_bootloader_port_and_flash
@@ -197,12 +195,29 @@ flash () {
     ${postFlash_HOOKS}
 }
 
+wait_for_bootloader_port() {
+    declare -i tries
+    tries=15
+    
+    while [ "$tries" -gt 0 ] && [ -z "${DEVICE_PORT_BOOTLOADER}" ]; do
+        sleep 1
+        printf "."
+        find_bootloader_ports
+        tries=$(($tries-1))
+    done
+    
+    if [ "$tries" -gt 0 ]; then
+        echo "Found."
+    else 
+        echo "Timed out."
+    fi 
+}
 
 check_bootloader_port () {
     if [ -z "${DEVICE_PORT_BOOTLOADER}" ]; then
         echo "Unable to detect a keyboard in bootloader mode."
-	echo "You may need to hold a key or hit a reset button."
-	echo "Please check your keyboard's documentation"
+        echo "You may need to hold a key or hit a reset button."
+        echo "Please check your keyboard's documentation"
         return 1
     fi
 
@@ -215,14 +230,13 @@ check_bootloader_port_and_flash () {
     fi
  
     echo "Flashing your keyboard:"
-
     # If the flash fails, try a second time
     if ! flash_over_usb; then 
         sleep 2
         if  ! flash_over_usb; then
             if [ "${ARDUINO_VERBOSE}" != "-verbose" ]; then
                 echo "Something went wrong."
-    	        echo "You might want to try flashing again with the VERBOSE environment variable set"
+                echo "You might want to try flashing again with the VERBOSE environment variable set"
             fi
 
             return 1

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -197,6 +197,31 @@ flash () {
     ${postFlash_HOOKS}
 }
 
+wait_for_bootloader_port() {
+    ls /dev/cu.* > /tmp/1
+
+    local count=20
+    while [[ $count > 0 && -z "${DEVICE_PORT_BOOTLOADER}" ]]; do 
+        sleep 0.5
+        printf "."
+        ls /dev/cu.* > /tmp/2
+        DEVICE_PORT_BOOTLOADER=$(comm -13 /tmp/1 /tmp/2 | grep -o '/dev/cu.*')
+        mv /tmp/2 /tmp/1
+        let count--
+    done
+    
+    while [[ $count > 0 && ! -w "${DEVICE_PORT_BOOTLOADER}" ]]; do
+        sleep 0.5
+        printf "."
+        let count--
+    done 
+    
+    echo ""
+    
+    if [[ $count > 0 ]]; then
+        echo "Found ${DEVICE_PORT_BOOTLOADER}."
+    fi 
+}
 
 check_bootloader_port () {
     if [ -z "${DEVICE_PORT_BOOTLOADER}" ]; then

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -197,31 +197,6 @@ flash () {
     ${postFlash_HOOKS}
 }
 
-wait_for_bootloader_port() {
-    ls /dev/cu.* > /tmp/1
-
-    local count=20
-    while [[ $count > 0 && -z "${DEVICE_PORT_BOOTLOADER}" ]]; do 
-        sleep 0.5
-        printf "."
-        ls /dev/cu.* > /tmp/2
-        DEVICE_PORT_BOOTLOADER=$(comm -13 /tmp/1 /tmp/2 | grep -o '/dev/cu.*')
-        mv /tmp/2 /tmp/1
-        let count--
-    done
-    
-    while [[ $count > 0 && ! -w "${DEVICE_PORT_BOOTLOADER}" ]]; do
-        sleep 0.5
-        printf "."
-        let count--
-    done 
-    
-    echo ""
-    
-    if [[ $count > 0 ]]; then
-        echo "Found ${DEVICE_PORT_BOOTLOADER}."
-    fi 
-}
 
 check_bootloader_port () {
     if [ -z "${DEVICE_PORT_BOOTLOADER}" ]; then

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -143,15 +143,20 @@ find_sketch () {
 }
 
 
-prompt_reset () {
+prompt_before_flashing () {
     flashing_instructions=$(get_arduino_pref 'build.flashing_instructions')
 
-    if [ -z "${flashing_instructions}" ]; then
-        flashing_instructions="Reset your keyboard now to initiate flashing."
+    if [ "x${flashing_instructions}x" = "xx" ]; then
+        flashing_instructions="If your keyboard needs you to do something to put it in flashing mode, do that now."
     fi
-    
+
     printf '%b\n\n' "${flashing_instructions}"
     echo ""
+    echo "When you're ready to proceed, press 'Enter'."
+
+    # We do not want to permit line continuations here. We just want a newline.
+    # shellcheck disable=SC2162
+    read
 }
 
 
@@ -184,6 +189,7 @@ flash () {
         
         wait_for_bootloader_port
     fi
+    
     check_bootloader_port_and_flash
 
     # This is defined in the (optional) user config.

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -148,7 +148,7 @@ prompt_before_flashing () {
     flashing_instructions=$(get_arduino_pref 'build.flashing_instructions')
 
     if [ "x${flashing_instructions}x" = "xx" ]; then
-	flashing_instructions="If your keyboard needs you to do something to put it in flashing mode, do that now."
+        flashing_instructions="If your keyboard needs you to do something to put it in flashing mode, do that now."
     fi
 
     printf '%b\n\n' "${flashing_instructions}"
@@ -160,24 +160,50 @@ prompt_before_flashing () {
     read
 }
 
+
+prompt_reset () {
+    flashing_instructions=$(get_arduino_pref 'build.flashing_instructions')
+
+    if [ -z "${flashing_instructions}" ]; then
+        flashing_instructions="Reset your keyboard now to initiate flashing."
+    fi
+    
+    printf '%b\n\n' "${flashing_instructions}"
+    echo ""
+}
+
+
 flash () {
     maybe_build "$@"
-
-    # Check to see if we can see a keyboard bootloader port. 
-    # If we -can-, then we should skip over the "reset to bootloader" thing
-    find_bootloader_ports
-    if [ -z "${DEVICE_PORT_BOOTLOADER}" ]; then
-        prompt_before_flashing
-    
+      
+    WAIT_FOR_UPLOAD_PORT=$(get_arduino_pref 'upload.wait_for_upload_port')
+      
+    if [ "$WAIT_FOR_UPLOAD_PORT" != 'true' ]; then
+        # Check to see if we can see a keyboard bootloader port. 
+        # If we -can-, then we should skip over the "reset to bootloader" thing
+        find_bootloader_ports
+        if [ -z "${DEVICE_PORT_BOOTLOADER}" ]; then
+            prompt_before_flashing
+          
+            # This is defined in the (optional) user config.
+            # shellcheck disable=SC2154
+            ${preFlash_HOOKS}
+          
+            reset_device
+            sleep 2
+            find_bootloader_ports
+        fi
+    else
+        # For keyboards that require a reset to enter flashing mode
+        # and open a port 
+        prompt_reset
+        
         # This is defined in the (optional) user config.
         # shellcheck disable=SC2154
         ${preFlash_HOOKS}
-    
-        reset_device
-        sleep 2
-        find_bootloader_ports
+        
+        wait_for_bootloader_port
     fi
-
     check_bootloader_port_and_flash
 
     # This is defined in the (optional) user config.

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -143,24 +143,6 @@ find_sketch () {
 }
 
 
-
-prompt_before_flashing () {
-    flashing_instructions=$(get_arduino_pref 'build.flashing_instructions')
-
-    if [ "x${flashing_instructions}x" = "xx" ]; then
-        flashing_instructions="If your keyboard needs you to do something to put it in flashing mode, do that now."
-    fi
-
-    printf '%b\n\n' "${flashing_instructions}"
-    echo ""
-    echo "When you're ready to proceed, press 'Enter'."
-
-    # We do not want to permit line continuations here. We just want a newline.
-    # shellcheck disable=SC2162
-    read
-}
-
-
 prompt_reset () {
     flashing_instructions=$(get_arduino_pref 'build.flashing_instructions')
 
@@ -176,9 +158,7 @@ prompt_reset () {
 flash () {
     maybe_build "$@"
       
-    WAIT_FOR_UPLOAD_PORT=$(get_arduino_pref 'upload.wait_for_upload_port')
-      
-    if [ "$WAIT_FOR_UPLOAD_PORT" != 'true' ]; then
+    if [ -z "${QMK_FLASH}" ]; then
         # Check to see if we can see a keyboard bootloader port. 
         # If we -can-, then we should skip over the "reset to bootloader" thing
         find_bootloader_ports
@@ -194,9 +174,9 @@ flash () {
             find_bootloader_ports
         fi
     else
-        # For keyboards that require a reset to enter flashing mode
-        # and open a port 
-        prompt_reset
+        # For keyboards that require a reset before ports are visible
+        # i.e. QMK firmware
+        echo "Reset your keyboard now to initiate flashing."
         
         # This is defined in the (optional) user config.
         # shellcheck disable=SC2154

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -167,24 +167,17 @@ flash () {
     # If we -can-, then we should skip over the "reset to bootloader" thing
     find_bootloader_ports
     if [ -z "${DEVICE_PORT_BOOTLOADER}" ]; then
-        if [ -z "${QMK_FLASH}" ]; then
-            prompt_before_flashing
-          
-            # This is defined in the (optional) user config.
-            # shellcheck disable=SC2154
-            ${preFlash_HOOKS}
-          
-            reset_device
-            sleep 2
-            find_bootloader_ports
+        prompt_before_flashing
+        # This is defined in the (optional) user config.
+        # shellcheck disable=SC2154
+        ${preFlash_HOOKS}
+
+        if [ -z "${MANUAL_RESET}" ]; then          
+           reset_device
+           sleep 2
+           find_bootloader_ports
         else
-            # This is defined in the (optional) user config.
-            # shellcheck disable=SC2154
-            ${preFlash_HOOKS}
-        
-            # Keyboards with QMK firmware must be reset manually to enter bootloader mode.
-            echo "Reset your keyboard now to initiate flashing."
-            wait_for_bootloader_port
+           wait_for_bootloader_port
         fi
     fi
     

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -123,13 +123,13 @@ MD5="md5sum"
 if [ "${uname_S}" = "Darwin" ]; then
 
     find_device_port() {
-	DIR=$(dirname "$0")
-	DEVICE_PORT_PROBER="${DIR}/find-device-port-macos"
+        DIR=$(dirname "$0")
+        DEVICE_PORT_PROBER="${DIR}/find-device-port-macos"
         DEVICE_PORT="$(perl ${DEVICE_PORT_PROBER} ${VID} ${SKETCH_PID})"
     }
 
     reset_device_cmd() {
-	/bin/stty -f ${DEVICE_PORT} 1200
+        /bin/stty -f ${DEVICE_PORT} 1200
     }
 
     ARDUINO_PATH="${ARDUINO_PATH:-/Applications/Arduino.app/Contents/Java/}"
@@ -140,14 +140,44 @@ if [ "${uname_S}" = "Darwin" ]; then
 
     find_bootloader_ports() {
         find_device_vid_pid
-	DIR=$(dirname "$0")
+        DIR=$(dirname "$0")
         BOOTLOADER_VID="${BOOTLOADER_VID:-${VID}}"
-	DEVICE_PORT_PROBER="${DIR}/find-device-port-macos"
+        BOOTLOADER_PID="${BOOTLOADER_PID:-${SKETCH_PID}}"
+        DEVICE_PORT_PROBER="${DIR}/find-device-port-macos"
         if [[ "${DEVICE_PORT_BOOTLOADER}" = "" ]]; then
-          DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${BOOTLOADER_VID} ${BOOTLOADER_PID})"
+            DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${BOOTLOADER_VID} ${BOOTLOADER_PID})"
         else
-          echo "DEVICE_PORT_BOOTLOADER=\"${DEVICE_PORT_BOOTLOADER}\" predefined."
+            echo "DEVICE_PORT_BOOTLOADER=\"${DEVICE_PORT_BOOTLOADER}\" predefined."
         fi
+    }
+    
+    wait_for_bootloader_port() {
+        find_device_vid_pid
+        DIR=$(dirname "$0")
+        BOOTLOADER_VID="${BOOTLOADER_VID:-${VID}}"
+        BOOTLOADER_PID="${BOOTLOADER_PID:-${SKETCH_PID}}"
+        DEVICE_PORT_PROBER="${DIR}/find-device-port-macos"
+        
+        local count=40
+        while [ -z "${DEVICE_PORT_BOOTLOADER}" ] && [ count > 0 ]
+        do 
+            sleep 0.5
+            printf "."
+            DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${BOOTLOADER_VID} ${BOOTLOADER_PID})"
+            let count--
+        done
+        
+        while [ ! -w "${DEVICE_PORT_BOOTLOADER}" ] && [ count > 0 ]
+        do
+            sleep 0.5
+            printf "."
+            let count--
+        done 
+        
+        if [ count > 0 ]; then
+            echo ""
+            echo "Found ${DEVICE_PORT_BOOTLOADER}."
+        fi 
     }
 
 elif [ "${uname_S}" = "FreeBSD" ]; then

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -158,8 +158,8 @@ if [ "${uname_S}" = "Darwin" ]; then
         BOOTLOADER_PID="${SKETCH_PID}"
         DEVICE_PORT_PROBER="${DIR}/find-device-port-macos"
         
-        local count=40
-        while [ -z "${DEVICE_PORT_BOOTLOADER}" ] && [ count > 0 ]
+        local count=20
+        while [ count > 0 ] && [ -z "${DEVICE_PORT_BOOTLOADER}" ]
         do 
             sleep 0.5
             printf "."
@@ -167,7 +167,7 @@ if [ "${uname_S}" = "Darwin" ]; then
             let count--
         done
         
-        while [ ! -w "${DEVICE_PORT_BOOTLOADER}" ] && [ count > 0 ]
+        while [ count > 0 ] && [ ! -w "${DEVICE_PORT_BOOTLOADER}" ]
         do
             sleep 0.5
             printf "."

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -142,7 +142,6 @@ if [ "${uname_S}" = "Darwin" ]; then
         find_device_vid_pid
         DIR=$(dirname "$0")
         BOOTLOADER_VID="${BOOTLOADER_VID:-${VID}}"
-        BOOTLOADER_PID="${BOOTLOADER_PID}"
         DEVICE_PORT_PROBER="${DIR}/find-device-port-macos"
         if [[ "${DEVICE_PORT_BOOTLOADER}" = "" ]]; then
             DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${BOOTLOADER_VID} ${BOOTLOADER_PID})"
@@ -151,35 +150,6 @@ if [ "${uname_S}" = "Darwin" ]; then
         fi
     }
     
-    wait_for_bootloader_port() {
-        local tries=20
-        local tempName="${RANDOM}${RANDOM}"
-        local diff
-        ls /dev/cu.* > /tmp/${tempName}.1
-        
-        while [[ $tries > 0 && -z "${DEVICE_PORT_BOOTLOADER}" ]] ; do 
-            sleep 0.5
-            printf "."
-            ls /dev/cu.* > /tmp/${tempName}.2 
-            diff=$(comm -13 /tmp/${tempName}.1 /tmp/${tempName}.2)
-            DEVICE_PORT_BOOTLOADER="${diff:+$(echo ${diff} | grep -o '/dev/cu.*')}"
-            mv /tmp/${tempName}.2 /tmp/${tempName}.1
-            let tries--
-        done
-        
-        while [[ $tries > 0 && ! -w "${DEVICE_PORT_BOOTLOADER}" ]] ; do
-            sleep 0.5
-            printf "."
-            let tries--
-        done 
-        
-        echo ""
-        
-        if [[ $tries > 0 ]]; then
-            echo "Found ${DEVICE_PORT_BOOTLOADER}"
-        fi 
-    }
-
 elif [ "${uname_S}" = "FreeBSD" ]; then
 
     find_device_port() {

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -151,34 +151,6 @@ if [ "${uname_S}" = "Darwin" ]; then
         fi
     }
     
-    wait_for_bootloader_port() {
-        find_device_vid_pid
-        DIR=$(dirname "$0")
-        BOOTLOADER_VID="${BOOTLOADER_VID:-${VID}}"
-        BOOTLOADER_PID="${SKETCH_PID}"
-        DEVICE_PORT_PROBER="${DIR}/find-device-port-macos"
-        
-        local count=20
-        while [[ $count > 0 && -z "${DEVICE_PORT_BOOTLOADER}" ]]; do 
-            sleep 0.5
-            printf "."
-            DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${BOOTLOADER_VID} ${BOOTLOADER_PID})"
-            let count--
-        done
-        
-        while [[ $count > 0 && ! -w "${DEVICE_PORT_BOOTLOADER}" ]]; do
-            sleep 0.5
-            printf "."
-            let count--
-        done 
-        
-        echo ""
-        
-        if [[ $count > 0 ]]; then
-            echo "Found ${DEVICE_PORT_BOOTLOADER}."
-        fi 
-    }
-
 elif [ "${uname_S}" = "FreeBSD" ]; then
 
     find_device_port() {

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -142,7 +142,7 @@ if [ "${uname_S}" = "Darwin" ]; then
         find_device_vid_pid
         DIR=$(dirname "$0")
         BOOTLOADER_VID="${BOOTLOADER_VID:-${VID}}"
-        BOOTLOADER_PID="${BOOTLOADER_PID:-${SKETCH_PID}}"
+        BOOTLOADER_PID="${BOOTLOADER_PID}"
         DEVICE_PORT_PROBER="${DIR}/find-device-port-macos"
         if [[ "${DEVICE_PORT_BOOTLOADER}" = "" ]]; then
             DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${BOOTLOADER_VID} ${BOOTLOADER_PID})"
@@ -155,7 +155,7 @@ if [ "${uname_S}" = "Darwin" ]; then
         find_device_vid_pid
         DIR=$(dirname "$0")
         BOOTLOADER_VID="${BOOTLOADER_VID:-${VID}}"
-        BOOTLOADER_PID="${BOOTLOADER_PID:-${SKETCH_PID}}"
+        BOOTLOADER_PID="${SKETCH_PID}"
         DEVICE_PORT_PROBER="${DIR}/find-device-port-macos"
         
         local count=40

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -159,23 +159,22 @@ if [ "${uname_S}" = "Darwin" ]; then
         DEVICE_PORT_PROBER="${DIR}/find-device-port-macos"
         
         local count=20
-        while [ count > 0 ] && [ -z "${DEVICE_PORT_BOOTLOADER}" ]
-        do 
+        while [[ $count > 0 && -z "${DEVICE_PORT_BOOTLOADER}" ]]; do 
             sleep 0.5
             printf "."
             DEVICE_PORT_BOOTLOADER="$(perl ${DEVICE_PORT_PROBER} ${BOOTLOADER_VID} ${BOOTLOADER_PID})"
             let count--
         done
         
-        while [ count > 0 ] && [ ! -w "${DEVICE_PORT_BOOTLOADER}" ]
-        do
+        while [[ $count > 0 && ! -w "${DEVICE_PORT_BOOTLOADER}" ]]; do
             sleep 0.5
             printf "."
             let count--
         done 
         
-        if [ count > 0 ]; then
-            echo ""
+        echo ""
+        
+        if [[ $count > 0 ]]; then
             echo "Found ${DEVICE_PORT_BOOTLOADER}."
         fi 
     }

--- a/etc/kaleidoscope-builder.conf
+++ b/etc/kaleidoscope-builder.conf
@@ -151,6 +151,35 @@ if [ "${uname_S}" = "Darwin" ]; then
         fi
     }
     
+    wait_for_bootloader_port() {
+        local tries=20
+        local tempName="${RANDOM}${RANDOM}"
+        local diff
+        ls /dev/cu.* > /tmp/${tempName}.1
+        
+        while [[ $tries > 0 && -z "${DEVICE_PORT_BOOTLOADER}" ]] ; do 
+            sleep 0.5
+            printf "."
+            ls /dev/cu.* > /tmp/${tempName}.2 
+            diff=$(comm -13 /tmp/${tempName}.1 /tmp/${tempName}.2)
+            DEVICE_PORT_BOOTLOADER="${diff:+$(echo ${diff} | grep -o '/dev/cu.*')}"
+            mv /tmp/${tempName}.2 /tmp/${tempName}.1
+            let tries--
+        done
+        
+        while [[ $tries > 0 && ! -w "${DEVICE_PORT_BOOTLOADER}" ]] ; do
+            sleep 0.5
+            printf "."
+            let tries--
+        done 
+        
+        echo ""
+        
+        if [[ $tries > 0 ]]; then
+            echo "Found ${DEVICE_PORT_BOOTLOADER}"
+        fi 
+    }
+
 elif [ "${uname_S}" = "FreeBSD" ]; then
 
     find_device_port() {


### PR DESCRIPTION
I made these changes in order to flash my Atreus, which had QMK firmware and the Caterina bootloader that came with the AStar. 

The QMK firmware did not expose any serial ports until the keyboard was reset, so it could not be reset by sending a command from the script. A different method was necessary. 

The other changes were some improvements to the port detection logic for macos.

To flash an Atreus or another keyboard that has QMK, the QMK_FLASH flag needs to be set. In addition, the bootloader pid and vid needs to be set to the values defined by the bootloader that is currently installed. E.g. for my device:
```
QMK_FLASH=1
BOOTLOADER_VID="0x1ffb"
BOOTLOADER_PID="0x0101"
```
