### PR TITLE
Fix Atreus Classic layout to allow returning from upper layer.

### DIFF
--- a/examples/Devices/Technomancy/Atreus/Atreus.ino
+++ b/examples/Devices/Technomancy/Atreus/Atreus.ino
@@ -24,7 +24,9 @@
 #define TG(n) LockLayer(n)
 
 enum {
-  RESET
+  QWERTY,
+  FUN,
+  UPPER
 };
 
 #define Key_Exclamation LSHIFT(Key_1)
@@ -37,7 +39,7 @@ enum {
 
 /* *INDENT-OFF* */
 KEYMAPS(
-  [0] = KEYMAP_STACKED
+  [QWERTY] = KEYMAP_STACKED
   (
        Key_Q   ,Key_W   ,Key_E       ,Key_R         ,Key_T
       ,Key_A   ,Key_S   ,Key_D       ,Key_F         ,Key_G
@@ -47,33 +49,33 @@ KEYMAPS(
                     ,Key_Y     ,Key_U ,Key_I     ,Key_O      ,Key_P
                     ,Key_H     ,Key_J ,Key_K     ,Key_L      ,Key_Semicolon
                     ,Key_N     ,Key_M ,Key_Comma ,Key_Period ,Key_Slash
-       ,Key_LeftAlt ,Key_Space ,MO(1) ,Key_Minus ,Key_Quote  ,Key_Enter
+       ,Key_LeftAlt ,Key_Space ,MO(FUN) ,Key_Minus ,Key_Quote  ,Key_Enter
   ),
 
-  [1] = KEYMAP_STACKED
+  [FUN] = KEYMAP_STACKED
   (
        Key_Exclamation ,Key_At           ,Key_UpArrow   ,Key_LeftCurlyBracket ,Key_RightCurlyBracket
       ,Key_Hash        ,Key_LeftArrow    ,Key_DownArrow ,Key_RightArrow       ,Key_Dollar
       ,Key_LeftBracket ,Key_RightBracket ,Key_LeftParen ,Key_RightParen       ,Key_And
-      ,TG(2)           ,Key_Insert       ,Key_LeftGui   ,Key_LeftShift        ,Key_Backspace         ,Key_LeftControl
+      ,TG(UPPER)       ,Key_Insert       ,Key_LeftGui   ,Key_LeftShift        ,Key_Backspace         ,Key_LeftControl
 
-                   ,Key_PageUp   ,Key_7 ,Key_8      ,Key_9 ,Key_Star
-                   ,Key_PageDown ,Key_4 ,Key_5      ,Key_6 ,Key_Plus
-                   ,Key_Backtick ,Key_1 ,Key_2      ,Key_3 ,Key_Backslash
-      ,Key_LeftAlt ,Key_Space    ,MO(1) ,Key_Period ,Key_0 ,Key_Equals
+                   ,Key_PageUp   ,Key_7   ,Key_8      ,Key_9 ,Key_Star
+                   ,Key_PageDown ,Key_4   ,Key_5      ,Key_6 ,Key_Plus
+                   ,Key_Backtick ,Key_1   ,Key_2      ,Key_3 ,Key_Backslash
+      ,Key_LeftAlt ,Key_Space    ,MO(FUN) ,Key_Period ,Key_0 ,Key_Equals
    ),
 
-  [2] = KEYMAP_STACKED
+  [UPPER] = KEYMAP_STACKED
   (
        Key_Insert ,Key_Home                 ,Key_UpArrow   ,Key_End        ,Key_PageUp
       ,Key_Delete ,Key_LeftArrow            ,Key_DownArrow ,Key_RightArrow ,Key_PageDown
-      ,XXX        ,Consumer_VolumeIncrement ,XXX           ,XXX            ,M(RESET)
+      ,XXX        ,Consumer_VolumeIncrement ,XXX           ,XXX            ,___
       ,XXX        ,Consumer_VolumeDecrement ,___           ,___            ,___          ,___
 
-                ,Key_UpArrow   ,Key_F7 ,Key_F8          ,Key_F9         ,Key_F10
-                ,Key_DownArrow ,Key_F4 ,Key_F5          ,Key_F6         ,Key_F11
-                ,XXX           ,Key_F1 ,Key_F2          ,Key_F3         ,Key_F12
-      ,___      ,___           ,___    ,Key_PrintScreen ,Key_ScrollLock ,Consumer_PlaySlashPause
+                ,Key_UpArrow   ,Key_F7   ,Key_F8          ,Key_F9         ,Key_F10
+                ,Key_DownArrow ,Key_F4   ,Key_F5          ,Key_F6         ,Key_F11
+                ,XXX           ,Key_F1   ,Key_F2          ,Key_F3         ,Key_F12
+      ,___      ,___           ,M(QWERTY),Key_PrintScreen ,Key_ScrollLock ,Consumer_PlaySlashPause
    )
 )
 /* *INDENT-ON* */
@@ -82,8 +84,8 @@ KALEIDOSCOPE_INIT_PLUGINS(Macros);
 
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
   switch (macroIndex) {
-  case RESET:
-    Kaleidoscope.rebootBootloader();
+  case QWERTY:
+    Layer.move(QWERTY);
     break;
   default:
     break;


### PR DESCRIPTION
Previously tapping the fn key in the upper layer had no effect; now it
returns it to the base layer.

This also removes the RESET macro, which also had no effect. At this
time the Classic Atreus running Kaleidoscope must use the hardware
reset since both the firmware-based reset button and `make flash` are
ineffective. (It would be nice to fix either `RESET` or `make flash`; which
one makes more sense for the Atreus Classic?)