### PR TITLE
ConsumerControl: allow 10-bit keycodes

### DIFF
--- a/src/kaleidoscope/driver/hid/keyboardio/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/keyboardio/Keyboard.h
@@ -140,10 +140,10 @@ class ConsumerControlWrapper {
     ConsumerControl.releaseAll();
   }
 
-  void press(uint8_t code) {
+  void press(uint16_t code) {
     ConsumerControl.press(code);
   }
-  void release(uint8_t code) {
+  void release(uint16_t code) {
     ConsumerControl.release(code);
   }
 };


### PR DESCRIPTION
New contributor, typing on the Model01 I have finally switched over to!  I accept the DCO.  I have reviewed the contributor guidelines and code of conduct.  I checked the issues, the forum, and Google without success before starting on the road that led to this PR.

Use case: mapping `Consumer_AC_Home`, `Consumer_AC_Forward`, and `Consumer_AC_Back`.

Observed: when I put those in a keymap, I got no response from the computer for Home, and "unknown scancode" messages for Forward and Back.

Reason: I figured out that those AC codes were >0xff, but only the bottom 8 bits were being transmitted.

Solution in this PR: In ConsumerControlWrapper, accept consumer-control keycodes as `uint16_t` instead of `uint8_t`.  KeyboardioHID already does so; it's just that Kaleidoscope wasn't passing all 16 to HID.

Tested successfully with a Model01-Q on Lubuntu Eoan x64.

If this PR is accepted, I am happy to submit a PR for Kaleidoscope-Bundle-Keyboardio to update the submodule.

Thank you for considering this PR!

**Edit** Travis build 2600! :)