### PR TITLE
Boot Keyboard keys were never being released.

### DIFF
--- a/src/kaleidoscope/driver/hid/base/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/base/Keyboard.h
@@ -193,8 +193,12 @@ class Keyboard {
   }
   void releaseAllKeys() __attribute__((noinline)) {
     resetModifierTracking();
-    nkro_keyboard_.releaseAll();
-    consumer_control_.releaseAll();
+    if (boot_keyboard_.getProtocol() == HID_BOOT_PROTOCOL) {
+        boot_keyboard_.releaseAll();
+    } else {
+        nkro_keyboard_.releaseAll();
+        consumer_control_.releaseAll();
+    }
   }
   void pressConsumerControl(Key mapped_key) {
     consumer_control_.press(CONSUMER(mapped_key));


### PR DESCRIPTION
Fixes #825

Due to a presumed refactoring bug, keys on boot protocol keyboards were never being released. This can't possibly work