### PR TITLE
Introduce MCU Properties

### DIFF
--- a/src/kaleidoscope/device/ATmega32U4Keyboard.h
+++ b/src/kaleidoscope/device/ATmega32U4Keyboard.h
@@ -70,7 +70,8 @@ namespace kaleidoscope {
 namespace device {
 
 struct ATmega32U4KeyboardProps : kaleidoscope::device::BaseProps {
-  typedef kaleidoscope::driver::mcu::ATmega32U4 MCU;
+  typedef kaleidoscope::driver::mcu::ATmega32U4Props MCUProps;
+  typedef kaleidoscope::driver::mcu::ATmega32U4<MCUProps> MCU;
   typedef kaleidoscope::driver::storage::ATmega32U4EEPROMProps StorageProps;
   typedef kaleidoscope::driver::storage::AVREEPROM<StorageProps> Storage;
 };

--- a/src/kaleidoscope/device/Base.h
+++ b/src/kaleidoscope/device/Base.h
@@ -59,6 +59,7 @@ struct BaseProps {
   typedef kaleidoscope::driver::keyscanner::None KeyScanner;
   typedef kaleidoscope::driver::led::BaseProps LEDDriverProps;
   typedef kaleidoscope::driver::led::None LEDDriver;
+  typedef kaleidoscope::driver::mcu::BaseProps MCUProps;
   typedef kaleidoscope::driver::mcu::None MCU;
   typedef kaleidoscope::driver::bootloader::None Bootloader;
   typedef kaleidoscope::driver::storage::BaseProps StorageProps;
@@ -88,6 +89,7 @@ class Base {
   typedef typename _DeviceProps::KeyScannerProps::KeyAddr KeyAddr;
   typedef typename _DeviceProps::LEDDriverProps LEDDriverProps;
   typedef typename _DeviceProps::LEDDriver LEDDriver;
+  typedef typename _DeviceProps::MCUProps MCUProps;
   typedef typename _DeviceProps::MCU MCU;
   typedef typename _DeviceProps::Bootloader Bootloader;
   typedef typename _DeviceProps::StorageProps StorageProps;

--- a/src/kaleidoscope/device/kbdfans/KBD4x.h
+++ b/src/kaleidoscope/device/kbdfans/KBD4x.h
@@ -32,6 +32,11 @@ namespace device {
 namespace kbdfans {
 
 struct KBD4xProps : kaleidoscope::device::ATmega32U4KeyboardProps {
+  struct MCUProps: public kaleidoscope::driver::mcu::ATmega32U4Props {
+    static constexpr bool disable_jtag = true;
+    static constexpr bool disable_clock_division = true;
+  };
+  typedef kaleidoscope::driver::mcu::ATmega32U4<MCUProps> MCU;
   struct KeyScannerProps : public kaleidoscope::driver::keyscanner::ATmegaProps {
     ATMEGA_KEYSCANNER_PROPS(
       ROW_PIN_LIST({ PIN_D0, PIN_D1, PIN_D2, PIN_D3 }),
@@ -44,13 +49,7 @@ struct KBD4xProps : kaleidoscope::device::ATmega32U4KeyboardProps {
 };
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-class KBD4x: public kaleidoscope::device::ATmega32U4Keyboard<KBD4xProps> {
- public:
-  KBD4x() {
-    mcu_.disableJTAG();
-    mcu_.disableClockDivision();
-  }
-};
+ATMEGA32U4_DEVICE(KBD4x);
 #else // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 class KBD4x;
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/src/kaleidoscope/device/softhruf/Splitography.h
+++ b/src/kaleidoscope/device/softhruf/Splitography.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Hardware-SOFTHRUF-Splitography -- Splitography hardware support for Kaleidoscope
- * Copyright (C) 2018, 2019  Keyboard.io, Inc
+ * Copyright (C) 2018, 2019, 2020  Keyboard.io, Inc
  *
  * Based on QMK (commit e9a67f8fd) and sdothum's fork (commit 8616b44)
  *  (C) Jack Humbert, Jun Wako, Steven Hum, and others
@@ -39,6 +39,10 @@ namespace device {
 namespace softhruf {
 
 struct SplitographyProps : kaleidoscope::device::ATmega32U4KeyboardProps {
+  struct MCUProps: kaleidoscope::driver::mcu::ATmega32U4Props {
+    static constexpr bool disable_jtag = true;
+  };
+  typedef kaleidoscope::driver::mcu::ATmega32U4<MCUProps> MCU;
   struct KeyScannerProps : public kaleidoscope::driver::keyscanner::ATmegaProps {
     ATMEGA_KEYSCANNER_PROPS(
       ROW_PIN_LIST({ PIN_D0, PIN_D1, PIN_D2, PIN_D3 }),
@@ -51,12 +55,7 @@ struct SplitographyProps : kaleidoscope::device::ATmega32U4KeyboardProps {
 };
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-class Splitography: public kaleidoscope::device::ATmega32U4Keyboard<SplitographyProps> {
- public:
-  Splitography() {
-    mcu_.disableJTAG();
-  }
-};
+ATMEGA32U4_DEVICE(Splitography);
 #else // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 class Splitography;
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/src/kaleidoscope/driver/mcu/ATmega32U4.h
+++ b/src/kaleidoscope/driver/mcu/ATmega32U4.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * driver::MCU::ATmega32U4 -- ATmega32U4 MCU driver for Kaleidoscope
- * Copyright (C) 2019  Keyboard.io, Inc
+ * Copyright (C) 2019, 2020  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -23,8 +23,14 @@ namespace kaleidoscope {
 namespace driver {
 namespace mcu {
 
+struct ATmega32U4Props: public kaleidoscope::driver::mcu::BaseProps {
+  static constexpr bool disable_jtag = false;
+  static constexpr bool disable_clock_division = false;
+};
+
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-class ATmega32U4 : public kaleidoscope::driver::mcu::Base {
+template <typename _Props>
+class ATmega32U4 : public kaleidoscope::driver::mcu::Base<_Props> {
  public:
   void detachFromHost() {
     UDCON |= _BV(DETACH);
@@ -61,7 +67,12 @@ class ATmega32U4 : public kaleidoscope::driver::mcu::Base {
     CLKPR = (0 << CLKPS3) | (0 << CLKPS2) | (0 << CLKPS1) | (0 << CLKPS0);
   }
 
-  void setup() {}
+  void setup() {
+    if (_Props::disable_jtag)
+      disableJTAG();
+    if (_Props::disable_clock_division)
+      disableClockDivision();
+  }
 };
 #else
 typedef Base ATmega32U4;

--- a/src/kaleidoscope/driver/mcu/Base.h
+++ b/src/kaleidoscope/driver/mcu/Base.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * driver::mcu::Base -- MCU driver base class for Kaleidoscope
- * Copyright (C) 2019  Keyboard.io, Inc
+ * Copyright (C) 2019, 2020  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -21,6 +21,9 @@ namespace kaleidoscope {
 namespace driver {
 namespace mcu {
 
+struct BaseProps {};
+
+template<typename _Props>
 class Base {
  public:
   Base() {}

--- a/src/kaleidoscope/driver/mcu/None.h
+++ b/src/kaleidoscope/driver/mcu/None.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * driver::MCU::None -- Dummy MCU driver for Kaleidoscope
- * Copyright (C) 2019  Keyboard.io, Inc
+ * Copyright (C) 2019, 2020  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -27,9 +27,9 @@ namespace mcu {
  * The purpose of this class is to serve as a default inside the base
  * `kaleidoscope::device::Base` class, with a name more descriptive than
  * `mcu::Base`. In practice, one shouldn't use it, and should override the
- * bootloader in the device description.
+ * MCU in the device description.
  */
-class None : public kaleidoscope::driver::mcu::Base {};
+class None : public kaleidoscope::driver::mcu::Base<BaseProps> {};
 
 }
 }

--- a/src/kaleidoscope/driver/mcu/SAMD.h
+++ b/src/kaleidoscope/driver/mcu/SAMD.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * driver::mcu::SAMD -- SAMD MCU driver class for Kaleidoscope
- * Copyright (C) 2019  Keyboard.io, Inc
+ * Copyright (C) 2019, 2020  Keyboard.io, Inc
  * Copyright (C) 2019  Dygma, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -26,7 +26,7 @@ namespace kaleidoscope {
 namespace driver {
 namespace mcu {
 
-class SAMD : public kaleidoscope::driver::mcu::Base {
+class SAMD : public kaleidoscope::driver::mcu::Base<BaseProps> {
  public:
   void detachFromHost() {
     USBDevice.detach();


### PR DESCRIPTION
This introduces MCU properties, so that MCU drivers can change their behaviour and/or setup tasks based on them, without having to write a `setup()` method or a custom constructor for the top-level device.

In practice, this allows us to tell the MCU driver to - for example - disable JTAG or clock division during setup, and thus, we won't need to do that in code in the device constructor.

This is a breaking change, kind of, because the `mcu::Base` and `mcu::ATmega32U4` drivers changed APIs. However, no device was using those directly, only via `ATmega32U4Keyboard`, and those parts remain compatible.

While there, updated the `KBD4x` and `Splitography` devices to use the new properties instead of a custom constructor.
