### PR TITLE
Update link to key layout diagram

### DIFF
--- a/docs/plugins/MagicCombo.md
+++ b/docs/plugins/MagicCombo.md
@@ -65,6 +65,6 @@ started with the plugin.
 
 `RxCy` coordinates for a Model01:
 
-![rxcy layout](../model01_coordinates.png)
+![rxcy layout](../hardware-devices/keyboardio/model01/model01_coordinates.png)
 
  [plugin:example]: ../../examples/Keystrokes/MagicCombo/MagicCombo.ino


### PR DESCRIPTION
Link was broken with this change https://github.com/keyboardio/Kaleidoscope/commit/a60651054a5a2fb28b3aac517e67cbe4#diff-0f4002969730fe05379377f79815fef8