### PR TITLE
SpaceCadet:  Fix key injection when many pressed at once

### DIFF
--- a/src/kaleidoscope/plugin/SpaceCadet.cpp
+++ b/src/kaleidoscope/plugin/SpaceCadet.cpp
@@ -119,7 +119,7 @@ EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, KeyAddr key_add
     ) {
 
       if (map[i].flagged
-        && map[i].input != mapped_key) {
+          && map[i].input != mapped_key) {
         other_mapped_key_flagged = true;
         break;
       }

--- a/src/kaleidoscope/plugin/SpaceCadet.cpp
+++ b/src/kaleidoscope/plugin/SpaceCadet.cpp
@@ -118,11 +118,11 @@ EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, KeyAddr key_add
       ++i
     ) {
 
-        if (map[i].flagged
-         && map[i].input != mapped_key) {
-          other_mapped_key_flagged = true;
-          break;
-        }
+      if (map[i].flagged
+        && map[i].input != mapped_key) {
+        other_mapped_key_flagged = true;
+        break;
+      }
     }
 
     //This will only set one key, and, if it isn't in our map, it clears everything for the non-pressed key
@@ -141,8 +141,7 @@ EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, KeyAddr key_add
         //Only activate this as part of the mapping if there isn't already a
         //key waiting for timeout. This allows us to return OK later and for
         //this loop to inject all the other flagged keys
-        if (!other_mapped_key_flagged)
-        {
+        if (!other_mapped_key_flagged) {
           //The keypress was valid and a match. Mark it as flagged and reset the counter
           map[i].flagged = true;
           map[i].start_time = Runtime.millisAtCycleStart();


### PR DESCRIPTION
Hi team,

I ran into an issue recently where having the following mapping for SpaceCadet was causing a peculiar issue at work.

```
  static kaleidoscope::plugin::SpaceCadet::KeyBinding spacecadetmap[] = {
      {Key_LeftShift, Key_LeftParen},
      {Key_RightShift, Key_RightParen},
      {Key_LeftGui, Key_LeftCurlyBracket, 250},
      {Key_RightAlt, Key_RightCurlyBracket},
      {Key_LeftAlt, Key_RightCurlyBracket},
      {Key_LeftControl, Key_LeftBracket},
      {Key_RightControl, Key_RightBracket},
      SPACECADET_MAP_END};
```

These were great but also do not allow for quick combos like `Ctrl + Shift + B`.  Doing this would produce `Ctrl+B` and the `Shift` would be dropped.  Swapping the order of the mapping so that the Ctrl mappings came first would produce a `Shift+B` and the `Ctrl` would be dropped.  I found myself having to do `Ctrl + Shift + wait a full second + B`.  

This fixes the issue by pre-checking the existing map flag statuses and aborting the timeouts if two keys are found to have been pressed.  This causes any combination of any mapped keys (e.g., `Ctrl+Shift`) to produce just those inputs again.  I am not sure it would make sense to me to want anything else, but I understand that this might be a backwards-incompatible change and am happy to put this behind a flag that must be opted-in to use.

(Amended commit to sign-off)