### PR TITLE
Guard against nullptr access in LEDControl

### DIFF
--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -28,7 +28,7 @@ static constexpr uint8_t uninitialized_mode_id = 255;
 
 uint8_t LEDControl::mode_id = uninitialized_mode_id;
 uint8_t LEDControl::num_led_modes_ = LEDModeManager::numLEDModes();
-LEDMode *LEDControl::cur_led_mode_;
+LEDMode *LEDControl::cur_led_mode_ = nullptr;
 uint8_t LEDControl::syncDelay = 32;
 uint16_t LEDControl::syncTimer = 0;
 bool LEDControl::enabled_ = true;

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -41,13 +41,15 @@ class LEDControl : public kaleidoscope::Plugin {
     if (!Runtime.has_leds)
       return;
 
-    cur_led_mode_->update();
+    if (cur_led_mode_ != nullptr)
+      cur_led_mode_->update();
   }
   static void refreshAt(KeyAddr key_addr) {
     if (!Runtime.has_leds)
       return;
 
-    cur_led_mode_->refreshAt(key_addr);
+    if (cur_led_mode_ != nullptr)
+      cur_led_mode_->refreshAt(key_addr);
   }
   static void set_mode(uint8_t mode_id);
   static uint8_t get_mode_index() {
@@ -71,7 +73,8 @@ class LEDControl : public kaleidoscope::Plugin {
 
     set_all_leds_to({0, 0, 0});
 
-    cur_led_mode_->onActivate();
+    if (cur_led_mode_ != nullptr)
+      cur_led_mode_->onActivate();
   }
 
   static void setCrgbAt(uint8_t led_index, cRGB crgb);


### PR DESCRIPTION
If LEDControl is used without any LEDMode plugin, `cur_led_mode_` is
an unitialized pointer. This initializes it to `nullptr` and guards
against accessing it.

Fixes #855 