### PR TITLE
keyscanner::ATmega: Allow setting the scan cycle time at run-time

### DIFF
--- a/src/kaleidoscope/driver/keyscanner/ATmega.h
+++ b/src/kaleidoscope/driver/keyscanner/ATmega.h
@@ -111,10 +111,14 @@ class ATmega: public kaleidoscope::driver::keyscanner::Base<_KeyScannerProps> {
     }
 
     /* Set up Timer1 for 1700usec */
+    setScanCycleTime(1700);
+  }
+
+  void setScanCycleTime(uint16_t c) {
     TCCR1B = _BV(WGM13);
     TCCR1A = 0;
 
-    const uint32_t cycles = (F_CPU / 2000000) * 1700;
+    const uint32_t cycles = (F_CPU / 2000000) * c;
 
     ICR1 = cycles;
     TCCR1B = _BV(WGM13) | _BV(CS10);


### PR DESCRIPTION
With this, it is possible to set the time (in milliseconds) between scans. The aim is to make it possible to change this setting in one's `setup()` in their own sketch.

One can do that as follows:

  `Kaleidoscope.device().keyscanner().setScanCycleTime(2000);`

This is currently only implemented for the ATmega keyscanner.