### PR TITLE
Remove boilerplate macros from the Atreus2 definition

### DIFF
--- a/src/kaleidoscope/device/keyboardio/Atreus2.cpp
+++ b/src/kaleidoscope/device/keyboardio/Atreus2.cpp
@@ -22,17 +22,25 @@
 #include "kaleidoscope/Runtime.h"
 #include "kaleidoscope/driver/keyscanner/Base_Impl.h"
 
+using namespace kaleidoscope::device::keyboardio;
+
+using KeyScannerProps = typename AtreusProps::KeyScannerProps;
+using KeyScanner = typename AtreusProps::KeyScanner;
+
 namespace kaleidoscope {
 namespace device {
 namespace keyboardio {
-const uint8_t kaleidoscope::Device::KeyScannerProps::matrix_rows;
-const uint8_t kaleidoscope::Device::KeyScannerProps::matrix_columns;
-constexpr uint8_t kaleidoscope::Device::KeyScannerProps::matrix_row_pins[matrix_rows];
-constexpr uint8_t kaleidoscope::Device::KeyScannerProps::matrix_col_pins[matrix_columns];
-template<> uint16_t kaleidoscope::Device::KeyScanner::previousKeyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};
-template<> uint16_t kaleidoscope::Device::KeyScanner::keyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};
-template<> uint16_t kaleidoscope::Device::KeyScanner::masks_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};
-template<> uint8_t kaleidoscope::Device::KeyScanner::debounce_matrix_[kaleidoscope::Device::KeyScannerProps::matrix_rows][kaleidoscope::Device::KeyScannerProps::matrix_columns] = {};
+
+const uint8_t KeyScannerProps::matrix_rows;
+const uint8_t KeyScannerProps::matrix_columns;
+
+constexpr uint8_t KeyScannerProps::matrix_row_pins[matrix_rows];
+constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
+
+template<> uint16_t KeyScanner::previousKeyState_[KeyScannerProps::matrix_rows] = {};
+template<> uint16_t KeyScanner::keyState_[KeyScannerProps::matrix_rows] = {};
+template<> uint16_t KeyScanner::masks_[KeyScannerProps::matrix_rows] = {};
+template<> uint8_t KeyScanner::debounce_matrix_[KeyScannerProps::matrix_rows][KeyScannerProps::matrix_columns] = {};
 
 ISR(TIMER1_OVF_vect) {
   Runtime.device().keyScanner().do_scan_ = true;

--- a/src/kaleidoscope/device/keyboardio/Atreus2.cpp
+++ b/src/kaleidoscope/device/keyboardio/Atreus2.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Keyboardio Atreus hardware support for Kaleidoscope
- * Copyright (C) 2019  Keyboard.io, Inc
+ * Copyright (C) 2019, 2020  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,8 +22,11 @@
 #include "kaleidoscope/Runtime.h"
 #include "kaleidoscope/driver/keyscanner/Base_Impl.h"
 
+// We're using the `kaleidoscope::device::keyboardio` namespace, and set up the
+// aliases here, so that they're in the global namespace, within the scope of
+// this file. We do that, because of how templates are resolved and evaluated,
+// see more just down below!
 using namespace kaleidoscope::device::keyboardio;
-
 using KeyScannerProps = typename AtreusProps::KeyScannerProps;
 using KeyScanner = typename AtreusProps::KeyScanner;
 
@@ -31,17 +34,34 @@ namespace kaleidoscope {
 namespace device {
 namespace keyboardio {
 
+// `KeyScannerProps` here refers to the alias set up above. We do not need to
+// prefix the `matrix_rows` and `matrix_columns` names within the array
+// declaration, because those are resolved within the context of the class, so
+// the `matrix_rows` in `KeyScannerProps::matrix_row_pins[matrix_rows]` gets
+// resolved as `KeyScannerProps::matrix_rows`.
 const uint8_t KeyScannerProps::matrix_rows;
 const uint8_t KeyScannerProps::matrix_columns;
-
 constexpr uint8_t KeyScannerProps::matrix_row_pins[matrix_rows];
 constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
+// Resolving is a bit different in case of templates, however: the name of the
+// array is resolved within the scope of the namespace and the class, but the
+// array size is not - because it is a template. Therefore, we need a fully
+// qualified name there - or an alias in the global scope, which we set up just
+// above.
 template<> uint16_t KeyScanner::previousKeyState_[KeyScannerProps::matrix_rows] = {};
 template<> uint16_t KeyScanner::keyState_[KeyScannerProps::matrix_rows] = {};
 template<> uint16_t KeyScanner::masks_[KeyScannerProps::matrix_rows] = {};
 template<> uint8_t KeyScanner::debounce_matrix_[KeyScannerProps::matrix_rows][KeyScannerProps::matrix_columns] = {};
 
+// We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
+// cannot be in a header-only driver, and must be placed here.
+//
+// Timer1 is responsible for setting a property on the KeyScanner, which will
+// tell it to do a scan. We use this to make sure that scans happen at roughly
+// the intervals we want. We do the scan outside of the interrupt scope for
+// practical reasons: guarding every codepath against interrupts that can be
+// reached from the scan is far too tedious, for very little gain.
 ISR(TIMER1_OVF_vect) {
   Runtime.device().keyScanner().do_scan_ = true;
 }

--- a/src/kaleidoscope/device/keyboardio/Atreus2.cpp
+++ b/src/kaleidoscope/device/keyboardio/Atreus2.cpp
@@ -25,8 +25,18 @@
 namespace kaleidoscope {
 namespace device {
 namespace keyboardio {
-
-ATMEGA_KEYSCANNER_BOILERPLATE
+  const uint8_t kaleidoscope::Device::KeyScannerProps::matrix_rows;                 
+  const uint8_t kaleidoscope::Device::KeyScannerProps::matrix_columns; 
+  constexpr uint8_t kaleidoscope::Device::KeyScannerProps::matrix_row_pins[matrix_rows];                
+  constexpr uint8_t kaleidoscope::Device::KeyScannerProps::matrix_col_pins[matrix_columns];             
+  template<> uint16_t kaleidoscope::Device::KeyScanner::previousKeyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {}; 
+  template<> uint16_t kaleidoscope::Device::KeyScanner::keyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};         
+  template<> uint16_t kaleidoscope::Device::KeyScanner::masks_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};            
+  template<> uint8_t kaleidoscope::Device::KeyScanner::debounce_matrix_[kaleidoscope::Device::KeyScannerProps::matrix_rows][kaleidoscope::Device::KeyScannerProps::matrix_columns] = {}; 
+                                                                                           
+  ISR(TIMER1_OVF_vect) {                                                                   
+    Runtime.device().keyScanner().do_scan_ = true;                                         
+  }
 
 }
 }

--- a/src/kaleidoscope/device/keyboardio/Atreus2.cpp
+++ b/src/kaleidoscope/device/keyboardio/Atreus2.cpp
@@ -25,18 +25,18 @@
 namespace kaleidoscope {
 namespace device {
 namespace keyboardio {
-  const uint8_t kaleidoscope::Device::KeyScannerProps::matrix_rows;                 
-  const uint8_t kaleidoscope::Device::KeyScannerProps::matrix_columns; 
-  constexpr uint8_t kaleidoscope::Device::KeyScannerProps::matrix_row_pins[matrix_rows];                
-  constexpr uint8_t kaleidoscope::Device::KeyScannerProps::matrix_col_pins[matrix_columns];             
-  template<> uint16_t kaleidoscope::Device::KeyScanner::previousKeyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {}; 
-  template<> uint16_t kaleidoscope::Device::KeyScanner::keyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};         
-  template<> uint16_t kaleidoscope::Device::KeyScanner::masks_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};            
-  template<> uint8_t kaleidoscope::Device::KeyScanner::debounce_matrix_[kaleidoscope::Device::KeyScannerProps::matrix_rows][kaleidoscope::Device::KeyScannerProps::matrix_columns] = {}; 
-                                                                                           
-  ISR(TIMER1_OVF_vect) {                                                                   
-    Runtime.device().keyScanner().do_scan_ = true;                                         
-  }
+const uint8_t kaleidoscope::Device::KeyScannerProps::matrix_rows;
+const uint8_t kaleidoscope::Device::KeyScannerProps::matrix_columns;
+constexpr uint8_t kaleidoscope::Device::KeyScannerProps::matrix_row_pins[matrix_rows];
+constexpr uint8_t kaleidoscope::Device::KeyScannerProps::matrix_col_pins[matrix_columns];
+template<> uint16_t kaleidoscope::Device::KeyScanner::previousKeyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};
+template<> uint16_t kaleidoscope::Device::KeyScanner::keyState_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};
+template<> uint16_t kaleidoscope::Device::KeyScanner::masks_[kaleidoscope::Device::KeyScannerProps::matrix_rows] = {};
+template<> uint8_t kaleidoscope::Device::KeyScanner::debounce_matrix_[kaleidoscope::Device::KeyScannerProps::matrix_rows][kaleidoscope::Device::KeyScannerProps::matrix_columns] = {};
+
+ISR(TIMER1_OVF_vect) {
+  Runtime.device().keyScanner().do_scan_ = true;
+}
 
 }
 }

--- a/src/kaleidoscope/device/keyboardio/Atreus2.h
+++ b/src/kaleidoscope/device/keyboardio/Atreus2.h
@@ -30,32 +30,32 @@ namespace device {
 namespace keyboardio {
 
 
-  struct AtreusProps : kaleidoscope::device::ATmega32U4KeyboardProps {          
-    struct KeyScannerProps : public kaleidoscope::driver::keyscanner::ATmegaProps {                                                                             
+struct AtreusProps : kaleidoscope::device::ATmega32U4KeyboardProps {
+  struct KeyScannerProps : public kaleidoscope::driver::keyscanner::ATmegaProps {
 
-      static constexpr uint8_t matrix_rows = 4;
-      static constexpr uint8_t matrix_columns = 12;
-      typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;		
+    static constexpr uint8_t matrix_rows = 4;
+    static constexpr uint8_t matrix_columns = 12;
+    typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-      static constexpr uint8_t matrix_row_pins[matrix_rows] =  {PIN_F6, PIN_F5, PIN_F4, PIN_F1};
-      static constexpr uint8_t matrix_col_pins[matrix_columns] = {PIN_F7, PIN_E2, PIN_C7, PIN_C6, PIN_B6, PIN_B5, PIN_D7, PIN_D6, PIN_D4, PIN_D5, PIN_D3, PIN_D2};
+    static constexpr uint8_t matrix_row_pins[matrix_rows] =  {PIN_F6, PIN_F5, PIN_F4, PIN_F1};
+    static constexpr uint8_t matrix_col_pins[matrix_columns] = {PIN_F7, PIN_E2, PIN_C7, PIN_C6, PIN_B6, PIN_B5, PIN_D7, PIN_D6, PIN_D4, PIN_D5, PIN_D3, PIN_D2};
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-    }; 
-
-      typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner; 
-      typedef kaleidoscope::driver::bootloader::avr::Caterina BootLoader;        
-      static constexpr const char *short_name = "atreus";                             
   };
 
+  typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner;
+  typedef kaleidoscope::driver::bootloader::avr::Caterina BootLoader;
+  static constexpr const char *short_name = "atreus";
+};
+
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-  class Atreus: public kaleidoscope::device::ATmega32U4Keyboard<AtreusProps> {};
+class Atreus: public kaleidoscope::device::ATmega32U4Keyboard<AtreusProps> {};
 #else // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-  /* Device definition omitted for virtual device builds.                      
-   * We need to forward declare the device name, though, as there are          
-   * some legacy extern references to boards whose definition                  
-   * depends on this.                                                          
-   */                                                                          
-  class Atreus;
+/* Device definition omitted for virtual device builds.
+ * We need to forward declare the device name, though, as there are
+ * some legacy extern references to boards whose definition
+ * depends on this.
+ */
+class Atreus;
 
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 

--- a/src/kaleidoscope/device/keyboardio/Atreus2.h
+++ b/src/kaleidoscope/device/keyboardio/Atreus2.h
@@ -32,18 +32,23 @@ namespace keyboardio {
 
   struct AtreusProps : kaleidoscope::device::ATmega32U4KeyboardProps {          
     struct KeyScannerProps : public kaleidoscope::driver::keyscanner::ATmegaProps {                                                                             
-      ATMEGA_KEYSCANNER_PROPS(
-         ROW_PIN_LIST({PIN_F6, PIN_F5, PIN_F4, PIN_F1}),
-         COL_PIN_LIST({PIN_F7, PIN_E2, PIN_C7, PIN_C6, PIN_B6, PIN_B5, PIN_D7, PIN_D6, PIN_D4, PIN_D5, PIN_D3, PIN_D2}));
-    };                                                                            
-    typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner; 
-    typedef kaleidoscope::driver::bootloader::avr::Caterina BootLoader;        
-    static constexpr const char *short_name = "atreus";                             
+
+      static constexpr uint8_t matrix_rows = 4;
+      static constexpr uint8_t matrix_columns = 12;
+      typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;		
+#ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+      static constexpr uint8_t matrix_row_pins[matrix_rows] =  {PIN_F6, PIN_F5, PIN_F4, PIN_F1};
+      static constexpr uint8_t matrix_col_pins[matrix_columns] = {PIN_F7, PIN_E2, PIN_C7, PIN_C6, PIN_B6, PIN_B5, PIN_D7, PIN_D6, PIN_D4, PIN_D5, PIN_D3, PIN_D2};
+#endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+    }; 
+
+      typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner; 
+      typedef kaleidoscope::driver::bootloader::avr::Caterina BootLoader;        
+      static constexpr const char *short_name = "atreus";                             
   };
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
   class Atreus: public kaleidoscope::device::ATmega32U4Keyboard<AtreusProps> {};
-
 #else // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
   /* Device definition omitted for virtual device builds.                      
    * We need to forward declare the device name, though, as there are          

--- a/src/kaleidoscope/device/keyboardio/Atreus2.h
+++ b/src/kaleidoscope/device/keyboardio/Atreus2.h
@@ -30,9 +30,16 @@ namespace device {
 namespace keyboardio {
 
 
-  ATMEGA32U4_DEVICE_PROPS(Atreus, Caterina, "atreus",                          
-                          ROW_PIN_LIST({PIN_F6, PIN_F5, PIN_F4, PIN_F1}),
-                          COL_PIN_LIST({PIN_F7, PIN_E2, PIN_C7, PIN_C6, PIN_B6, PIN_B5, PIN_D7, PIN_D6, PIN_D4, PIN_D5, PIN_D3, PIN_D2}));
+  struct AtreusProps : kaleidoscope::device::ATmega32U4KeyboardProps {          
+    struct KeyScannerProps : public kaleidoscope::driver::keyscanner::ATmegaProps {                                                                             
+      ATMEGA_KEYSCANNER_PROPS(
+         ROW_PIN_LIST({PIN_F6, PIN_F5, PIN_F4, PIN_F1}),
+         COL_PIN_LIST({PIN_F7, PIN_E2, PIN_C7, PIN_C6, PIN_B6, PIN_B5, PIN_D7, PIN_D6, PIN_D4, PIN_D5, PIN_D3, PIN_D2}));
+    };                                                                            
+    typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner; 
+    typedef kaleidoscope::driver::bootloader::avr::Caterina BootLoader;        
+    static constexpr const char *short_name = "atreus";                             
+  };
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
   class Atreus: public kaleidoscope::device::ATmega32U4Keyboard<AtreusProps> {};

--- a/src/kaleidoscope/device/keyboardio/Atreus2.h
+++ b/src/kaleidoscope/device/keyboardio/Atreus2.h
@@ -35,7 +35,7 @@ namespace keyboardio {
                           COL_PIN_LIST({PIN_F7, PIN_E2, PIN_C7, PIN_C6, PIN_B6, PIN_B5, PIN_D7, PIN_D6, PIN_D4, PIN_D5, PIN_D3, PIN_D2}));
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-  ATMEGA32U4_DEVICE(Atreus)
+  class Atreus: public kaleidoscope::device::ATmega32U4Keyboard<AtreusProps> {};
 
 #else // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
   /* Device definition omitted for virtual device builds.                      

--- a/src/kaleidoscope/device/keyboardio/Atreus2.h
+++ b/src/kaleidoscope/device/keyboardio/Atreus2.h
@@ -29,11 +29,24 @@ namespace kaleidoscope {
 namespace device {
 namespace keyboardio {
 
-ATMEGA32U4_KEYBOARD(
-  Atreus, Caterina, "atreus",
-  ROW_PIN_LIST({PIN_F6, PIN_F5, PIN_F4, PIN_F1}),
-  COL_PIN_LIST({PIN_F7, PIN_E2, PIN_C7, PIN_C6, PIN_B6, PIN_B5, PIN_D7, PIN_D6, PIN_D4, PIN_D5, PIN_D3, PIN_D2})
-);
+
+  ATMEGA32U4_DEVICE_PROPS(Atreus, Caterina, "atreus",                          
+                          ROW_PIN_LIST({PIN_F6, PIN_F5, PIN_F4, PIN_F1}),
+                          COL_PIN_LIST({PIN_F7, PIN_E2, PIN_C7, PIN_C6, PIN_B6, PIN_B5, PIN_D7, PIN_D6, PIN_D4, PIN_D5, PIN_D3, PIN_D2}));
+
+#ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+  ATMEGA32U4_DEVICE(Atreus)
+
+#else // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+  /* Device definition omitted for virtual device builds.                      
+   * We need to forward declare the device name, though, as there are          
+   * some legacy extern references to boards whose definition                  
+   * depends on this.                                                          
+   */                                                                          
+  class Atreus;
+
+#endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+
 
 #define PER_KEY_DATA(dflt,                                                    \
     R0C0, R0C1, R0C2, R0C3, R0C4,             R0C7, R0C8, R0C9, R0C10, R0C11, \


### PR DESCRIPTION
@algernon could you have a look at this and see if it seems sensible.  On top of this, I'd really love us to be able to make the content in Atreus2.cpp more concise. The namespacing in there is really confusing to me.