### PR TITLE
driver/mcu/ATmega32U4: Fix the class declaration for virtual builds

### DIFF
--- a/src/kaleidoscope/driver/mcu/ATmega32U4.h
+++ b/src/kaleidoscope/driver/mcu/ATmega32U4.h
@@ -64,7 +64,8 @@ class ATmega32U4 : public kaleidoscope::driver::mcu::Base {
   void setup() {}
 };
 #else
-typedef Base ATmega32U4;
+template <typename _Props>
+class ATmega32U4 : public kaleidoscope::driver::mcu::Base<_Props> {};
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
 }


### PR DESCRIPTION
Due to the introduction of MCU properties recently, we need to declare the class for virtual builds, and can't get away with simply typedefing it to Base.

Without this, virtual builds fail to compile.