### PR TITLE
Keyboardio Atreus: Minor fixups, and a version info macro

### DIFF
--- a/examples/Devices/Keyboardio/Atreus/Atreus.ino
+++ b/examples/Devices/Keyboardio/Atreus/Atreus.ino
@@ -17,6 +17,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#ifndef BUILD_INFORMATION
+#define BUILD_INFORMATION "locally built"
+#endif
+
 #include "Kaleidoscope.h"
 #include "Kaleidoscope-EEPROM-Settings.h"
 #include "Kaleidoscope-EEPROM-Keymap.h"
@@ -33,7 +37,8 @@
 #define TG(n) LockLayer(n)
 
 enum {
-  MACRO_QWERTY
+  MACRO_QWERTY,
+  MACRO_VERSION_INFO
 };
 
 #define Key_Exclamation LSHIFT(Key_1)
@@ -82,10 +87,10 @@ KEYMAPS(
 
   [UPPER] = KEYMAP_STACKED
   (
-       Key_Insert          ,Key_Home                 ,Key_UpArrow   ,Key_End        ,Key_PageUp
-      ,Key_Delete          ,Key_LeftArrow            ,Key_DownArrow ,Key_RightArrow ,Key_PageDown
-      ,XXX                 ,Consumer_VolumeIncrement ,XXX           ,XXX            ,___ ,___
-      ,MoveToLayer(QWERTY) ,Consumer_VolumeDecrement ,___           ,___            ,___ ,___
+       Key_Insert            ,Key_Home                 ,Key_UpArrow   ,Key_End        ,Key_PageUp
+      ,Key_Delete            ,Key_LeftArrow            ,Key_DownArrow ,Key_RightArrow ,Key_PageDown
+      ,M(MACRO_VERSION_INFO) ,Consumer_VolumeIncrement ,XXX           ,XXX            ,___ ,___
+      ,MoveToLayer(QWERTY)   ,Consumer_VolumeDecrement ,___           ,___            ,___ ,___
 
                 ,Key_UpArrow   ,Key_F7              ,Key_F8          ,Key_F9         ,Key_F10
                 ,Key_DownArrow ,Key_F4              ,Key_F5          ,Key_F6         ,Key_F11
@@ -116,6 +121,12 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
     // longer do. We keep it so that if someone still has the old layout with
     // the macro in EEPROM, it will keep working after a firmware update.
     Layer.move(QWERTY);
+    break;
+  case MACRO_VERSION_INFO:
+    if (keyToggledOn(keyState)) {
+      Macros.type(PSTR("Keyboardio Atreus - Kaleidoscope "));
+      Macros.type(PSTR(BUILD_INFORMATION));
+    }
     break;
   default:
     break;

--- a/examples/Devices/Keyboardio/Atreus/Atreus.ino
+++ b/examples/Devices/Keyboardio/Atreus/Atreus.ino
@@ -82,15 +82,15 @@ KEYMAPS(
 
   [UPPER] = KEYMAP_STACKED
   (
-       Key_Insert      ,Key_Home                 ,Key_UpArrow   ,Key_End        ,Key_PageUp
-      ,Key_Delete      ,Key_LeftArrow            ,Key_DownArrow ,Key_RightArrow ,Key_PageDown
-      ,XXX             ,Consumer_VolumeIncrement ,XXX           ,XXX            ,___ ,___
-      ,M(MACRO_QWERTY) ,Consumer_VolumeDecrement ,___           ,___            ,___ ,___
+       Key_Insert          ,Key_Home                 ,Key_UpArrow   ,Key_End        ,Key_PageUp
+      ,Key_Delete          ,Key_LeftArrow            ,Key_DownArrow ,Key_RightArrow ,Key_PageDown
+      ,XXX                 ,Consumer_VolumeIncrement ,XXX           ,XXX            ,___ ,___
+      ,MoveToLayer(QWERTY) ,Consumer_VolumeDecrement ,___           ,___            ,___ ,___
 
-                ,Key_UpArrow   ,Key_F7          ,Key_F8          ,Key_F9         ,Key_F10
-                ,Key_DownArrow ,Key_F4          ,Key_F5          ,Key_F6         ,Key_F11
-      ,___      ,XXX           ,Key_F1          ,Key_F2          ,Key_F3         ,Key_F12
-      ,___      ,___           ,M(MACRO_QWERTY) ,Key_PrintScreen ,Key_ScrollLock ,Consumer_PlaySlashPause
+                ,Key_UpArrow   ,Key_F7              ,Key_F8          ,Key_F9         ,Key_F10
+                ,Key_DownArrow ,Key_F4              ,Key_F5          ,Key_F6         ,Key_F11
+      ,___      ,XXX           ,Key_F1              ,Key_F2          ,Key_F3         ,Key_F12
+      ,___      ,___           ,MoveToLayer(QWERTY) ,Key_PrintScreen ,Key_ScrollLock ,Consumer_PlaySlashPause
    )
 )
 /* *INDENT-ON* */
@@ -111,6 +111,10 @@ KALEIDOSCOPE_INIT_PLUGINS(
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
   switch (macroIndex) {
   case MACRO_QWERTY:
+    // This macro is currently unused, but is kept around for compatibility
+    // reasons. We used to use it in place of `MoveToLayer(QWERTY)`, but no
+    // longer do. We keep it so that if someone still has the old layout with
+    // the macro in EEPROM, it will keep working after a firmware update.
     Layer.move(QWERTY);
     break;
   default:

--- a/examples/Devices/Keyboardio/Atreus/Atreus.ino
+++ b/examples/Devices/Keyboardio/Atreus/Atreus.ino
@@ -33,7 +33,7 @@
 #define TG(n) LockLayer(n)
 
 enum {
-  LAYER_QWERTY
+  MACRO_QWERTY
 };
 
 #define Key_Exclamation LSHIFT(Key_1)
@@ -82,15 +82,15 @@ KEYMAPS(
 
   [UPPER] = KEYMAP_STACKED
   (
-       Key_Insert ,Key_Home                 ,Key_UpArrow   ,Key_End        ,Key_PageUp
-      ,Key_Delete ,Key_LeftArrow            ,Key_DownArrow ,Key_RightArrow ,Key_PageDown
-      ,XXX        ,Consumer_VolumeIncrement ,XXX           ,XXX            ,___ ,___
-      ,M(QWERTY)  ,Consumer_VolumeDecrement ,___           ,___            ,___ ,___
+       Key_Insert      ,Key_Home                 ,Key_UpArrow   ,Key_End        ,Key_PageUp
+      ,Key_Delete      ,Key_LeftArrow            ,Key_DownArrow ,Key_RightArrow ,Key_PageDown
+      ,XXX             ,Consumer_VolumeIncrement ,XXX           ,XXX            ,___ ,___
+      ,M(MACRO_QWERTY) ,Consumer_VolumeDecrement ,___           ,___            ,___ ,___
 
-                ,Key_UpArrow   ,Key_F7 ,Key_F8          ,Key_F9         ,Key_F10
-                ,Key_DownArrow ,Key_F4 ,Key_F5          ,Key_F6         ,Key_F11
-      ,___      ,XXX           ,Key_F1 ,Key_F2          ,Key_F3         ,Key_F12
-      ,___      ,___           ,M(QWERTY)  ,Key_PrintScreen ,Key_ScrollLock ,Consumer_PlaySlashPause
+                ,Key_UpArrow   ,Key_F7          ,Key_F8          ,Key_F9         ,Key_F10
+                ,Key_DownArrow ,Key_F4          ,Key_F5          ,Key_F6         ,Key_F11
+      ,___      ,XXX           ,Key_F1          ,Key_F2          ,Key_F3         ,Key_F12
+      ,___      ,___           ,M(MACRO_QWERTY) ,Key_PrintScreen ,Key_ScrollLock ,Consumer_PlaySlashPause
    )
 )
 /* *INDENT-ON* */
@@ -110,8 +110,8 @@ KALEIDOSCOPE_INIT_PLUGINS(
 
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
   switch (macroIndex) {
-  case QWERTY:
-    Layer.move(LAYER_QWERTY);
+  case MACRO_QWERTY:
+    Layer.move(QWERTY);
     break;
   default:
     break;


### PR DESCRIPTION
This patchset does a small cleanup in the Keyboardio Atreus example sketch first:

- We fix the confusion between the `QWERTY` layer and the `LAYER_QWERTY` macro, which were used interchangeably.
- We move away from a `M(MACRO_QWERTY)` macro to switch back to the qwerty layer, to use `MoveToLayer()`, now that we have it available. We still keep the old macro, for the sake of compatibility (see the commit message and the in-file comment why).
- We also add a macro to `UPPER + Z` which will type `Keyboardio Atreus - Kaleidoscope` followed by whatever version was set during build time.