### PR TITLE
Make the keyscan_interval prop of the keyscanner configurable. 

### DIFF
--- a/src/kaleidoscope/device/keyboardio/Atreus2.h
+++ b/src/kaleidoscope/device/keyboardio/Atreus2.h
@@ -33,6 +33,8 @@ namespace keyboardio {
 struct AtreusProps : kaleidoscope::device::ATmega32U4KeyboardProps {
   struct KeyScannerProps : public kaleidoscope::driver::keyscanner::ATmegaProps {
 
+    static const uint16_t keyscan_interval = 2700;
+
     static constexpr uint8_t matrix_rows = 4;
     static constexpr uint8_t matrix_columns = 12;
     typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;

--- a/src/kaleidoscope/driver/keyscanner/ATmega.h
+++ b/src/kaleidoscope/driver/keyscanner/ATmega.h
@@ -35,6 +35,8 @@ namespace keyscanner {
 
 struct ATmegaProps: kaleidoscope::driver::keyscanner::BaseProps {
   static const uint8_t debounce = 3;
+  static const uint16_t keyscan_interval = 1700;
+
 
   /*
    * The following two lines declare an empty array. Both of these must be
@@ -75,7 +77,7 @@ class ATmega: public kaleidoscope::driver::keyscanner::Base<_KeyScannerProps> {
     }
 
     /* Set up Timer1 for 1700usec */
-    setScanCycleTime(1700);
+    setScanCycleTime(_KeyScannerProps::keyscan_interval);
   }
 
   void setScanCycleTime(uint16_t c) {


### PR DESCRIPTION
And also set the default for the Atreus a bit more conservatively.