### PR TITLE
ATmega debouncer cleanup

### DIFF
--- a/docs/api-reference/device-apis.md
+++ b/docs/api-reference/device-apis.md
@@ -225,7 +225,7 @@ constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
 // `KeyScanner` here refers to the alias set up above, just like in the
 // `KeyScannerProps` case above.
-template<> KeyScanner::state_t KeyScanner::state_ = {};
+template<> KeyScanner::row_state_t KeyScanner::matrix_state_[KeyScannerProps::matrix_rows] = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/docs/api-reference/device-apis.md
+++ b/docs/api-reference/device-apis.md
@@ -223,15 +223,9 @@ const uint8_t KeyScannerProps::matrix_columns;
 constexpr uint8_t KeyScannerProps::matrix_row_pins[matrix_rows];
 constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
-// Resolving is a bit different in case of templates, however: the name of the
-// array is resolved within the scope of the namespace and the class, but the
-// array size is not - because it is a template. Therefore, we need a fully
-// qualified name there - or an alias in the global scope, which we set up just
-// above.
-template<> uint16_t KeyScanner::previousKeyState_[KeyScannerProps::matrix_rows] = {};
-template<> uint16_t KeyScanner::keyState_[KeyScannerProps::matrix_rows] = {};
-template<> uint16_t KeyScanner::masks_[KeyScannerProps::matrix_rows] = {};
-template<> uint8_t KeyScanner::debounce_matrix_[KeyScannerProps::matrix_rows][KeyScannerProps::matrix_columns] = {};
+// `KeyScanner` here refers to the alias set up above, just like in the
+// `KeyScannerProps` case above.
+template<> KeyScanner::state_t KeyScanner::state_ = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/src/kaleidoscope/device/kbdfans/KBD4x.cpp
+++ b/src/kaleidoscope/device/kbdfans/KBD4x.cpp
@@ -42,15 +42,9 @@ const uint8_t KeyScannerProps::matrix_columns;
 constexpr uint8_t KeyScannerProps::matrix_row_pins[matrix_rows];
 constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
-// Resolving is a bit different in case of templates, however: the name of the
-// array is resolved within the scope of the namespace and the class, but the
-// array size is not - because it is a template. Therefore, we need a fully
-// qualified name there - or an alias in the global scope, which we set up just
-// above.
-template<> uint16_t KeyScanner::previousKeyState_[KeyScannerProps::matrix_rows] = {};
-template<> uint16_t KeyScanner::keyState_[KeyScannerProps::matrix_rows] = {};
-template<> uint16_t KeyScanner::masks_[KeyScannerProps::matrix_rows] = {};
-template<> uint8_t KeyScanner::debounce_matrix_[KeyScannerProps::matrix_rows][KeyScannerProps::matrix_columns] = {};
+// `KeyScanner` here refers to the alias set up above, just like in the
+// `KeyScannerProps` case above.
+template<> KeyScanner::state_t KeyScanner::state_ = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/src/kaleidoscope/device/kbdfans/KBD4x.cpp
+++ b/src/kaleidoscope/device/kbdfans/KBD4x.cpp
@@ -44,7 +44,7 @@ constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
 // `KeyScanner` here refers to the alias set up above, just like in the
 // `KeyScannerProps` case above.
-template<> KeyScanner::state_t KeyScanner::state_ = {};
+template<> KeyScanner::row_state_t KeyScanner::matrix_state_[KeyScannerProps::matrix_rows] = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/src/kaleidoscope/device/keyboardio/Atreus2.cpp
+++ b/src/kaleidoscope/device/keyboardio/Atreus2.cpp
@@ -51,7 +51,7 @@ constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 template<> uint16_t KeyScanner::previousKeyState_[KeyScannerProps::matrix_rows] = {};
 template<> uint16_t KeyScanner::keyState_[KeyScannerProps::matrix_rows] = {};
 template<> uint16_t KeyScanner::masks_[KeyScannerProps::matrix_rows] = {};
-template<> uint8_t KeyScanner::debounce_matrix_[KeyScannerProps::matrix_rows][KeyScannerProps::matrix_columns] = {};
+template<> KeyScanner::debounce_t KeyScanner::db[KeyScannerProps::matrix_rows] = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/src/kaleidoscope/device/keyboardio/Atreus2.cpp
+++ b/src/kaleidoscope/device/keyboardio/Atreus2.cpp
@@ -43,15 +43,9 @@ const uint8_t KeyScannerProps::matrix_columns;
 constexpr uint8_t KeyScannerProps::matrix_row_pins[matrix_rows];
 constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
-// Resolving is a bit different in case of templates, however: the name of the
-// array is resolved within the scope of the namespace and the class, but the
-// array size is not - because it is a template. Therefore, we need a fully
-// qualified name there - or an alias in the global scope, which we set up just
-// above.
-template<> uint16_t KeyScanner::previousKeyState_[KeyScannerProps::matrix_rows] = {};
-template<> uint16_t KeyScanner::keyState_[KeyScannerProps::matrix_rows] = {};
-template<> uint16_t KeyScanner::masks_[KeyScannerProps::matrix_rows] = {};
-template<> KeyScanner::debounce_t KeyScanner::db[KeyScannerProps::matrix_rows] = {};
+// `KeyScanner` here refers to the alias set up above, just like in the
+// `KeyScannerProps` case above.
+template<> KeyScanner::state_t KeyScanner::state_ = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/src/kaleidoscope/device/keyboardio/Atreus2.cpp
+++ b/src/kaleidoscope/device/keyboardio/Atreus2.cpp
@@ -45,7 +45,7 @@ constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
 // `KeyScanner` here refers to the alias set up above, just like in the
 // `KeyScannerProps` case above.
-template<> KeyScanner::state_t KeyScanner::state_ = {};
+template<> KeyScanner::row_state_t KeyScanner::matrix_state_[KeyScannerProps::matrix_rows] = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/src/kaleidoscope/device/keyboardio/Imago.cpp
+++ b/src/kaleidoscope/device/keyboardio/Imago.cpp
@@ -71,7 +71,7 @@ constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
 // `KeyScanner` here refers to the alias set up above, just like in the
 // `KeyScannerProps` case above.
-template<> KeyScanner::state_t KeyScanner::state_ = {};
+template<> KeyScanner::row_state_t KeyScanner::matrix_state_[KeyScannerProps::matrix_rows] = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/src/kaleidoscope/device/keyboardio/Imago.cpp
+++ b/src/kaleidoscope/device/keyboardio/Imago.cpp
@@ -69,15 +69,9 @@ const uint8_t KeyScannerProps::matrix_columns;
 constexpr uint8_t KeyScannerProps::matrix_row_pins[matrix_rows];
 constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
-// Resolving is a bit different in case of templates, however: the name of the
-// array is resolved within the scope of the namespace and the class, but the
-// array size is not - because it is a template. Therefore, we need a fully
-// qualified name there - or an alias in the global scope, which we set up just
-// above.
-template<> uint16_t KeyScanner::previousKeyState_[KeyScannerProps::matrix_rows] = {};
-template<> uint16_t KeyScanner::keyState_[KeyScannerProps::matrix_rows] = {};
-template<> uint16_t KeyScanner::masks_[KeyScannerProps::matrix_rows] = {};
-template<> uint8_t KeyScanner::debounce_matrix_[KeyScannerProps::matrix_rows][KeyScannerProps::matrix_columns] = {};
+// `KeyScanner` here refers to the alias set up above, just like in the
+// `KeyScannerProps` case above.
+template<> KeyScanner::state_t KeyScanner::state_ = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/src/kaleidoscope/device/olkb/Planck.cpp
+++ b/src/kaleidoscope/device/olkb/Planck.cpp
@@ -41,15 +41,9 @@ const uint8_t KeyScannerProps::matrix_columns;
 constexpr uint8_t KeyScannerProps::matrix_row_pins[matrix_rows];
 constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
-// Resolving is a bit different in case of templates, however: the name of the
-// array is resolved within the scope of the namespace and the class, but the
-// array size is not - because it is a template. Therefore, we need a fully
-// qualified name there - or an alias in the global scope, which we set up just
-// above.
-template<> uint16_t KeyScanner::previousKeyState_[KeyScannerProps::matrix_rows] = {};
-template<> uint16_t KeyScanner::keyState_[KeyScannerProps::matrix_rows] = {};
-template<> uint16_t KeyScanner::masks_[KeyScannerProps::matrix_rows] = {};
-template<> uint8_t KeyScanner::debounce_matrix_[KeyScannerProps::matrix_rows][KeyScannerProps::matrix_columns] = {};
+// `KeyScanner` here refers to the alias set up above, just like in the
+// `KeyScannerProps` case above.
+template<> KeyScanner::state_t KeyScanner::state_ = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/src/kaleidoscope/device/olkb/Planck.cpp
+++ b/src/kaleidoscope/device/olkb/Planck.cpp
@@ -43,7 +43,7 @@ constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
 // `KeyScanner` here refers to the alias set up above, just like in the
 // `KeyScannerProps` case above.
-template<> KeyScanner::state_t KeyScanner::state_ = {};
+template<> KeyScanner::row_state_t KeyScanner::matrix_state_[KeyScannerProps::matrix_rows] = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/src/kaleidoscope/device/softhruf/Splitography.cpp
+++ b/src/kaleidoscope/device/softhruf/Splitography.cpp
@@ -48,15 +48,9 @@ const uint8_t KeyScannerProps::matrix_columns;
 constexpr uint8_t KeyScannerProps::matrix_row_pins[matrix_rows];
 constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
-// Resolving is a bit different in case of templates, however: the name of the
-// array is resolved within the scope of the namespace and the class, but the
-// array size is not - because it is a template. Therefore, we need a fully
-// qualified name there - or an alias in the global scope, which we set up just
-// above.
-template<> uint16_t KeyScanner::previousKeyState_[KeyScannerProps::matrix_rows] = {};
-template<> uint16_t KeyScanner::keyState_[KeyScannerProps::matrix_rows] = {};
-template<> uint16_t KeyScanner::masks_[KeyScannerProps::matrix_rows] = {};
-template<> uint8_t KeyScanner::debounce_matrix_[KeyScannerProps::matrix_rows][KeyScannerProps::matrix_columns] = {};
+// `KeyScanner` here refers to the alias set up above, just like in the
+// `KeyScannerProps` case above.
+template<> KeyScanner::state_t KeyScanner::state_ = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/src/kaleidoscope/device/softhruf/Splitography.cpp
+++ b/src/kaleidoscope/device/softhruf/Splitography.cpp
@@ -50,7 +50,7 @@ constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
 // `KeyScanner` here refers to the alias set up above, just like in the
 // `KeyScannerProps` case above.
-template<> KeyScanner::state_t KeyScanner::state_ = {};
+template<> KeyScanner::row_state_t KeyScanner::matrix_state_[KeyScannerProps::matrix_rows] = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/src/kaleidoscope/device/technomancy/Atreus.cpp
+++ b/src/kaleidoscope/device/technomancy/Atreus.cpp
@@ -51,15 +51,9 @@ const uint8_t KeyScannerProps::matrix_columns;
 constexpr uint8_t KeyScannerProps::matrix_row_pins[matrix_rows];
 constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
-// Resolving is a bit different in case of templates, however: the name of the
-// array is resolved within the scope of the namespace and the class, but the
-// array size is not - because it is a template. Therefore, we need a fully
-// qualified name there - or an alias in the global scope, which we set up just
-// above.
-template<> uint16_t KeyScanner::previousKeyState_[KeyScannerProps::matrix_rows] = {};
-template<> uint16_t KeyScanner::keyState_[KeyScannerProps::matrix_rows] = {};
-template<> uint16_t KeyScanner::masks_[KeyScannerProps::matrix_rows] = {};
-template<> uint8_t KeyScanner::debounce_matrix_[KeyScannerProps::matrix_rows][KeyScannerProps::matrix_columns] = {};
+// `KeyScanner` here refers to the alias set up above, just like in the
+// `KeyScannerProps` case above.
+template<> KeyScanner::state_t KeyScanner::state_ = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/src/kaleidoscope/device/technomancy/Atreus.cpp
+++ b/src/kaleidoscope/device/technomancy/Atreus.cpp
@@ -53,7 +53,7 @@ constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
 
 // `KeyScanner` here refers to the alias set up above, just like in the
 // `KeyScannerProps` case above.
-template<> KeyScanner::state_t KeyScanner::state_ = {};
+template<> KeyScanner::row_state_t KeyScanner::matrix_state_[KeyScannerProps::matrix_rows] = {};
 
 // We set up the TIMER1 interrupt vector here. Due to dependency reasons, this
 // cannot be in a header-only driver, and must be placed here.

--- a/src/kaleidoscope/driver/keyscanner/ATmega.h
+++ b/src/kaleidoscope/driver/keyscanner/ATmega.h
@@ -95,10 +95,10 @@ class ATmega: public kaleidoscope::driver::keyscanner::Base<_KeyScannerProps> {
     typename _KeyScannerProps::RowState any_debounced_changes = 0;
 
     for (uint8_t current_row = 0; current_row < _KeyScannerProps::matrix_rows; current_row++) {
+      OUTPUT_TOGGLE(_KeyScannerProps::matrix_row_pins[current_row]);
       typename _KeyScannerProps::RowState hot_pins = readCols();
 
       OUTPUT_TOGGLE(_KeyScannerProps::matrix_row_pins[current_row]);
-      OUTPUT_TOGGLE(_KeyScannerProps::matrix_row_pins[(current_row + 1) % _KeyScannerProps::matrix_rows]);
 
       any_debounced_changes |= debounce(hot_pins, &state_.debounce[current_row]);
 


### PR DESCRIPTION
This is a series of commits that cleans up the ATmega debouncer, making it not only easier to understand, but easier to work with and debug.

We do this by switching to a new debouncing algorithm, lifted from `keyboardio/avr_keyscanner`, and renaming our state variables to have much more sensible names that reflect their purpose.