### PR TITLE
Lift out the debouncer from keyscanner::ATmega into its own component

### DIFF
--- a/docs/api-reference/device-apis.md
+++ b/docs/api-reference/device-apis.md
@@ -160,6 +160,7 @@ four keys only.
 #include "kaleidoscope/driver/keyscanner/AVR.h"
 #include "kaleidoscope/driver/bootloader/avr/Caterina.h"
 #include "kaleidoscope/device/ATMega32U4Keyboard.h"
+#include "kaleidoscope/driver/debouncer/Counter.h"
 
 namespace kaleidoscope {
 namespace device {
@@ -170,6 +171,7 @@ struct KeypadProps : kaleidoscope::device::ATmega32U4KeyboardProps {
     static constexpr uint8_t matrix_rows = 2;
     static constexpr uint8_t matrix_columns = 2;
     typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
+    typedef driver::debouncer::Counter<matrix_rows, uint16_t> Debouncer;
     static constexpr uint8_t matrix_row_pins[matrix_rows] = {PIN_D0, PIN_D1};
     static constexpr uint8_t matrix_col_pins[matrix_columns] = {PIN_C0, PIN_C1};
   };

--- a/src/kaleidoscope/device/ez/ErgoDox.cpp
+++ b/src/kaleidoscope/device/ez/ErgoDox.cpp
@@ -173,18 +173,8 @@ bool ErgoDox::isKeyswitchPressed(KeyAddr key_addr) {
   return (bitRead(matrix_state_[key_addr.row()].current, key_addr.col()) != 0);
 }
 
-bool ErgoDox::isKeyswitchPressed(uint8_t keyIndex) {
-  keyIndex--;
-  return isKeyswitchPressed(KeyAddr(keyIndex));
-}
-
 bool ErgoDox::wasKeyswitchPressed(KeyAddr key_addr) {
   return (bitRead(matrix_state_[key_addr.row()].previous, key_addr.col()) != 0);
-}
-
-bool ErgoDox::wasKeyswitchPressed(uint8_t keyIndex) {
-  keyIndex--;
-  return wasKeyswitchPressed(KeyAddr(keyIndex));
 }
 
 uint8_t ErgoDox::previousPressedKeyswitchCount() {

--- a/src/kaleidoscope/device/ez/ErgoDox.h
+++ b/src/kaleidoscope/device/ez/ErgoDox.h
@@ -37,6 +37,7 @@ struct cRGB {
 
 #include "kaleidoscope/driver/keyscanner/Base.h"
 #include "kaleidoscope/driver/bootloader/avr/HalfKay.h"
+#include "kaleidoscope/driver/debouncer/Counter.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #include "kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.h"
@@ -51,7 +52,7 @@ struct ErgoDoxProps : public kaleidoscope::device::ATmega32U4KeyboardProps {
     static constexpr uint8_t matrix_rows = 14;
     static constexpr uint8_t matrix_columns = 6;
     typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
-
+    typedef kaleidoscope::driver::debouncer::Counter<matrix_rows, uint8_t> Debouncer;
   };
   typedef kaleidoscope::driver::bootloader::avr::HalfKay Bootloader;
   static constexpr const char *short_name = "ErgoDox-EZ";
@@ -84,18 +85,18 @@ class ErgoDox : public kaleidoscope::device::ATmega32U4Keyboard<ErgoDoxProps> {
   void setStatusLED(uint8_t led, bool state = true);
   void setStatusLEDBrightness(uint8_t led, uint8_t brightness);
 
-  static uint8_t debounce;
+
+ protected:
+  struct row_state_t {
+    uint8_t previous;
+    uint8_t current;
+    uint8_t masks;
+  };
+  typename ErgoDoxProps::KeyScannerProps::Debouncer debouncer_;
 
  private:
+  static row_state_t matrix_state_[ErgoDoxProps::KeyScannerProps::matrix_rows];
   static ErgoDoxScanner scanner_;
-  static uint8_t previousKeyState_[matrix_rows];
-  static uint8_t keyState_[matrix_rows];
-  static uint8_t masks_[matrix_rows];
-  static uint8_t debounce_matrix_[matrix_rows][matrix_columns];
-
-  static uint8_t debounceMaskForRow(uint8_t row);
-  static void debounceRow(uint8_t change, uint8_t row);
-  static void readMatrixRow(uint8_t row);
 };
 #else // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 class ErgoDox;

--- a/src/kaleidoscope/device/ez/ErgoDox.h
+++ b/src/kaleidoscope/device/ez/ErgoDox.h
@@ -73,18 +73,14 @@ class ErgoDox : public kaleidoscope::device::ATmega32U4Keyboard<ErgoDoxProps> {
   bool isKeyMasked(KeyAddr key_addr);
 
   bool isKeyswitchPressed(KeyAddr key_addr);
-  bool isKeyswitchPressed(uint8_t keyIndex);
   uint8_t pressedKeyswitchCount();
 
   bool wasKeyswitchPressed(KeyAddr key_addr);
-
-  bool wasKeyswitchPressed(uint8_t keyIndex);
   uint8_t previousPressedKeyswitchCount();
 
   // ErgoDox-specific stuff
   void setStatusLED(uint8_t led, bool state = true);
   void setStatusLEDBrightness(uint8_t led, uint8_t brightness);
-
 
  protected:
   struct row_state_t {

--- a/src/kaleidoscope/device/kbdfans/KBD4x.h
+++ b/src/kaleidoscope/device/kbdfans/KBD4x.h
@@ -26,6 +26,7 @@
 #include "kaleidoscope/driver/keyscanner/ATmega.h"
 #include "kaleidoscope/driver/bootloader/avr/FLIP.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/debouncer/Counter.h"
 
 namespace kaleidoscope {
 namespace device {
@@ -41,6 +42,7 @@ struct KBD4xProps : kaleidoscope::device::ATmega32U4KeyboardProps {
     static constexpr uint8_t matrix_rows = 4;
     static constexpr uint8_t matrix_columns = 12;
     typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
+    typedef driver::debouncer::Counter<matrix_rows, uint16_t> Debouncer;
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
     static constexpr uint8_t matrix_row_pins[matrix_rows] = {PIN_D0, PIN_D1, PIN_D2, PIN_D3};
     static constexpr uint8_t matrix_col_pins[matrix_columns] = { PIN_F0, PIN_F1, PIN_F4, PIN_F5, PIN_F6, PIN_F7, PIN_B3, PIN_B1, PIN_B0, PIN_D5, PIN_B7, PIN_C7 };

--- a/src/kaleidoscope/device/keyboardio/Atreus2.h
+++ b/src/kaleidoscope/device/keyboardio/Atreus2.h
@@ -24,6 +24,7 @@
 
 #include "kaleidoscope/driver/bootloader/avr/Caterina.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/debouncer/Counter.h"
 
 namespace kaleidoscope {
 namespace device {
@@ -37,6 +38,7 @@ struct AtreusProps : kaleidoscope::device::ATmega32U4KeyboardProps {
 
     static constexpr uint8_t matrix_rows = 4;
     static constexpr uint8_t matrix_columns = 12;
+    typedef driver::debouncer::Counter<matrix_rows, uint16_t> Debouncer;
     typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
     static constexpr uint8_t matrix_row_pins[matrix_rows] =  {PIN_F6, PIN_F5, PIN_F4, PIN_F1};

--- a/src/kaleidoscope/device/keyboardio/Imago.h
+++ b/src/kaleidoscope/device/keyboardio/Imago.h
@@ -33,6 +33,7 @@ struct cRGB {
 #include "kaleidoscope/driver/led/Base.h"
 #include "kaleidoscope/driver/bootloader/avr/Caterina.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/debouncer/Counter.h"
 
 namespace kaleidoscope {
 namespace device {
@@ -88,6 +89,7 @@ struct ImagoProps : kaleidoscope::device::ATmega32U4KeyboardProps {
     static constexpr uint8_t matrix_rows = 5;
     static constexpr uint8_t matrix_columns = 16;
     typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
+    typedef driver::debouncer::Counter<matrix_rows, uint16_t> Debouncer;
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
     static constexpr uint8_t matrix_row_pins[matrix_rows] = {PIN_F6, PIN_F5, PIN_F4, PIN_F1, PIN_F0};
     static constexpr uint8_t matrix_col_pins[matrix_columns] = {PIN_B2, PIN_B7, PIN_E2, PIN_C7, PIN_C6, PIN_B6, PIN_B5, PIN_B4, PIN_D7, PIN_D6,  PIN_D4, PIN_D5, PIN_D3, PIN_D2, PIN_E6, PIN_F7};

--- a/src/kaleidoscope/device/olkb/Planck.h
+++ b/src/kaleidoscope/device/olkb/Planck.h
@@ -23,6 +23,7 @@
 
 #include "kaleidoscope/driver/bootloader/avr/HalfKay.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/debouncer/Counter.h"
 
 namespace kaleidoscope {
 namespace device {
@@ -33,6 +34,7 @@ struct PlanckProps : kaleidoscope::device::ATmega32U4KeyboardProps {
     static constexpr uint8_t matrix_rows = 4;
     static constexpr uint8_t matrix_columns = 12;
     typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
+    typedef driver::debouncer::Counter<matrix_rows, uint16_t> Debouncer;
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
     static constexpr uint8_t matrix_row_pins[matrix_rows] = {PIN_D0, PIN_D5, PIN_B5, PIN_B6};
     static constexpr uint8_t matrix_col_pins[matrix_columns] = {PIN_F0, PIN_F1, PIN_F4, PIN_F5, PIN_F6, PIN_F7, PIN_B3, PIN_B1, PIN_B0, PIN_D5, PIN_B7, PIN_C7};

--- a/src/kaleidoscope/device/softhruf/Splitography.h
+++ b/src/kaleidoscope/device/softhruf/Splitography.h
@@ -33,6 +33,7 @@
 #include "kaleidoscope/driver/keyscanner/ATmega.h"
 #include "kaleidoscope/driver/bootloader/avr/FLIP.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/debouncer/Counter.h"
 
 namespace kaleidoscope {
 namespace device {
@@ -47,6 +48,7 @@ struct SplitographyProps : kaleidoscope::device::ATmega32U4KeyboardProps {
     static constexpr uint8_t matrix_rows = 4;
     static constexpr uint8_t matrix_columns = 12;
     typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
+    typedef driver::debouncer::Counter<matrix_rows, uint16_t> Debouncer;
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
     static constexpr uint8_t matrix_row_pins[matrix_rows] = {PIN_D0, PIN_D1, PIN_D2, PIN_D3};
     static constexpr uint8_t matrix_col_pins[matrix_columns] = { PIN_F0, PIN_F1, PIN_F4, PIN_F5, PIN_F6, PIN_F7, PIN_C7, PIN_C6, PIN_B6, PIN_B5, PIN_B4, PIN_D7 };

--- a/src/kaleidoscope/device/technomancy/Atreus.h
+++ b/src/kaleidoscope/device/technomancy/Atreus.h
@@ -31,6 +31,7 @@
 #include "kaleidoscope/driver/bootloader/avr/HalfKay.h"
 #include "kaleidoscope/driver/bootloader/avr/Caterina.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/debouncer/Counter.h"
 
 namespace kaleidoscope {
 namespace device {
@@ -42,6 +43,7 @@ struct AtreusProps : kaleidoscope::device::ATmega32U4KeyboardProps {
     static constexpr uint8_t matrix_rows = 4;
     static constexpr uint8_t matrix_columns = 12;
     typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
+    typedef driver::debouncer::Counter<matrix_rows, uint16_t> Debouncer;
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 

--- a/src/kaleidoscope/driver/debouncer/Base.h
+++ b/src/kaleidoscope/driver/debouncer/Base.h
@@ -1,0 +1,42 @@
+/* -*- mode: c++ -*-
+ * kaleidoscope::driver::debouncer::Base -- Debouncer driver base class for Kaleidoscope
+ * Copyright (C) 2020  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <Arduino.h>
+
+namespace kaleidoscope {
+namespace driver {
+namespace debouncer {
+
+template <uint8_t _rows, typename RowState>
+class Base {
+ public:
+  Base() {}
+
+  RowState debounce(RowState sample, uint8_t row) {
+    return 0;
+  }
+
+  RowState getRowState(uint8_t row) {
+    return 0;
+  }
+};
+
+}
+}
+}

--- a/src/kaleidoscope/driver/debouncer/Counter.h
+++ b/src/kaleidoscope/driver/debouncer/Counter.h
@@ -1,0 +1,73 @@
+/* -*- mode: c++ -*-
+ * kaleidoscope::driver::debouncer::Counter -- Counter based debouncer driver class for Kaleidoscope
+ * Copyright (C) 2018-2020  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "kaleidoscope/driver/debouncer/Base.h"
+
+namespace kaleidoscope {
+namespace driver {
+namespace debouncer {
+
+template <uint8_t _rows, typename RowState>
+class Counter: public kaleidoscope::driver::debouncer::Base<_rows, RowState> {
+ protected:
+  /*
+    each of these variables are storing the state for a row of keys
+
+    so for key 0, the counter is represented by db0[0] and db1[0]
+    and the state in debounced_state[0].
+  */
+  struct debounce_t {
+    RowState db0;    // counter bit 0
+    RowState db1;    // counter bit 1
+    RowState debounced_state;  // debounced state
+  };
+
+  debounce_t debounce_state_[_rows];
+ public:
+  RowState debounce(RowState sample, uint8_t row) {
+    RowState delta, changes;
+
+    // Use xor to detect changes from last stable state:
+    // if a key has changed, it's bit will be 1, otherwise 0
+    delta = sample ^ debounce_state_[row].debounced_state;
+
+    // Increment counters and reset any unchanged bits:
+    // increment bit 1 for all changed keys
+    debounce_state_[row].db1 = ((debounce_state_[row].db1) ^ (debounce_state_[row].db0)) & delta;
+    // increment bit 0 for all changed keys
+    debounce_state_[row].db0 = ~(debounce_state_[row].db0) & delta;
+
+    // Calculate returned change set: if delta is still true
+    // and the counter has wrapped back to 0, the key is changed.
+
+    changes = ~(~delta | (debounce_state_[row].db0) | (debounce_state_[row].db1));
+    // Update state: in this case use xor to flip any bit that is true in changes.
+    debounce_state_[row].debounced_state ^= changes;
+
+    return changes;
+  }
+
+  RowState getRowState(uint8_t row) {
+    return debounce_state_[row].debounced_state;
+  }
+};
+
+}
+}
+}

--- a/src/kaleidoscope/driver/debouncer/None.h
+++ b/src/kaleidoscope/driver/debouncer/None.h
@@ -1,0 +1,49 @@
+/* -*- mode: c++ -*-
+ * kaleidoscope::driver::debouncer::None -- No-debouncer driver class for Kaleidoscope
+ * Copyright (C) 2018-2020  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "kaleidoscope/driver/debouncer/Base.h"
+
+namespace kaleidoscope {
+namespace driver {
+namespace debouncer {
+
+template <uint8_t _rows, typename RowState>
+class None: public kaleidoscope::driver::debouncer::Base<_rows, RowState> {
+ protected:
+  struct debounce_t {
+    RowState debounced_state;
+  };
+
+  debounce_t debounce_state_[_rows];
+ public:
+  RowState debounce(RowState sample, uint8_t row) {
+    RowState changes = sample ^ debounce_state_[row].debounced_state;
+    if (changes)
+      debounce_state_[row].debounced_state = changes;
+    return changes;
+  }
+
+  RowState getRowState(uint8_t row) {
+    return debounce_state_[row].debounced_state;
+  }
+};
+
+}
+}
+}

--- a/src/kaleidoscope/driver/keyscanner/ATmega.h
+++ b/src/kaleidoscope/driver/keyscanner/ATmega.h
@@ -104,14 +104,15 @@ class ATmega: public kaleidoscope::driver::keyscanner::Base<_KeyScannerProps> {
       OUTPUT_TOGGLE(_KeyScannerProps::matrix_row_pins[current_row]);
 
       any_debounced_changes |= debouncer_.debounce(hot_pins, current_row);
+    }
 
-      if (any_debounced_changes) {
-        for (uint8_t current_row = 0; current_row < _KeyScannerProps::matrix_rows; current_row++) {
-          matrix_state_[current_row].current = debouncer_.getRowState(current_row);
-        }
+    if (any_debounced_changes) {
+      for (uint8_t current_row = 0; current_row < _KeyScannerProps::matrix_rows; current_row++) {
+        matrix_state_[current_row].current = debouncer_.getRowState(current_row);
       }
     }
   }
+
   void scanMatrix() {
     if (do_scan_) {
       do_scan_ = false;


### PR DESCRIPTION
With the recent changes to how debouncing is done in `keyscanner::ATmega`, we can now lift the debouncer out into its own driver. Theoretically, these can be used by any keyscanner, not just `ATmega`, but for now, only said one does.

Also updated all the devices using `keyscanner::ATmega`, and the device API docs too.

Fixes #847.
