### PR TITLE
Arch based distro requires different command

### DIFF
--- a/docs/setup_toolchain.md
+++ b/docs/setup_toolchain.md
@@ -57,6 +57,11 @@ Next step: [Add keyboard support to Arduino](#add-keyboard-support-to-arduino)
     $ sudo cp 60-kaleidoscope.rules /etc/udev/rules.d
     $ sudo /etc/init.d/udev reload
     ```
+    For Arch based distros one may have to use:
+    
+    ```sh
+    $ sudo udevadm control --reload-rules && udevadm trigger
+    ```
 
 4. Then disconnect and reconnect the keyboard for that change to take effect.
 


### PR DESCRIPTION
For Arch/Manjaro the needed command is : `udevadm control --reload-rules && udevadm trigger` as referenced from https://unix.stackexchange.com/questions/39370/how-to-reload-udev-rules-without-reboot