### PR TITLE
Arch distro command differs

### DIFF
--- a/docs/setup_toolchain.md
+++ b/docs/setup_toolchain.md
@@ -57,6 +57,12 @@ Next step: [Add keyboard support to Arduino](#add-keyboard-support-to-arduino)
     $ sudo cp 60-kaleidoscope.rules /etc/udev/rules.d
     $ sudo /etc/init.d/udev reload
     ```
+    
+    For Arch based distributions the following command will be used instead of `sudo /etc/init.d/udev reload`
+    ```sh
+    $ sudo udevadm control --reload-rules && udevadm trigger
+    ```
+    
 
 4. Then disconnect and reconnect the keyboard for that change to take effect.
 


### PR DESCRIPTION
for line 58:sudo /etc/init.d/udev reload

as referenced in: https://unix.stackexchange.com/questions/39370/how-to-reload-udev-rules-without-reboot

Arch users will need: 
udevadm control --reload-rules && udevadm trigger