### PR TITLE
Deprecate key masking

### DIFF
--- a/docs/NEWS.md
+++ b/docs/NEWS.md
@@ -212,6 +212,10 @@ allowing external tools to aid in migrations. The setting wasn't widely used -
 if at all -, which is why we chose to repurpose it instead of adding a new
 field.
 
+### Key masking has been deprecated
+
+Key masking was a band-aid introduced to avoid accidentally sending unintended keys when key mapping changes between a key being pressed and released. Since the introduction of keymap caching, this is no longer necessary, as long as we can keep the mapping consistent. Users of key masking are encouraged to find ways to use the caching mechanism instead.
+
 ## Bugfixes
 
 We fixed way too many issues to list here, so we're going to narrow it down to the most important, most visible ones.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -19,6 +19,7 @@ If any of this does not make sense to you, or you have trouble updating your .in
     - [MagicCombo](#magiccombo)
     - [TypingBreaks](#typingbreaks)
     - [Redial](#redial)
+    - [Key mapping has been deprecated](#key-mapping-has-been-deprecated)
   + [Deprecated APIs and their replacements](#deprecated-apis-and-their-replacements)
     - [Source code and namespace rearrangement](#source-code-and-namespace-rearrangement)
 * [Removed APIs](#removed-apis)
@@ -490,6 +491,14 @@ Storing the settable settings in EEPROM makes it depend on `Kaleidoscope-EEPROM-
 ### Redial
 
 Older versions of the plugin required one to set up `Key_Redial` manually, and let the plugin know about it via `Redial.key`. This is no longer required, as the plugin sets up the redial key itself. As such, `Redial.key` was removed, and `Key_Redial` is defined by the plugin itself. To upgrade, simply remove your definition of `Key_Redial` and the `Redial.key` assignment from your sketch.
+
+### Key masking has been deprecated
+
+Key masking was a band-aid introduced to avoid accidentally sending unintended keys when key mapping changes between a key being pressed and released. Since the introduction of keymap caching, this is no longer necessary, as long as we can keep the mapping consistent. Users of key masking are encouraged to find ways to use the caching mechanism instead.
+
+As an example, if you had a key event handler that in some cases masked a key, it should now map it to `Key_NoKey` instead, until released.
+
+The masking API has been deprecated, and is scheduled to be removed after **2020-11-25**.
 
 ## Deprecated APIs and their replacements
 

--- a/src/kaleidoscope/device/Base.h
+++ b/src/kaleidoscope/device/Base.h
@@ -269,7 +269,7 @@ class Base {
    *
    * @param key_addr is the matrix address of the key.
    */
-  void maskKey(KeyAddr key_addr) {
+  void maskKey(KeyAddr key_addr) DEPRECATED(KEY_MASKING) {
     key_scanner_.maskKey(key_addr);
   }
   /**

--- a/src/kaleidoscope/plugin/Escape-OneShot.cpp
+++ b/src/kaleidoscope/plugin/Escape-OneShot.cpp
@@ -23,17 +23,19 @@
 namespace kaleidoscope {
 namespace plugin {
 
+bool EscapeOneShot::did_escape_;
+
 EventHandlerResult EscapeOneShot::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
-  if (mapped_key != Key_Escape ||
-      (keyState & INJECTED) ||
-      !keyToggledOn(keyState))
+  if (mapped_key != Key_Escape || (keyState & INJECTED))
     return EventHandlerResult::OK;
+
+  if (did_escape_)
+    mapped_key = Key_NoKey;
+  did_escape_ = !keyToggledOff(keyState);
 
   if ((!::OneShot.isActive() || ::OneShot.isPressed()) && !::OneShot.isSticky()) {
     return EventHandlerResult::OK;
   }
-
-  Runtime.device().maskKey(key_addr);
 
   ::OneShot.cancel(true);
   return EventHandlerResult::EVENT_CONSUMED;

--- a/src/kaleidoscope/plugin/Escape-OneShot.h
+++ b/src/kaleidoscope/plugin/Escape-OneShot.h
@@ -26,6 +26,9 @@ class EscapeOneShot : public kaleidoscope::Plugin {
   EscapeOneShot(void) {}
 
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);
+
+ private:
+  static bool did_escape_;
 };
 }
 }

--- a/src/kaleidoscope/plugin/TapDance.cpp
+++ b/src/kaleidoscope/plugin/TapDance.cpp
@@ -38,7 +38,6 @@ void TapDance::interrupt(KeyAddr key_addr) {
 
   last_tap_dance_key_ = Key_NoKey;
 
-  Runtime.device().maskKey(key_addr);
   Runtime.hid().keyboard().sendReport();
   Runtime.hid().keyboard().releaseAllKeys();
 
@@ -114,13 +113,11 @@ EventHandlerResult TapDance::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr,
     if (last_tap_dance_key_ == Key_NoKey)
       return EventHandlerResult::OK;
 
-    if (keyToggledOn(keyState))
+    if (keyToggledOn(keyState)) {
       interrupt(key_addr);
-
-    if (Runtime.device().isKeyMasked(key_addr)) {
-      Runtime.device().unMaskKey(key_addr);
-      return EventHandlerResult::EVENT_CONSUMED;
+      mapped_key = Key_NoKey;
     }
+
     return EventHandlerResult::OK;
   }
 

--- a/src/kaleidoscope_internal/deprecations.h
+++ b/src/kaleidoscope_internal/deprecations.h
@@ -27,6 +27,12 @@
 
 /* Messages */
 
+#define _DEPRECATED_MESSAGE_KEY_MASKING                                  __NL__ \
+  "Key masking has been deprecated, please map keys to NoKey instead.\n" __NL__ \
+  "\n"                                                                   __NL__ \
+  "For further information and examples on how to do that, \n"           __NL__ \
+  "please see UPGRADING.md"
+
 #define _DEPRECATED_MESSAGE_HID_FACADE                                   __NL__ \
   "The HID facade in the `kaleidoscope::hid` namespace is deprecated.\n" __NL__ \
   "Please use `Kaleidoscope.hid()` instead."


### PR DESCRIPTION
This patchset does three things: it migrates `TapDance` and `Escape-OneShot` away from key masking, and then deprecates that.

Key masking is a bandaid which we no longer need, yet, comes with a noticable amount of code and complexity. Deprecating it gets us one step closer to being able to remove it.