### PR TITLE
Rewrite of ActiveModColor

### DIFF
--- a/src/kaleidoscope/KeyAddrBitfield.h
+++ b/src/kaleidoscope/KeyAddrBitfield.h
@@ -102,7 +102,7 @@ class KeyAddrBitfield {
   class Iterator {
    public:
     Iterator(KeyAddrBitfield &bitfield, uint8_t x)
-        : bitfield_(bitfield), block_index_(x) {}
+      : bitfield_(bitfield), block_index_(x) {}
 
     bool operator!=(const Iterator &other) {
       // First, the test for the end condition (return false when all the blocks have been
@@ -154,9 +154,9 @@ class KeyAddrBitfield {
 
   }; // class Iterator {
 
-} __attribute__((packed)); // class Bitfield {
+} __attribute__((packed)); // class KeyAddrBitfield {
 
-} // namespace kaleidoglyph {
+} // namespace kaleidoscope {
 
 
 // ================================================================================

--- a/src/kaleidoscope/KeyAddrBitfield.h
+++ b/src/kaleidoscope/KeyAddrBitfield.h
@@ -1,4 +1,18 @@
-// -*- c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 

--- a/src/kaleidoscope/KeyAddrBitfield.h
+++ b/src/kaleidoscope/KeyAddrBitfield.h
@@ -1,0 +1,170 @@
+// -*- c++ -*-
+
+#pragma once
+
+#include <Arduino.h>
+
+#include "kaleidoscope/KeyAddr.h"
+
+
+namespace kaleidoscope {
+
+// Return the number of `UnitType` units required to store `n` bits. Both `UnitType` &
+// `WidthType` should be integer types. `WidthType` is whatever type the parameter `n` is
+// stored as, and can be deduced by the compiler, so it's not necessary to declare it
+// when calling this function (e.g. `bitfieldSize<uint16_t>(n)`). The default `UnitType`
+// is `byte` (i.e. `uint8_t`, which is almost always what we want, so most of the time we
+// can also drop that template parameter (e.g. `bitfieldSize(n)`).
+template <typename _UnitType = byte, typename _WidthType>
+constexpr _WidthType bitfieldSize(_WidthType n) {
+  return ((n - 1) / (8 * sizeof(_UnitType))) + 1;
+}
+
+// ================================================================================
+// Generic Bitfield class, useful for defining KeyAddrBitfield, and others.
+class KeyAddrBitfield {
+
+ public:
+
+  static constexpr uint8_t size = KeyAddr::upper_limit;
+  static constexpr uint8_t block_size = 8 * sizeof(uint8_t);
+  static constexpr uint8_t total_blocks = bitfieldSize<uint8_t>(size);
+
+  static constexpr uint8_t blockIndex(KeyAddr k) {
+    return k.toInt() / block_size;
+  }
+  static constexpr uint8_t bitIndex(KeyAddr k) {
+    return k.toInt() % block_size;
+  }
+  static constexpr KeyAddr index(uint8_t block_index, uint8_t bit_index) {
+    uint8_t offset = (block_index * block_size) + bit_index;
+    return KeyAddr(offset);
+  }
+  bool read(KeyAddr k) const {
+    // assert(k.toInt() < size);
+    return bitRead(data_[blockIndex(k)], bitIndex(k));
+  }
+  void set(KeyAddr k) {
+    // assert(k.toInt() < size);
+    bitSet(data_[blockIndex(k)], bitIndex(k));
+  }
+  void clear(KeyAddr k) {
+    // assert(k.toInt() < size);
+    bitClear(data_[blockIndex(k)], bitIndex(k));
+  }
+  void write(KeyAddr k, bool value) {
+    // assert(k.toInt() < size);
+    bitWrite(data_[blockIndex(k)], bitIndex(k), value);
+  }
+
+  // This function returns the number of set bits in the bitfield up to and
+  // including the bit at index `k`. Two important things to note: it doesn't
+  // verify that the bit for index `k` is set (the caller must do so first,
+  // using `read()`), and what is returned is 1-indexed, so the caller will need
+  // to subtract 1 before using it as an array index (e.g. when doing a `Key`
+  // lookup for a sparse keymap layer).
+  uint8_t ordinal(KeyAddr k) const {
+    // assert(k.toInt() < size);
+    uint8_t block_index = blockIndex(k);
+    uint8_t count{0};
+    for (uint8_t b{0}; b < block_index; ++b) {
+      count += __builtin_popcount(data_[b]);
+    }
+    uint8_t last_data_unit = data_[block_index];
+    last_data_unit &= ~(0xFF << bitIndex(k));
+    count += __builtin_popcount(last_data_unit);
+    return count;
+  }
+
+  uint8_t &block(uint8_t block_index) {
+    // assert(block_index < total_blocks);
+    return data_[block_index];
+  }
+
+ private:
+
+  uint8_t data_[total_blocks] = {};
+
+
+  // ----------------------------------------------------------------------------
+  // Iterator!
+ public:
+  class Iterator;
+  friend class KeyAddrBitfield::Iterator;
+
+  Iterator begin() {
+    return Iterator{*this, 0};
+  }
+  Iterator end() {
+    return Iterator{*this, total_blocks};
+  }
+
+  class Iterator {
+   public:
+    Iterator(KeyAddrBitfield &bitfield, uint8_t x)
+        : bitfield_(bitfield), block_index_(x) {}
+
+    bool operator!=(const Iterator &other) {
+      // First, the test for the end condition (return false when all the blocks have been
+      // tested):
+      while (block_index_ < other.block_index_) {
+        // Get the data for the block at `block_index_` from the bitfield, then shift it
+        // by the number of bits we've already checked (`bit_index_`):
+        block_ = bitfield_.data_[block_index_];
+        block_ >>= bit_index_;
+
+        // Now we iterate through that block until we either find a bit that is set, or we
+        // find that there are no more bits set. If (as expected most of the time) no bits
+        // are set, we do nothing:
+        while (block_ != 0) {
+          // If the low (remaining) bit is set, generate an `KeyAddr` object from the
+          // bitfield coordinates and store it for the dereference operator to return:
+          if (block_ & 1) {
+            index_ = KeyAddrBitfield::index(block_index_, bit_index_);
+            return true;
+          }
+          // The low bit wasn't set, so we shift the data block by one and track that
+          // shift with the bit coordinate (`bit_index_`):
+          block_ >>= 1;
+          bit_index_ += 1;
+        }
+
+        // When we're done checking a block, move on to the next one:
+        block_index_ += 1;
+        bit_index_  = 0;
+      }
+      return false;
+    }
+
+    KeyAddr operator*() {
+      // assert(index_ < size);
+      return index_;
+    }
+
+    void operator++() {
+      ++bit_index_;
+    }
+
+   private:
+    KeyAddrBitfield &bitfield_;
+    uint8_t block_index_;    // index of the block
+    uint8_t bit_index_{0}; // bit index in the block
+    uint8_t block_;
+    KeyAddr index_;
+
+  }; // class Iterator {
+
+} __attribute__((packed)); // class Bitfield {
+
+} // namespace kaleidoglyph {
+
+
+// ================================================================================
+// How to use the iterator above:
+#if 0
+// To use the KeyAddrBitfield::Iterator, write a loop like the following:
+KeyAddrBitfield bitfield;
+for (KeyAddr k : bitfield) {
+  // Here, you'll get a `KeyAddr` object for each bit that is set in `bitfield`.
+}
+#endif

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-LED-ActiveModColor -- Light up the LEDs under the active modifiers
- * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2016-2020  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -18,12 +18,12 @@
 #include <Kaleidoscope-LED-ActiveModColor.h>
 #include <Kaleidoscope-OneShot.h>
 #include "kaleidoscope/layers.h"
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace plugin {
 
-KeyAddr ActiveModColorEffect::mod_keys_[MAX_MODS_PER_LAYER];
-uint8_t ActiveModColorEffect::mod_key_count_;
+KeyAddrBitfield ActiveModColorEffect::mod_key_bits_;
 bool ActiveModColorEffect::highlight_normal_modifiers_ = true;
 
 cRGB ActiveModColorEffect::highlight_color = (cRGB) {
@@ -32,20 +32,33 @@ cRGB ActiveModColorEffect::highlight_color = (cRGB) {
 
 cRGB ActiveModColorEffect::sticky_color = CRGB(160, 0, 0);
 
-EventHandlerResult ActiveModColorEffect::onLayerChange() {
-  if (!Runtime.has_leds)
+EventHandlerResult ActiveModColorEffect::onKeyswitchEvent(Key &key,
+                                                          KeyAddr key_addr,
+                                                          uint8_t key_state) {
+  // If `key_addr` is not a physical key address, ignore it:
+  if (! key_addr.isValid()) {
     return EventHandlerResult::OK;
+  }
 
-  mod_key_count_ = 0;
-
-  for (auto key_addr : KeyAddr::all()) {
-    Key k = Layer.lookupOnActiveLayer(key_addr);
-
-    if (::OneShot.isOneShotKey(k) ||
-        (highlight_normal_modifiers_ && (
-           (k >= Key_LeftControl && k <= Key_RightGui) ||
-           (k.getFlags() == (SYNTHETIC | SWITCH_TO_KEYMAP))))) {
-      mod_keys_[mod_key_count_++] = key_addr;
+  if (keyToggledOn(key_state)) {
+    // If a key toggles on, we check its value. If it's a OneShot key,
+    // it will get highlighted. Conditionally (if
+    // `highlight_normal_modifiers_` is set), we also highlight
+    // modifier and layer-shift keys.
+    if (::OneShot.isOneShotKey(key) ||
+        (highlight_normal_modifiers_ &&
+         ((key >= Key_LeftControl && key <= Key_RightGui) ||
+          (key.getFlags() == (SYNTHETIC | SWITCH_TO_KEYMAP))))) {
+      mod_key_bits_.set(key_addr);
+    }
+  } else if (keyToggledOff(key_state)) {
+    // When a non-OneShot key toggles off, if it was being
+    // highlighted, we clear it immediately. We don't do this for
+    // OneShot keys, because they remain active after toggling off.
+    if (mod_key_bits_.read(key_addr) &&
+        (! ::OneShot.isOneShotKey(key))) {
+      mod_key_bits_.clear(key_addr);
+      ::LEDControl.refreshAt(key_addr);
     }
   }
 
@@ -53,36 +66,32 @@ EventHandlerResult ActiveModColorEffect::onLayerChange() {
 }
 
 EventHandlerResult ActiveModColorEffect::beforeReportingState() {
-  if (mod_key_count_ == 0) {
-    onLayerChange();
-  }
 
-  for (uint8_t i = 0; i < mod_key_count_; i++) {
-    const KeyAddr &key_addr = mod_keys_[i];
+  // This loop iterates through only the `key_addr`s that have their
+  // bits in the `mod_key_bits_` bitfield set.
+  for (KeyAddr key_addr: mod_key_bits_) {
+    Key key = Layer.lookup(key_addr);
 
-    Key k = Layer.lookupOnActiveLayer(key_addr);
-
-    if (::OneShot.isOneShotKey(k)) {
-      if (::OneShot.isSticky(k))
+    if (::OneShot.isOneShotKey(key)) {
+      // First, we deal with OneShot keys:
+      if (::OneShot.isSticky(key)) {
+        // If the OneShot key is sticky, it gets a different color:
         ::LEDControl.setCrgbAt(key_addr, sticky_color);
-      else if (::OneShot.isActive(k))
+      } else if (::OneShot.isActive(key)) {
+        // Non-sticky active OneShot keys also get highlighted:
         ::LEDControl.setCrgbAt(key_addr, highlight_color);
-      else
+      } else {
+        // If the OneShot key isn't active anymore at this point, we
+        // unset the for its address in the bitfield, and reset the
+        // color of the LED for that key:
+        mod_key_bits_.clear(key_addr);
         ::LEDControl.refreshAt(key_addr);
-    } else if (k >= Key_LeftControl && k <= Key_RightGui) {
-      if (kaleidoscope::Runtime.hid().keyboard().isModifierKeyActive(k))
-        ::LEDControl.setCrgbAt(key_addr, highlight_color);
-      else
-        ::LEDControl.refreshAt(key_addr);
-    } else if (k.getFlags() == (SYNTHETIC | SWITCH_TO_KEYMAP)) {
-      uint8_t layer = k.getKeyCode();
-      if (layer >= LAYER_SHIFT_OFFSET)
-        layer -= LAYER_SHIFT_OFFSET;
-
-      if (Layer.isActive(layer))
-        ::LEDControl.setCrgbAt(key_addr, highlight_color);
-      else
-        ::LEDControl.refreshAt(key_addr);
+      }
+    } else {
+      // Any non-OneShot keys here must be modifiers or layer-shift
+      // keys that are still being held, so we don't need to do any
+      // more checking, and just highlight them now:
+      ::LEDControl.setCrgbAt(key_addr, highlight_color);
     }
   }
 

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -78,7 +78,7 @@ EventHandlerResult ActiveModColorEffect::beforeReportingState() {
       if (::OneShot.isSticky(key)) {
         // If the OneShot key is sticky, it gets a different color:
         ::LEDControl.setCrgbAt(key_addr, sticky_color);
-      } else if (::OneShot.isActive(key)) {
+      } else if (::OneShot.isActive(key) || ::OneShot.isPressed(key)) {
         // Non-sticky active OneShot keys also get highlighted:
         ::LEDControl.setCrgbAt(key_addr, highlight_color);
       } else {

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -32,9 +32,10 @@ cRGB ActiveModColorEffect::highlight_color = (cRGB) {
 
 cRGB ActiveModColorEffect::sticky_color = CRGB(160, 0, 0);
 
-EventHandlerResult ActiveModColorEffect::onKeyswitchEvent(Key &key,
-                                                          KeyAddr key_addr,
-                                                          uint8_t key_state) {
+EventHandlerResult ActiveModColorEffect::onKeyswitchEvent(
+  Key &key,
+  KeyAddr key_addr,
+  uint8_t key_state) {
   // If `key_addr` is not a physical key address, ignore it:
   if (! key_addr.isValid()) {
     return EventHandlerResult::OK;
@@ -69,7 +70,7 @@ EventHandlerResult ActiveModColorEffect::beforeReportingState() {
 
   // This loop iterates through only the `key_addr`s that have their
   // bits in the `mod_key_bits_` bitfield set.
-  for (KeyAddr key_addr: mod_key_bits_) {
+  for (KeyAddr key_addr : mod_key_bits_) {
     Key key = Layer.lookup(key_addr);
 
     if (::OneShot.isOneShotKey(key)) {

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.h
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-LED-ActiveModColor -- Light up the LEDs under the active modifiers
- * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2016-2020  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/kaleidoscope/plugin/LED-ActiveModColor.h
+++ b/src/kaleidoscope/plugin/LED-ActiveModColor.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/KeyAddrBitfield.h"
 #include <Kaleidoscope-LEDControl.h>
 
 #define MAX_MODS_PER_LAYER 16
@@ -35,16 +36,14 @@ class ActiveModColorEffect : public kaleidoscope::Plugin {
     highlight_normal_modifiers_ = value;
   }
 
+  EventHandlerResult onKeyswitchEvent(Key &key,
+                                      KeyAddr key_addr,
+                                      uint8_t key_state);
   EventHandlerResult beforeReportingState();
-  EventHandlerResult onLayerChange();
-  EventHandlerResult onSetup() {
-    return onLayerChange();
-  }
 
  private:
   static bool highlight_normal_modifiers_;
-  static KeyAddr mod_keys_[MAX_MODS_PER_LAYER];
-  static uint8_t mod_key_count_;
+  static KeyAddrBitfield mod_key_bits_;
 };
 }
 }

--- a/src/kaleidoscope/plugin/OneShot.cpp
+++ b/src/kaleidoscope/plugin/OneShot.cpp
@@ -100,7 +100,7 @@ EventHandlerResult OneShot::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, 
       activateOneShot(idx);
     }
 
-    return EventHandlerResult::EVENT_CONSUMED;
+    return EventHandlerResult::OK;
   }
 
   if (isOneShotKey_(mapped_key)) {
@@ -141,7 +141,7 @@ EventHandlerResult OneShot::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, 
       }
     }
 
-    return EventHandlerResult::EVENT_CONSUMED;
+    return EventHandlerResult::OK;
   }
 
   // ordinary key here, with some event


### PR DESCRIPTION
I have rewritten LED-ActiveModColor to make it compatible with Qukeys (and, potentially, other plugins that change a `Key` value to a modifier or layer shift in response to user input other than layer changes. The big change is the introduction of the `KeyAddrBitfield` class, which represents a binary state of the keys (in this case, the keys currently in need of highlighting). `KeyAddrBitfield` also comes with a very efficient iterator that returns each `KeyAddr` that corresponds to a non-zero bit in the bitfield (assuming most bits are zeroes most of the time).

This both uses less space than the previous array of 16 `KeyAddr`s (at least, on the Model01) and eliminates the limitation on the number of such keys, as well as a potentially serious out of bounds write (if that limit was exceeded).

With this new design, there's no longer a need for the `onLayerChange()` hook, and some of the logic is simplified. Instead there's a new `onKeyswitchEvent()` hook that toggles bits for held modifier keys, and turns them on for OneShot keys. The `beforeReportingState()` hook gets a bit simpler, because it only needs to turn off bits for OneShot keys, and highlighting requires fewer checks. Overall, this version ends up using more program memory, but less RAM.

I haven't adequately tested this yet, but I'm not marking the PR as a draft, because I want to see if it passes all the build tests.

Fixes #882.