### PR TITLE
Add Consumer keys to adjust display brightness

### DIFF
--- a/src/kaleidoscope/key_defs_consumerctl.h
+++ b/src/kaleidoscope/key_defs_consumerctl.h
@@ -397,3 +397,8 @@
 #define Consumer_AC_Split CONSUMER_KEY(HID_CONSUMER_AC_SPLIT, KEY_FLAGS |  HID_TYPE_SEL)
 #define Consumer_AC_Distribute_Horizontally CONSUMER_KEY(HID_CONSUMER_AC_DISTRIBUTE_HORIZONTALLY, KEY_FLAGS |  HID_TYPE_SEL)
 #define Consumer_AC_Distribute_Vertically CONSUMER_KEY(HID_CONSUMER_AC_DISTRIBUTE_VERTICALLY, KEY_FLAGS |  HID_TYPE_SEL)
+
+// These keys are not documented in the USB HID Usage Tables, but are
+// supported by Linux, macOS, and Windows to change display brightness.
+#define Consumer_BrightnessUp CONSUMER_KEY(0x6f, HID_TYPE_OSC)
+#define Consumer_BrightnessDown CONSUMER_KEY(0x70, HID_TYPE_OSC)


### PR DESCRIPTION
This adds `Consumer_BrightnessUp` and `Consumer_BrightnessDown`, which are not included in the USB HID Usage Tables (1.12v2), but which are supported by Linux, macOS, and Windows (according to QMK docs).

References:
- [QMK documentation](https://beta.docs.qmk.fm/using-qmk/simple-keycodes/keycodes)
- [Linux kernel HID input source code](https://github.com/torvalds/linux/blob/7fe10096c1508c7f033d34d0741809f8eecc1ed4/drivers/hid/hid-input.c#L903)

I haven't had a chance to test these keys on Linux or Windows, but they work on my iMac running Catalina.