### PR TITLE
Correct the construction of Consumer Control Key objects

### DIFF
--- a/src/kaleidoscope/key_defs.h
+++ b/src/kaleidoscope/key_defs.h
@@ -262,7 +262,7 @@ typedef kaleidoscope::Key Key_;
    use the CONSUMER(key) macro this will return the 10bit keycode.
 */
 #define CONSUMER(key) (key.getRaw() & 0x03FF)
-#define CONSUMER_KEY(code, flags) Key((code) | ((flags | SYNTHETIC|IS_CONSUMER) << 8))
+#define CONSUMER_KEY(code, flags) Key((code & 0x03FF) | ((SYNTHETIC | IS_CONSUMER) << 8))
 
 namespace kaleidoscope {
 constexpr Key bad_keymap_key{0, RESERVED};


### PR DESCRIPTION
There were a few minor problems in the way Consumer `Key` objects were constructed (using `CONSUMER_KEY()`). First, no masking of the high bits was being done, so it was possible to create a "Consumer" key with the `RESERVED` bit set (e.g. `Key_Transparent`), or the `SWITCH_TO_KEYMAP` bit (in fact, any `Key` value with both the `SYNTHETIC` and `IS_CONSUMER` bits set was possible).

Second, the high six bits of the raw `Key` value should always be `010010` (`SYNTHETIC | IS_CONSUMER`), as Consumer keys don't have any flags. The macro should really only take one argument: a 16-bit integer keycode value. The `HID_TYPE_*` constants really shouldn't be used at all in defining the keys in key_defs_consumer.h, because
setting those bits could potentially cause a key to be misidentified by some plugin.

This change fixes these potential problems by ignoring the `flags` parameter, masking the high six bits of the `code` supplied, and setting those high six bits to the correct value.

This is the least intrusive way to fix the problem(s). Really, it should be done more comprehensively (removing the `flags` parameter, converting the constructor from a macro to a `constexpr`, updating the key_defs_consumerctl.h file accordingly, removing the `HID_TYPE_*` definitions from key_defs.h, and possibly updating all the Consumer key HID values in HIDTables.h (in both Kaleidoscope and KeyboardioHID). I think all of that is worth doing, but this simple patch may be worthwhile in the interim.