### PR TITLE
Add a small tool, to run things within Docker

### DIFF
--- a/bin/run-docker
+++ b/bin/run-docker
@@ -1,0 +1,20 @@
+#! /bin/sh
+## -*- mode: sh -*-
+set -e
+
+uname_S=$(uname -s 2>/dev/null || echo not)
+
+ARDUINO_LOCAL_LIB_PATH="${ARDUINO_LOCAL_LIB_PATH:-${HOME}/Arduino}"
+
+if [ "${uname_S}" = "Darwin" ]; then
+    ARDUINO_LOCAL_LIB_PATH="${ARDUINO_LOCAL_LIB_PATH:-${HOME}/Documents/Arduino}"
+fi
+
+BOARD_HARDWARE_PATH="${BOARD_HARDWARE_PATH:-${ARDUINO_LOCAL_LIB_PATH}/hardware}"
+
+docker build -t kaleidoscope/docker etc
+docker run --rm -it \
+       -v "${BOARD_HARDWARE_PATH}/keyboardio:/kaleidoscope/hardware/keyboardio" \
+       -v "$(pwd):/kaleidoscope/hardware/keyboardio/avr/libraries/Kaleidoscope" \
+       -e DOCKER_COMMAND="$*" \
+       kaleidoscope/docker

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:stable-slim
+LABEL maintainer="Keyboard.io, inc"
+
+RUN apt-get -qq update
+RUN apt-get -qq install -y xz-utils curl git-core make build-essential libxtst-dev
+
+ENV ARDUINO_VERSION "1.8.13"
+
+WORKDIR /usr/local
+RUN curl https://downloads.arduino.cc/arduino-${ARDUINO_VERSION}-linux64.tar.xz | \
+  xzcat | tar xf - && \
+  ln -s arduino-${ARDUINO_VERSION} arduino
+RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | \
+  sh
+RUN /usr/local/bin/arduino-cli core install arduino:avr
+
+VOLUME ["/kaleidoscope/hardware/keyboardio"]
+ENV BOARD_HARDWARE_PATH "/kaleidoscope/hardware"
+WORKDIR /kaleidoscope/hardware/keyboardio/avr/libraries/Kaleidoscope
+ENTRYPOINT ["/bin/bash", "-c", "eval \"${DOCKER_COMMAND}\""]


### PR DESCRIPTION
To make it easier to reproduce things, and to help build in a clean environment, this adds a thin Dockerfile that has Arduino and arduino-cli pre-installed, and - along with the `bin/run-docker` script - is set up so that one can easily run arbitrary commands in the context of the current bundle and Kaleidoscope.

The first run will take a while, because docker will build the image. Subsequent runs will use the cache.

To use: `bin/run-docker make`, for example. Any argument passed to the `bin/run-docker` will be eval-ed within the container, and will run there.
