### PR TITLE
docker: Simplify the Dockerfile a little

### DIFF
--- a/bin/run-docker
+++ b/bin/run-docker
@@ -16,5 +16,4 @@ docker build -t kaleidoscope/docker etc
 docker run --rm -it \
        -v "${BOARD_HARDWARE_PATH}/keyboardio:/kaleidoscope/hardware/keyboardio" \
        -v "$(pwd):/kaleidoscope/hardware/keyboardio/avr/libraries/Kaleidoscope" \
-       -e DOCKER_COMMAND="$*" \
-       kaleidoscope/docker
+       kaleidoscope/docker -c "$*"

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -17,4 +17,4 @@ RUN /usr/local/bin/arduino-cli core install arduino:avr
 VOLUME ["/kaleidoscope/hardware/keyboardio"]
 ENV BOARD_HARDWARE_PATH "/kaleidoscope/hardware"
 WORKDIR /kaleidoscope/hardware/keyboardio/avr/libraries/Kaleidoscope
-ENTRYPOINT ["/bin/bash", "-c", "eval \"${DOCKER_COMMAND}\""]
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
We can pass arguments to the entrypoint from the `docker run` commandline, so we do not need to do that via an environment variable. This way, we're an environment variable and an `eval` shorter.