### PR TITLE
Add a full keyboard state array

### DIFF
--- a/docs/codebase/glossary.md
+++ b/docs/codebase/glossary.md
@@ -17,7 +17,7 @@ A single physical input, such as a keyswitch or other input like a knob or a sli
 
 ### Key number
 
-An integer representing a Keyswitch’s position in the “Physical Layout”
+An integer representing a Keyswitch’s position in the “Physical Layout”. Represented in the code by the `KeyAddr` type.
 
 ### Physical Layout
 
@@ -33,7 +33,7 @@ A representation of a specific behavior. Most often a representation of a specif
 
 ### Keymap
 
-A list of key bindings for all keyswitchess on the Physical Layout
+A list of key bindings for all keyswitchess on the Physical Layout. Represented in the code by the `KeyMap` type.
 
 ### Keymaps
 
@@ -47,10 +47,9 @@ An entry in that ordered list of keymaps. Each layer has a unique id number that
 
 An ordered list of all the currently-active layers, in the order they should be evaluated when figuring out what a key does.
 
-### Override Layer
+### Live keys
 
-A special layer that’s always active and evaluated before checking keys in the “Active layer stack”  
-
+A representation of the current state of the keyboard's keys, where non-transparent entries indicate keys that are active (logically—usually, but not necessarily, physically held). Represented in the code by the `LiveKeys` type (and the `live_keys` object).
 
 
 ## Keyswitch state

--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.cpp
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.cpp
@@ -23,21 +23,19 @@
 namespace kaleidoscope {
 namespace plugin {
 
-bool EscapeOneShot::did_escape_;
-
 EventHandlerResult EscapeOneShot::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
   if (mapped_key != Key_Escape || (keyState & INJECTED))
     return EventHandlerResult::OK;
 
-  if (did_escape_)
-    mapped_key = Key_NoKey;
-  did_escape_ = !keyToggledOff(keyState);
+  if (!keyToggledOn(keyState))
+    return EventHandlerResult::OK;
 
   if ((!::OneShot.isActive() || ::OneShot.isPressed()) && !::OneShot.isSticky()) {
     return EventHandlerResult::OK;
   }
 
   ::OneShot.cancel(true);
+  mapped_key = Key_NoKey;
   return EventHandlerResult::EVENT_CONSUMED;
 }
 

--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.h
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.h
@@ -27,8 +27,6 @@ class EscapeOneShot : public kaleidoscope::Plugin {
 
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);
 
- private:
-  static bool did_escape_;
 };
 }
 }

--- a/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.cpp
+++ b/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.cpp
@@ -67,7 +67,7 @@ EventHandlerResult Qukeys::onKeyswitchEvent(Key& key, KeyAddr k, uint8_t key_sta
     }
     // Any event that gets added to the queue gets re-processed later, so we
     // need to abort processing now.
-    return EventHandlerResult::EVENT_CONSUMED;
+    return EventHandlerResult::ABORT;
   }
 
   // The key is being held. We need to determine if we should block it because
@@ -84,7 +84,7 @@ EventHandlerResult Qukeys::onKeyswitchEvent(Key& key, KeyAddr k, uint8_t key_sta
       }
       // Otherwise, the first matching event was a key press, so we need to
       // suppress it for now.
-      return EventHandlerResult::EVENT_CONSUMED;
+      return EventHandlerResult::ABORT;
     }
   }
 

--- a/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.h
+++ b/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.h
@@ -20,7 +20,7 @@
 
 #include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
-#include "kaleidoscope/plugin/Qukeys/KeyAddrEventQueue.h"
+#include "kaleidoscope/KeyAddrEventQueue.h"
 
 // DualUse Key definitions for Qukeys in the keymap
 #define MT(mod, key) Key(                                               \

--- a/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys/KeyAddrEventQueue.h
+++ b/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys/KeyAddrEventQueue.h
@@ -105,6 +105,19 @@ class KeyAddrEventQueue {
     release_event_bits_ >>= 1;
   }
 
+  void shift(uint8_t n) {
+    if (n >= length_) {
+      clear();
+      return;
+    }
+    length_ -= n;
+    for (uint8_t i{0}; i < length_; ++i) {
+      addrs_[i]      = addrs_[i + n];
+      timestamps_[i] = timestamps_[i + n];
+    }
+    release_event_bits_ >>= n;
+  }
+
   // Empty the queue entirely.
   void clear() {
     length_             = 0;

--- a/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.cpp
+++ b/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.cpp
@@ -21,27 +21,16 @@
 namespace kaleidoscope {
 namespace plugin {
 
-Key Redial::key_to_redial_;
 Key Redial::last_key_;
-bool Redial::redial_held_ = false;
 
 EventHandlerResult Redial::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
-  if (mapped_key == Key_Redial) {
-    if (keyToggledOff(key_state))
-      key_to_redial_ = last_key_;
-
-    mapped_key = key_to_redial_;
-    redial_held_ = keyIsPressed(key_state);
-
-    return EventHandlerResult::OK;
+  if (keyToggledOn(key_state)) {
+    if (mapped_key == Key_Redial) {
+      mapped_key = last_key_;
+    } else if (shouldRemember(mapped_key)) {
+      last_key_ = mapped_key;
+    }
   }
-
-  if (keyToggledOn(key_state) && shouldRemember(mapped_key)) {
-    last_key_ = mapped_key;
-    if (!redial_held_)
-      key_to_redial_ = mapped_key;
-  }
-
   return EventHandlerResult::OK;
 }
 

--- a/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.h
+++ b/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.h
@@ -34,9 +34,7 @@ class Redial : public kaleidoscope::Plugin {
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 
  private:
-  static Key key_to_redial_;
   static Key last_key_;
-  static bool redial_held_;
 };
 
 }

--- a/plugins/Kaleidoscope-ShapeShifter/src/kaleidoscope/plugin/ShapeShifter.h
+++ b/plugins/Kaleidoscope-ShapeShifter/src/kaleidoscope/plugin/ShapeShifter.h
@@ -33,10 +33,6 @@ class ShapeShifter : public kaleidoscope::Plugin {
   static const dictionary_t *dictionary;
 
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
-  EventHandlerResult beforeReportingState();
-
- private:
-  static bool mod_active_;
 };
 }
 

--- a/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.cpp
+++ b/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.cpp
@@ -17,70 +17,21 @@
 
 #include <Kaleidoscope-TapDance.h>
 #include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/layers.h"
 
 namespace kaleidoscope {
 namespace plugin {
 
-// --- state ---
-uint16_t TapDance::start_time_;
+// --- config ---
+
 uint16_t TapDance::time_out = 200;
-TapDance::TapDanceState TapDance::state_[TapDance::TAPDANCE_KEY_COUNT];
-Key TapDance::last_tap_dance_key_ = Key_NoKey;
-KeyAddr TapDance::last_tap_dance_addr_;
-
-// --- actions ---
-
-void TapDance::interrupt(KeyAddr key_addr) {
-  uint8_t idx = last_tap_dance_key_.getRaw() - ranges::TD_FIRST;
-
-  tapDanceAction(idx, last_tap_dance_addr_, state_[idx].count, Interrupt);
-  state_[idx].triggered = true;
-
-  last_tap_dance_key_ = Key_NoKey;
-
-  Runtime.hid().keyboard().sendReport();
-  Runtime.hid().keyboard().releaseAllKeys();
-
-  if (state_[idx].pressed)
-    return;
-
-  release(idx);
-}
-
-void TapDance::timeout(void) {
-  uint8_t idx = last_tap_dance_key_.getRaw() - ranges::TD_FIRST;
-
-  tapDanceAction(idx, last_tap_dance_addr_, state_[idx].count, Timeout);
-  state_[idx].triggered = true;
-
-  if (state_[idx].pressed)
-    return;
-
-  last_tap_dance_key_ = Key_NoKey;
-
-  release(idx);
-}
-
-void TapDance::release(uint8_t tap_dance_index) {
-  last_tap_dance_key_ = Key_NoKey;
-
-  state_[tap_dance_index].pressed = false;
-  state_[tap_dance_index].triggered = false;
-  state_[tap_dance_index].release_next = true;
-}
-
-void TapDance::tap(void) {
-  uint8_t idx = last_tap_dance_key_.getRaw() - ranges::TD_FIRST;
-
-  state_[idx].count++;
-  start_time_ = Runtime.millisAtCycleStart();
-
-  tapDanceAction(idx, last_tap_dance_addr_, state_[idx].count, Tap);
-}
+KeyAddr TapDance::release_addr_ = KeyAddr{KeyAddr::invalid_state};
 
 // --- api ---
-
-void TapDance::actionKeys(uint8_t tap_count, ActionType tap_dance_action, uint8_t max_keys, const Key tap_keys[]) {
+void TapDance::actionKeys(uint8_t tap_count,
+                          ActionType tap_dance_action,
+                          uint8_t max_keys,
+                          const Key tap_keys[]) {
   if (tap_count > max_keys)
     tap_count = max_keys;
 
@@ -91,108 +42,127 @@ void TapDance::actionKeys(uint8_t tap_count, ActionType tap_dance_action, uint8_
     break;
   case Interrupt:
   case Timeout:
-    handleKeyswitchEvent(key, last_tap_dance_addr_, IS_PRESSED | INJECTED);
+    if (event_queue_.isEmpty())
+      break;
+    {
+      KeyAddr td_addr = event_queue_.addr(0);
+      bool key_released = (live_keys[td_addr] == Key_Transparent);
+      handleKeyswitchEvent(key, td_addr, IS_PRESSED | INJECTED);
+      if (key_released)
+        release_addr_ = td_addr;
+    }
     break;
   case Hold:
-    handleKeyswitchEvent(key, last_tap_dance_addr_, IS_PRESSED | WAS_PRESSED | INJECTED);
-    break;
   case Release:
-    kaleidoscope::Runtime.hid().keyboard().sendReport();
-    handleKeyswitchEvent(key, last_tap_dance_addr_, WAS_PRESSED | INJECTED);
     break;
   }
 }
+
 
 // --- hooks ---
 
-EventHandlerResult TapDance::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
-  if (keyState & INJECTED)
+EventHandlerResult TapDance::onKeyswitchEvent(Key &key,
+                                              KeyAddr key_addr,
+                                              uint8_t key_state) {
+  if (key_state & INJECTED)
     return EventHandlerResult::OK;
 
-  if (mapped_key.getRaw() < ranges::TD_FIRST || mapped_key.getRaw() > ranges::TD_LAST) {
-    if (last_tap_dance_key_ == Key_NoKey)
-      return EventHandlerResult::OK;
-
-    if (keyToggledOn(keyState)) {
-      interrupt(key_addr);
-      mapped_key = Key_NoKey;
-    }
-
-    return EventHandlerResult::OK;
-  }
-
-  uint8_t tap_dance_index = mapped_key.getRaw() - ranges::TD_FIRST;
-
-  if (keyToggledOff(keyState))
-    state_[tap_dance_index].pressed = false;
-
-  if (last_tap_dance_key_ != mapped_key) {
-    if (last_tap_dance_key_ == Key_NoKey) {
-      if (state_[tap_dance_index].triggered) {
-        if (keyToggledOff(keyState)) {
-          release(tap_dance_index);
-        }
-
-        return EventHandlerResult::EVENT_CONSUMED;
-      }
-
-      last_tap_dance_key_ = mapped_key;
-      last_tap_dance_addr_ = key_addr;
-
-      tap();
-
+  if (event_queue_.isEmpty()) {
+    if (keyToggledOn(key_state) && isTapDanceKey(key)) {
+      // Begin a new TapDance sequence:
+      uint8_t td_id = key.getRaw() - ranges::TD_FIRST;
+      tapDanceAction(td_id, key_addr, 1, Tap);
+      event_queue_.append(key_addr, key_state);
       return EventHandlerResult::EVENT_CONSUMED;
+    }
+    return EventHandlerResult::OK;
+  }
+
+  uint8_t td_count = event_queue_.length();
+  KeyAddr td_addr = event_queue_.addr(0);
+  Key     td_key = Layer.lookup(td_addr);
+  uint8_t td_id = td_key.getRaw() - ranges::TD_FIRST;
+
+  if (keyToggledOn(key_state)) {
+    if (key_addr == td_addr) {
+      // The same TapDance key was pressed again; continue the sequence:
+      tapDanceAction(td_id, td_addr, ++td_count, Tap);
     } else {
-      if (keyToggledOff(keyState) && state_[tap_dance_index].count) {
-        release(tap_dance_index);
-        return EventHandlerResult::EVENT_CONSUMED;
+      // A different key was pressed; interrupt the sequeunce:
+      tapDanceAction(td_id, td_addr, td_count, Interrupt);
+      event_queue_.clear();
+      // If the sequence was interrupted by another TapDance key, start the new
+      // sequence:
+      if (isTapDanceKey(Layer.lookup(key_addr))) {
+        td_id = key.getRaw() - ranges::TD_FIRST;
+        tapDanceAction(td_id, key_addr, 1, Tap);
       }
-
-      if (!keyToggledOn(keyState)) {
-        return EventHandlerResult::EVENT_CONSUMED;
+    }
+    // Any key that toggles on while a TapDance sequence is live gets added to
+    // the queue. If it interrupted the queue, we need to hold off on processing
+    // that event until the next cycle to guarantee that the events appear in
+    // order on the host.
+    event_queue_.append(key_addr, key_state);
+    if (isTapDanceKey(key))
+      return EventHandlerResult::EVENT_CONSUMED;
+    return EventHandlerResult::ABORT;
+  } else if (keyIsPressed(key_state)) {
+    // Until a key press event has been released from the queue, its "hold
+    // event" must be suppressed every cycle.
+    for (uint8_t i{0}; i < event_queue_.length(); ++i) {
+      if (event_queue_.addr(i) == key_addr) {
+        return EventHandlerResult::ABORT;
       }
-
-      interrupt(key_addr);
     }
   }
-
-  // in sequence
-
-  if (keyToggledOff(keyState)) {
+  // We always indicate that other plugins don't need to handle TapDance keys,
+  // but we do allow them to show up as active keys when they're held. This way,
+  // when one times out, if it's not being held any longer, we can send the
+  // release event.
+  if (isTapDanceKey(key))
     return EventHandlerResult::EVENT_CONSUMED;
-  }
-
-  last_tap_dance_key_ = mapped_key;
-  last_tap_dance_addr_ = key_addr;
-  state_[tap_dance_index].pressed = true;
-
-  if (keyToggledOn(keyState)) {
-    tap();
-    return EventHandlerResult::EVENT_CONSUMED;
-  }
-
-  if (state_[tap_dance_index].triggered)
-    tapDanceAction(tap_dance_index, key_addr, state_[tap_dance_index].count, Hold);
-
-  return EventHandlerResult::EVENT_CONSUMED;
+  // This key is being held, but is not in the queue, or it toggled off, but is
+  // not (currently) a TapDance key.
+  return EventHandlerResult::OK;
 }
 
 EventHandlerResult TapDance::afterEachCycle() {
-  for (uint8_t i = 0; i < TAPDANCE_KEY_COUNT; i++) {
-    if (!state_[i].release_next)
-      continue;
-
-    tapDanceAction(i, last_tap_dance_addr_, state_[i].count, Release);
-    state_[i].count = 0;
-    state_[i].release_next = false;
+  if (release_addr_.isValid()) {
+    handleKeyswitchEvent(Key_NoKey, release_addr_, WAS_PRESSED | INJECTED);
+    release_addr_ = KeyAddr{KeyAddr::invalid_state};
+  }
+  Key event_key;
+  // Purge any non-TapDance key events from the front of the queue.
+  while (! event_queue_.isEmpty()) {
+    KeyAddr event_addr = event_queue_.addr(0);
+    event_key = Layer.lookup(event_addr);
+    if (isTapDanceKey(event_key)) {
+      break;
+    }
+    handleKeyswitchEvent(event_key, event_addr, IS_PRESSED | INJECTED);
+    event_queue_.shift();
   }
 
-  if (last_tap_dance_key_ == Key_NoKey)
+  if (event_queue_.isEmpty())
     return EventHandlerResult::OK;
 
-  if (Runtime.hasTimeExpired(start_time_, time_out))
-    timeout();
+  // The first event in the queue is now guaranteed to be a TapDance key.
+  uint8_t td_id = event_key.getRaw() - ranges::TD_FIRST;
+  KeyAddr td_addr = event_queue_.addr(0);
 
+  // Check for timeout
+  uint8_t td_count = event_queue_.length();
+  uint16_t start_time = event_queue_.timestamp(td_count - 1);
+  if (Runtime.hasTimeExpired(start_time, time_out)) {
+    tapDanceAction(td_id, td_addr, td_count, Timeout);
+    event_queue_.clear();
+    // There's still a race condition here, but it's a minor one. If a TapDance
+    // sequence times out in the `afterEachCycle()` handler, then another key
+    // toggles on in the following scan cycle, and that key is handled first,
+    // the two events could show up out of order on the host. The probability of
+    // this happening is low, and event-driven Kaleidoscope will fix it
+    // completely, so I'm willing to accept the risk for now.
+  }
   return EventHandlerResult::OK;
 }
 

--- a/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.h
+++ b/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.h
@@ -20,7 +20,7 @@
 #include "kaleidoscope/Runtime.h"
 #include "kaleidoscope/LiveKeys.h"
 #include <Kaleidoscope-Ranges.h>
-#include "kaleidoscope/plugin/Qukeys/KeyAddrEventQueue.h"
+#include "kaleidoscope/KeyAddrEventQueue.h"
 
 #define TD(n) Key(kaleidoscope::ranges::TD_FIRST + n)
 

--- a/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.h
+++ b/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.h
@@ -18,7 +18,9 @@
 #pragma once
 
 #include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/LiveKeys.h"
 #include <Kaleidoscope-Ranges.h>
+#include "kaleidoscope/plugin/Qukeys/KeyAddrEventQueue.h"
 
 #define TD(n) Key(kaleidoscope::ranges::TD_FIRST + n)
 
@@ -49,24 +51,20 @@ class TapDance : public kaleidoscope::Plugin {
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);
   EventHandlerResult afterEachCycle();
 
+  static constexpr bool isTapDanceKey(Key key) {
+    return (key.getRaw() >= ranges::TD_FIRST &&
+            key.getRaw() <= ranges::TD_LAST);
+  }
+
  private:
-  static constexpr uint8_t TAPDANCE_KEY_COUNT = 16;
-  struct TapDanceState {
-    bool pressed: 1;
-    bool triggered: 1;
-    bool release_next: 1;
-    uint8_t count;
-  };
-  static TapDanceState state_[TAPDANCE_KEY_COUNT];
+  // The maximum number of events in the queue at a time.
+  static constexpr uint8_t queue_capacity_{8};
 
-  static uint16_t start_time_;
-  static Key last_tap_dance_key_;
-  static KeyAddr last_tap_dance_addr_;
+  // The event queue stores a series of press and release events.
+  KeyAddrEventQueue<queue_capacity_> event_queue_;
 
-  static void tap(void);
-  static void interrupt(KeyAddr key_addr);
-  static void timeout(void);
-  static void release(uint8_t tap_dance_index);
+  static KeyAddr release_addr_;
+
 };
 }
 

--- a/plugins/Kaleidoscope-TopsyTurvy/src/kaleidoscope/plugin/TopsyTurvy.h
+++ b/plugins/Kaleidoscope-TopsyTurvy/src/kaleidoscope/plugin/TopsyTurvy.h
@@ -29,12 +29,18 @@ class TopsyTurvy: public kaleidoscope::Plugin {
  public:
   TopsyTurvy(void) {}
 
-  EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
+  EventHandlerResult beforeEachCycle();
+  EventHandlerResult beforeReportingState();
+  EventHandlerResult onKeyswitchEvent(Key &key, KeyAddr key_addr, uint8_t key_state);
+
+  static bool isTopsyTurvyKey(Key key) {
+    return (key >= ranges::TT_FIRST &&
+            key <= ranges::TT_LAST);
+  }
 
  private:
-  static uint8_t last_pressed_position_;
-  static bool is_shifted_;
-  static bool is_active_;
+  static KeyAddr tt_addr_;
+  static bool shift_detected_;
 };
 }
 }

--- a/plugins/Kaleidoscope-WinKeyToggle/src/kaleidoscope/plugin/WinKeyToggle.cpp
+++ b/plugins/Kaleidoscope-WinKeyToggle/src/kaleidoscope/plugin/WinKeyToggle.cpp
@@ -27,8 +27,10 @@ EventHandlerResult WinKeyToggle::onKeyswitchEvent(Key &key, KeyAddr key_addr, ui
   if (!enabled_)
     return EventHandlerResult::OK;
 
-  if (key == Key_LeftGui || key == Key_RightGui)
+  if (key == Key_LeftGui || key == Key_RightGui) {
+    key = Key_NoKey;
     return EventHandlerResult::EVENT_CONSUMED;
+  }
 
   return EventHandlerResult::OK;
 }

--- a/src/kaleidoscope/KeyAddrEventQueue.h
+++ b/src/kaleidoscope/KeyAddrEventQueue.h
@@ -25,7 +25,6 @@
 #include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
-namespace plugin {
 
 // This class defines a keyswitch event queue that stores both press and release
 // events, recording the key address, a timestamp, and the keyswitch state
@@ -125,5 +124,4 @@ class KeyAddrEventQueue {
   }
 };
 
-}  // namespace plugin
 }  // namespace kaleidoscope

--- a/src/kaleidoscope/KeyMap.h
+++ b/src/kaleidoscope/KeyMap.h
@@ -1,0 +1,96 @@
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2021  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "kaleidoscope_internal/device.h"
+#include "kaleidoscope/KeyAddr.h"
+#include "kaleidoscope/key_defs.h"
+
+namespace kaleidoscope {
+
+// A `KeyMap` is a collection of `Key` objects, indexed by `KeyAddr`, with one
+// entry per key on the keyboard.
+
+class KeyMap {
+
+ private:
+  static constexpr uint8_t kSize_ = kaleidoscope_internal::device.numKeys();
+
+  Key keys_[kSize_];
+
+ public:
+  // Return the number of `Key` entries in the array
+  static constexpr uint8_t size() {
+    return kSize_;
+  }
+
+  // To set the value of an entry:
+  // key_array[key_addr] = Key_X;
+  Key& operator[](KeyAddr key_addr) {
+    return keys_[key_addr.toInt()];
+  }
+
+  // To get the value of an entry:
+  // Key key = key_array[key_addr];
+  const Key& operator[](KeyAddr key_addr) const {
+    return keys_[key_addr.toInt()];
+  }
+
+  // This function sets all entries to the value `Key_Transparent`
+  void clear() {
+    memset(keys_, -1, sizeof(keys_));
+  }
+
+  // ---------------------------------------------------------------------------
+  // The following code defines an iterator class for the `KeyMap`, such that
+  // we can write the following code to get each `Key` entry in the array:
+  //
+  // for (Key key : key_map) {...}
+ private:
+  class Iterator;
+  friend class KeyMap::Iterator;
+
+ public:
+  Iterator begin() {
+    return {*this, KeyAddr(uint8_t(0))};
+  }
+  Iterator end() {
+    return {*this, KeyAddr(kSize_)};
+  }
+
+ private:
+  class Iterator {
+   public:
+    Iterator(KeyMap &array, KeyAddr key_addr)
+      : array_(array), key_addr_(key_addr) {}
+    bool operator!=(const Iterator &other) const {
+      return key_addr_ != other.key_addr_;
+    }
+    Key operator*() const {
+      return array_[key_addr_];
+    }
+    Iterator& operator++() {
+      ++key_addr_;
+      return *this;
+    }
+   private:
+    KeyMap &array_;
+    KeyAddr key_addr_;
+  };
+};
+
+} // namespace kaleidoscope

--- a/src/kaleidoscope/LiveKeys.cpp
+++ b/src/kaleidoscope/LiveKeys.cpp
@@ -1,0 +1,24 @@
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2021  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "kaleidoscope/LiveKeys.h"
+#include "kaleidoscope/KeyMap.h"
+
+namespace kaleidoscope {
+
+LiveKeys live_keys;
+
+} // namespace kaleidoscope

--- a/src/kaleidoscope/LiveKeys.h
+++ b/src/kaleidoscope/LiveKeys.h
@@ -1,0 +1,57 @@
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2021  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "kaleidoscope/KeyAddr.h"
+#include "kaleidoscope/KeyMap.h"
+#include "kaleidoscope/key_defs.h"
+
+namespace kaleidoscope {
+
+class LiveKeys {
+ public:
+  const Key& operator[](KeyAddr key_addr) const {
+    return key_map_[key_addr];
+  }
+  Key& operator[](KeyAddr key_addr) {
+    return key_map_[key_addr];
+  }
+  void activate(KeyAddr key_addr, Key key) {
+    key_map_[key_addr] = key;
+  }
+  void clear(KeyAddr key_addr) {
+    key_map_[key_addr] = Key_Transparent;
+  }
+  void mask(KeyAddr key_addr) {
+    key_map_[key_addr] = Key_NoKey;
+  }
+  void clear() {
+    key_map_.clear();
+  }
+  KeyMap& all() {
+    return key_map_;
+  }
+
+ private:
+  KeyMap key_map_;
+};
+
+extern LiveKeys live_keys;
+
+//for (Key key : live_keys.all()) {}
+
+} // namespace kaleidoscope

--- a/src/kaleidoscope/Runtime.cpp
+++ b/src/kaleidoscope/Runtime.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/LiveKeys.h"
 #include "kaleidoscope/layers.h"
 #include "kaleidoscope/keyswitch_state.h"
 
@@ -41,6 +42,9 @@ Runtime_::setup(void) {
   kaleidoscope::Hooks::onSetup();
 
   device().setup();
+
+  // Clear the keyboard state array (all keys idle at start)
+  live_keys.clear();
 
   Layer.setup();
 }

--- a/src/kaleidoscope/event_handler_result.h
+++ b/src/kaleidoscope/event_handler_result.h
@@ -18,9 +18,33 @@
 
 namespace kaleidoscope {
 
+// This is the set of return values for event handlers. Event handlers for
+// plugins are called in sequence by the corresponding hook function, in plugin
+// initialization order. The interpretation of these return values can vary
+// based on the needs of the hook function, but should be as follows:
+//
+// - OK: Continue processing the event. The calling hook function should
+//       continue calling next event handler in the sequence. If all event
+//       handlers return `OK`, finish processing the event.
+//
+// - EVENT_CONSUMED: Stop processing event handlers. The calling hook function
+//       should not call any further handlers, but may continue to take some
+//       actions to finish processing the event. This should be used to indicate
+//       that the event has been successfully handled.
+//
+// - ABORT: Ignore the event. The calling hook function should not call any
+//       further handlers, and should treat the event as if it didn't
+//       happen. This should be used by plugin handlers that need to either
+//       suppress an event or queue the event in order to delay it.
+//
+// - ERROR: Undefined error. The calling hook function should not call any
+//       further handlers. There is currently no specification for what should
+//       happen if this is returned.
+
 enum class EventHandlerResult {
   OK,
   EVENT_CONSUMED,
+  ABORT,
   ERROR,
 };
 

--- a/src/kaleidoscope/key_events.cpp
+++ b/src/kaleidoscope/key_events.cpp
@@ -41,7 +41,7 @@ static bool handleSyntheticKeyswitchEvent(Key mappedKey, uint8_t keyState) {
   } else if (mappedKey.getFlags() & IS_INTERNAL) {
     return false;
   } else if (mappedKey.getFlags() & SWITCH_TO_KEYMAP) {
-    // Should not happen, handled elsewhere.
+    Layer.handleKeymapKeyswitchEvent(mappedKey, keyState);
   }
 
   return true;
@@ -124,6 +124,5 @@ void handleKeyswitchEvent(Key mappedKey, KeyAddr key_addr, uint8_t keyState) {
     return;
 
   // Handle all built-in key types.
-  Layer.eventHandler(mappedKey, key_addr, keyState);
   handleKeyswitchEventDefault(mappedKey, key_addr, keyState);
 }

--- a/src/kaleidoscope/keyswitch_state.h
+++ b/src/kaleidoscope/keyswitch_state.h
@@ -20,7 +20,6 @@
 #include <Arduino.h>
 
 #define INJECTED    B10000000
-#define EPHEMERAL   B01000000
 #define IS_PRESSED  B00000010
 #define WAS_PRESSED B00000001
 

--- a/src/kaleidoscope/layers.cpp
+++ b/src/kaleidoscope/layers.cpp
@@ -1,5 +1,5 @@
 /* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2018  Keyboard.io, Inc.
+ * Copyright (C) 2013-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -14,7 +14,8 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope_internal/device.h"
+#include "kaleidoscope/hooks.h"
 #include "kaleidoscope/layers.h"
 #include "kaleidoscope/keyswitch_state.h"
 
@@ -42,19 +43,15 @@ uint32_t Layer_::layer_state_;
 uint8_t Layer_::active_layer_count_ = 1;
 int8_t Layer_::active_layers_[31];
 
-Key Layer_::live_composite_keymap_[Runtime.device().numKeys()];
-uint8_t Layer_::active_layer_keymap_[Runtime.device().numKeys()];
+uint8_t Layer_::active_layer_keymap_[kaleidoscope_internal::device.numKeys()];
 Layer_::GetKeyFunction Layer_::getKey = &Layer_::getKeyFromPROGMEM;
 
 void Layer_::setup() {
   // Explicitly set layer 0's state to 1
   bitSet(layer_state_, 0);
 
-  // Update the keymap cache, so we start with a non-empty state.
+  // Update the active layer cache (every entry will be `0` to start)
   Layer.updateActiveLayers();
-  for (auto key_addr : KeyAddr::all()) {
-    Layer.updateLiveCompositeKeymap(key_addr);
-  }
 }
 
 void Layer_::handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState) {
@@ -113,24 +110,29 @@ void Layer_::handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState) {
 }
 
 Key Layer_::eventHandler(Key mappedKey, KeyAddr key_addr, uint8_t keyState) {
-  if (mappedKey.getFlags() != (SYNTHETIC | SWITCH_TO_KEYMAP))
-    return mappedKey;
-
-  handleKeymapKeyswitchEvent(mappedKey, keyState);
-  return Key_NoKey;
+  if (mappedKey.getFlags() == (SYNTHETIC | SWITCH_TO_KEYMAP))
+    handleKeymapKeyswitchEvent(mappedKey, keyState);
+  return mappedKey;
 }
 
 Key Layer_::getKeyFromPROGMEM(uint8_t layer, KeyAddr key_addr) {
   return keyFromKeymap(layer, key_addr);
 }
 
+// Deprecated
 void Layer_::updateLiveCompositeKeymap(KeyAddr key_addr) {
-  int8_t layer = active_layer_keymap_[key_addr.toInt()];
-  live_composite_keymap_[key_addr.toInt()] = (*getKey)(layer, key_addr);
+  // We could update the active keys cache here (as commented below), but I
+  // think that's unlikely to serve whatever purpose the caller had in
+  // mind. `Layer.lookup()` will still give the correct result, and without a
+  // `Key` value is specified, this function no longer serves a purpose.
+
+  // #include "kaleidoscope/LiveKeys.h"
+  // int8_t layer = active_layer_keymap_[key_addr.toInt()];
+  // live_keys.activate(key_addr, (*getKey)(layer, key_addr));
 }
 
 void Layer_::updateActiveLayers(void) {
-  memset(active_layer_keymap_, 0, Runtime.device().numKeys());
+  memset(active_layer_keymap_, 0, kaleidoscope_internal::device.numKeys());
   for (auto key_addr : KeyAddr::all()) {
     int8_t layer_index = active_layer_count_;
     while (layer_index > 0) {

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -111,6 +111,9 @@ class Layer_ {
   }
   static boolean isActive(uint8_t layer);
 
+  static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState);
+
+  DEPRECATED(LAYER_EVENTHANDLER)
   static Key eventHandler(Key mappedKey, KeyAddr key_addr, uint8_t keyState);
 
   typedef Key(*GetKeyFunction)(uint8_t layer, KeyAddr key_addr);
@@ -137,8 +140,6 @@ class Layer_ {
   static uint8_t active_layer_count_;
   static int8_t active_layers_[31];
   static uint8_t active_layer_keymap_[kaleidoscope_internal::device.numKeys()];
-
-  static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState);
 };
 }
 

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -1,5 +1,5 @@
 /* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2018  Keyboard.io, Inc.
+ * Copyright (C) 2013-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -20,6 +20,7 @@
 #include "kaleidoscope/key_defs.h"
 #include "kaleidoscope/keymaps.h"
 #include "kaleidoscope/device/device.h"
+#include "kaleidoscope/LiveKeys.h"
 #include "kaleidoscope_internal/device.h"
 #include "kaleidoscope_internal/sketch_exploration/sketch_exploration.h"
 #include "kaleidoscope_internal/shortname.h"
@@ -83,7 +84,13 @@ class Layer_ {
    * `lookupOnActiveLayer`.
    */
   static Key lookup(KeyAddr key_addr) {
-    return live_composite_keymap_[key_addr.toInt()];
+    // First check the keyboard state array
+    Key key = live_keys[key_addr];
+    // If that entry is clear, look up the entry from the active keymap layers
+    if (key == Key_Transparent) {
+      key = lookupOnActiveLayer(key_addr);
+    }
+    return key;
   }
   static Key lookupOnActiveLayer(KeyAddr key_addr) {
     uint8_t layer = active_layer_keymap_[key_addr.toInt()];
@@ -111,9 +118,11 @@ class Layer_ {
 
   static Key getKeyFromPROGMEM(uint8_t layer, KeyAddr key_addr);
 
+  DEPRECATED(LAYER_UPDATELIVECOMPOSITEKEYMAP)
   static void updateLiveCompositeKeymap(KeyAddr key_addr, Key mappedKey) {
-    live_composite_keymap_[key_addr.toInt()] = mappedKey;
+    live_keys.activate(key_addr, mappedKey);
   }
+  DEPRECATED(LAYER_UPDATELIVECOMPOSITEKEYMAP)
   static void updateLiveCompositeKeymap(KeyAddr key_addr);
   static void updateActiveLayers(void);
 
@@ -127,7 +136,6 @@ class Layer_ {
   static uint32_t layer_state_;
   static uint8_t active_layer_count_;
   static int8_t active_layers_[31];
-  static Key live_composite_keymap_[kaleidoscope_internal::device.numKeys()];
   static uint8_t active_layer_keymap_[kaleidoscope_internal::device.numKeys()];
 
   static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState);

--- a/src/kaleidoscope_internal/deprecations.h
+++ b/src/kaleidoscope_internal/deprecations.h
@@ -27,3 +27,10 @@
 
 /* Messages */
 
+#define _DEPRECATED_MESSAGE_LAYER_UPDATELIVECOMPOSITEKEYMAP             __NL__ \
+  "`Layer.updateLiveCompositeKeymap()` is deprecated.\n"                __NL__ \
+  "The 'live composite keymap' cache has been replaced with the\n"      __NL__ \
+  "'active keys' cache, which now represents the state of the active\n" __NL__ \
+  "keys at any given time. It is probably not necessary to directly\n"  __NL__ \
+  "update that cache from a plugin, but if you need to, please use\n"   __NL__ \
+  "the `live_keys.activate(key_addr, key)` function instead."

--- a/src/kaleidoscope_internal/deprecations.h
+++ b/src/kaleidoscope_internal/deprecations.h
@@ -34,3 +34,7 @@
   "keys at any given time. It is probably not necessary to directly\n"  __NL__ \
   "update that cache from a plugin, but if you need to, please use\n"   __NL__ \
   "the `live_keys.activate(key_addr, key)` function instead."
+
+#define _DEPRECATED_MESSAGE_LAYER_EVENTHANDLER               __NL__ \
+  "`Layer.eventHandler()` is deprecated.\n"                  __NL__ \
+  "Please use `Layer.handleKeymapKeyswitchEvent()` instead."

--- a/src/kaleidoscope_internal/event_dispatch.h
+++ b/src/kaleidoscope_internal/event_dispatch.h
@@ -80,7 +80,7 @@
 
 #define _REGISTER_EVENT_HANDLER(                                                 \
     HOOK_NAME, HOOK_VERSION, DEPRECATION_TAG,                                    \
-    SHOULD_ABORT_ON_CONSUMED_EVENT,                                              \
+    SHOULD_EXIT_IF_RESULT_NOT_OK,                                                \
     TMPL_PARAM_TYPE_LIST, TMPL_PARAM_LIST, TMPL_DUMMY_ARGS_LIST,                 \
     SIGNATURE, ARGS_LIST)                                                 __NL__ \
                                                                           __NL__ \
@@ -116,8 +116,8 @@
    MAKE_TEMPLATE_SIGNATURE(UNWRAP TMPL_PARAM_TYPE_LIST)                   __NL__ \
    struct _NAME4(EventHandler_, HOOK_NAME, _v, HOOK_VERSION) {            __NL__ \
                                                                           __NL__ \
-      static bool shouldAbortOnConsumedEvent() {                          __NL__ \
-        return SHOULD_ABORT_ON_CONSUMED_EVENT;                            __NL__ \
+      static bool shouldExitIfResultNotOk() {                             __NL__ \
+        return SHOULD_EXIT_IF_RESULT_NOT_OK;                              __NL__ \
       }                                                                   __NL__ \
                                                                           __NL__ \
       template<typename Plugin__,                                         __NL__ \
@@ -166,8 +166,8 @@
                                                                      __NL__ \
    result = EventHandler__::call(PLUGIN, hook_args...);              __NL__ \
                                                                      __NL__ \
-   if (EventHandler__::shouldAbortOnConsumedEvent() &&               __NL__ \
-       result == kaleidoscope::EventHandlerResult::EVENT_CONSUMED) { __NL__ \
+   if (EventHandler__::shouldExitIfResultNotOk() &&                  __NL__ \
+       result != kaleidoscope::EventHandlerResult::OK) {             __NL__ \
       return result;                                                 __NL__ \
    }                                                                 __NL__
 

--- a/tests/features/events/keyboard-state/macros/common.h
+++ b/tests/features/events/keyboard-state/macros/common.h
@@ -1,0 +1,27 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2021  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/tests/features/events/keyboard-state/macros/macros.ino
+++ b/tests/features/events/keyboard-state/macros/macros.ino
@@ -1,0 +1,82 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2021  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-Macros.h>
+
+#include "./common.h"
+
+#undef min
+#undef max
+#include <iostream>
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        Key_A, ___, ___, ___, ___, ___, ___,
+        ShiftToLayer(1), ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+    [1] = KEYMAP_STACKED
+    (
+        M(0), ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+const macro_t *macroAction(uint8_t index, uint8_t key_state) {
+  if (keyToggledOn(key_state)) {
+    switch (index) {
+    case 0:
+      Kaleidoscope.hid().keyboard().pressKey(Key_Y);
+      break;
+    }
+  }
+  return MACRO_NONE;
+}
+
+KALEIDOSCOPE_INIT_PLUGINS(Macros);
+
+void setup() {
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/features/events/keyboard-state/macros/sketch.json
+++ b/tests/features/events/keyboard-state/macros/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:virtual:model01",
+    "port": ""
+  }
+}

--- a/tests/features/events/keyboard-state/macros/test.ktest
+++ b/tests/features/events/keyboard-state/macros/test.ktest
@@ -1,0 +1,51 @@
+VERSION 1
+
+KEYSWITCH A 0 0
+KEYSWITCH LAYER_SHIFT 1 0
+
+# ==============================================================================
+# Keyboard state array
+NAME Keyboard state array cleared
+
+RUN 10 ms
+
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # Report should contain only `A`
+
+RUN 5 ms
+
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+
+RUN 5 ms
+
+# Press and hold `ShiftToLayer(1)`, changing the `A` key to `X`
+PRESS LAYER_SHIFT
+RUN 5 ms
+
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_Y # Report should contain only `Y`
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+
+RUN 5 ms
+
+RELEASE A
+
+RUN 5 ms
+
+RELEASE LAYER_SHIFT
+RUN 5 ms
+
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # Report should contain only `A`
+
+RUN 5 ms
+
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty

--- a/tests/features/events/keyboard-state/release-cleared/common.h
+++ b/tests/features/events/keyboard-state/release-cleared/common.h
@@ -1,0 +1,27 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2021  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/tests/features/events/keyboard-state/release-cleared/release-cleared.ino
+++ b/tests/features/events/keyboard-state/release-cleared/release-cleared.ino
@@ -1,0 +1,104 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2021  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+
+#include "./common.h"
+
+#undef min
+#undef max
+#include <iostream>
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        Key_A, ___, ___, ___, ___, ___, ___,
+        ShiftToLayer(1), ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+    [1] = KEYMAP_STACKED
+    (
+        Key_X, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+namespace kaleidoscope {
+namespace plugin {
+
+class ConvertXtoY : public kaleidoscope::Plugin {
+ public:
+  EventHandlerResult onKeyswitchEvent(Key &key, KeyAddr key_addr, uint8_t key_state) {
+    if (keyToggledOn(key_state)) {
+      if (key == Key_X)
+        key = Key_Y;
+    }
+    // It should be impossible to get a `Key_X` at this point, because the
+    // previous block changes any `Key_X` to `Key_Y`, which results in the
+    // active keys cache storing that value. On subsequent cycles (while the key
+    // is still pressed), the `key` value should be `Key_Y`.
+    if (keyIsPressed(key_state) && key == Key_X) {
+      std::cerr << "t=" << Runtime.millisAtCycleStart() << ": "
+                << "Error: we shouldn't see a key with value `X`" << std::endl;
+    }
+    // When `Key_Y` toggles off, return `EVENT_CONSUMED`. Despite this, the
+    // active keys cache entry should be cleared. If it's not, then a subsequent
+    // press of the same key without the layer shift in effect will still result
+    // in `Key_Y` instead of `Key_A`.
+    if (keyToggledOff(key_state) && (key == Key_Y)) {
+      return EventHandlerResult::EVENT_CONSUMED;
+    }
+    return EventHandlerResult::OK;
+  }
+};
+
+} // namespace plugin
+} // namespace kaleidoscope
+
+kaleidoscope::plugin::ConvertXtoY ConvertXtoY;
+
+KALEIDOSCOPE_INIT_PLUGINS(ConvertXtoY);
+
+void setup() {
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/features/events/keyboard-state/release-cleared/sketch.json
+++ b/tests/features/events/keyboard-state/release-cleared/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:virtual:model01",
+    "port": ""
+  }
+}

--- a/tests/features/events/keyboard-state/release-cleared/test.ktest
+++ b/tests/features/events/keyboard-state/release-cleared/test.ktest
@@ -1,0 +1,59 @@
+VERSION 1
+
+KEYSWITCH A 0 0
+KEYSWITCH LAYER_SHIFT 1 0
+
+# ==============================================================================
+# Keyboard state array
+NAME Keyboard state cleared
+
+RUN 10 ms
+
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # Report should contain only `A`
+
+RUN 5 ms
+
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+
+RUN 5 ms
+
+# Press and hold `ShiftToLayer(1)`, changing the `A` key to `X`
+PRESS LAYER_SHIFT
+RUN 5 ms
+
+# Press `X`, which gets converted to `Y` by the `ConvertXtoY` plugin defined in
+# the sketch. The plugin simply changes the value of the key, which causes it to
+# get set to `Key_Y` in the keyboard state array.
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_Y # Report should contain only `Y`
+
+RUN 5 ms
+
+# Release the `X` key (on Layer 1), which has become a `Y` key in the keyboard
+# state array. This should clear its entry.
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+
+RUN 5 ms
+
+# Release `ShiftToLayer(1)`. This should restore the `A` key to its base layer
+# value on subsequent presses, unless the Macros key gets "stuck" in the
+# keyboard state array because it returns `EVENT_CONSUMED`.
+RELEASE LAYER_SHIFT
+RUN 5 ms
+
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # Report should contain only `A`
+
+RUN 5 ms
+
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty

--- a/tests/issues/806/806.ino
+++ b/tests/issues/806/806.ino
@@ -1,0 +1,85 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-TapDance.h>
+
+#include "./common.h"
+
+#undef min
+#undef max
+#include <iostream>
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        Key_X, ___, ___, ___, ___, ___, ___,
+        TD(0), ___, ___, ___, ___, ___, ___,
+        LockLayer(1), ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+    [1] = KEYMAP_STACKED
+    (
+        Key_Y, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+void tapDanceAction(uint8_t tap_dance_index,
+                    KeyAddr key_addr,
+                    uint8_t tap_count,
+                    kaleidoscope::plugin::TapDance::ActionType tap_dance_action) {
+  switch (tap_dance_index) {
+  case 0:
+    return tapDanceActionKeys(tap_count, tap_dance_action,
+                              Key_A, LockLayer(1));
+  default:
+    break;
+  }
+}
+
+KALEIDOSCOPE_INIT_PLUGINS(TapDance);
+
+void setup() {
+  Kaleidoscope.setup();
+  TapDance.time_out = 25;
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/issues/806/common.h
+++ b/tests/issues/806/common.h
@@ -1,0 +1,27 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/tests/issues/806/sketch.json
+++ b/tests/issues/806/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:virtual:model01",
+    "port": ""
+  }
+}

--- a/tests/issues/806/test.ktest
+++ b/tests/issues/806/test.ktest
@@ -1,0 +1,24 @@
+VERSION 1
+
+KEYSWITCH X     0 0
+KEYSWITCH TD_0  1 0
+KEYSWITCH LL_1  2 0
+
+# ==============================================================================
+NAME TapDance hold past timeout
+
+RUN 5 ms
+
+PRESS TD_0
+RUN 1 cycle
+RUN 25 ms # timeout is 25 ms
+
+RUN 2 cycles
+EXPECT keyboard-report Key_A # The report should contain only `A`
+
+RUN 20 ms
+
+RELEASE TD_0
+RUN 1 cycle
+
+EXPECT keyboard-report empty # The report should be empty

--- a/tests/issues/922/922.ino
+++ b/tests/issues/922/922.ino
@@ -1,0 +1,72 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-TapDance.h>
+
+#include "./common.h"
+
+#undef min
+#undef max
+#include <iostream>
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        TD(0), TD(1), ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+void tapDanceAction(uint8_t tap_dance_index,
+                    KeyAddr key_addr,
+                    uint8_t tap_count,
+                    kaleidoscope::plugin::TapDance::ActionType tap_dance_action) {
+  switch (tap_dance_index) {
+  case 0:
+    return tapDanceActionKeys(tap_count, tap_dance_action,
+                              Key_A, Key_X);
+  case 1:
+    return tapDanceActionKeys(tap_count, tap_dance_action,
+                              Key_B, Key_Y);
+  default:
+    break;
+  }
+}
+
+KALEIDOSCOPE_INIT_PLUGINS(TapDance);
+
+void setup() {
+  Kaleidoscope.setup();
+  TapDance.time_out = 25;
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/issues/922/common.h
+++ b/tests/issues/922/common.h
@@ -1,0 +1,27 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/tests/issues/922/sketch.json
+++ b/tests/issues/922/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:virtual:model01",
+    "port": ""
+  }
+}

--- a/tests/issues/922/test.ktest
+++ b/tests/issues/922/test.ktest
@@ -1,0 +1,121 @@
+VERSION 1
+
+KEYSWITCH TD_0  0 0
+KEYSWITCH TD_1  0 1
+
+# ==============================================================================
+NAME TapDance to TapDance rollover left to right
+
+RUN 5 ms
+PRESS TD_0
+RUN 5 ms
+PRESS TD_1
+RUN 1 cycle
+EXPECT keyboard-report Key_A # TD_0 should be interrupted, yielding `A`
+RUN 4 ms
+RELEASE TD_0
+RUN 1 cycle
+EXPECT keyboard-report empty # Empty report on TD_0 release
+RUN 4 ms
+RELEASE TD_1
+RUN 18 ms
+EXPECT keyboard-report Key_B # TD_1 should time out, yielding `B`
+RUN 1 cycle
+EXPECT keyboard-report empty # Empty report after TD_1 timeout
+RUN 11 ms
+
+RUN 5 ms
+PRESS TD_0
+RUN 5 ms
+PRESS TD_1
+RUN 1 cycle
+EXPECT keyboard-report Key_A # TD_0 should be interrupted, yielding `A`
+RUN 4 ms
+RELEASE TD_0
+RUN 1 cycle
+EXPECT keyboard-report empty # Empty report on TD_0 release
+RUN 4 ms
+RELEASE TD_1
+RUN 18 ms
+EXPECT keyboard-report Key_B # TD_1 should time out, yielding `B`
+RUN 1 cycle
+EXPECT keyboard-report empty # Empty report after TD_1 timeout
+RUN 11 ms
+
+# ==============================================================================
+NAME TapDance to TapDance rollover right to left
+
+RUN 5 ms
+PRESS TD_1
+RUN 5 ms
+PRESS TD_0
+RUN 1 cycle
+EXPECT keyboard-report Key_B # TD_1 should be interrupted, yielding `B`
+RUN 4 ms
+RELEASE TD_1
+RUN 1 cycle
+EXPECT keyboard-report empty # Empty report on TD_1 release
+RUN 4 ms
+RELEASE TD_0
+RUN 18 ms
+EXPECT keyboard-report Key_A # TD_0 should time out, yielding `A`
+RUN 1 cycle
+EXPECT keyboard-report empty # Empty report after TD_0 timeout
+RUN 11 ms
+
+RUN 5 ms
+PRESS TD_1
+RUN 5 ms
+PRESS TD_0
+RUN 1 cycle
+EXPECT keyboard-report Key_B # TD_1 should be interrupted, yielding `B`
+RUN 4 ms
+RELEASE TD_1
+RUN 1 cycle
+EXPECT keyboard-report empty # Empty report on TD_1 release
+RUN 4 ms
+RELEASE TD_0
+RUN 18 ms
+EXPECT keyboard-report Key_A # TD_0 should time out, yielding `A`
+RUN 1 cycle
+EXPECT keyboard-report empty # Empty report after TD_0 timeout
+RUN 11 ms
+
+# ==============================================================================
+NAME TapDance to TapDance rollover back and forth
+
+RUN 5 ms
+PRESS TD_0
+RUN 5 ms
+PRESS TD_1
+RUN 1 cycle
+EXPECT keyboard-report Key_A # TD_0 should be interrupted, yielding `A`
+RUN 4 ms
+RELEASE TD_0
+RUN 1 cycle
+EXPECT keyboard-report empty # Empty report on TD_0 release
+RUN 4 ms
+RELEASE TD_1
+RUN 18 ms
+EXPECT keyboard-report Key_B # TD_1 should time out, yielding `B`
+RUN 1 cycle
+EXPECT keyboard-report empty # Empty report after TD_1 timeout
+RUN 11 ms
+
+RUN 5 ms
+PRESS TD_1
+RUN 5 ms
+PRESS TD_0
+RUN 1 cycle
+EXPECT keyboard-report Key_B # TD_1 should be interrupted, yielding `B`
+RUN 4 ms
+RELEASE TD_1
+RUN 1 cycle
+EXPECT keyboard-report empty # Empty report on TD_1 release
+RUN 4 ms
+RELEASE TD_0
+RUN 18 ms
+EXPECT keyboard-report Key_A # TD_0 should time out, yielding `A`
+RUN 1 cycle
+EXPECT keyboard-report empty # Empty report after TD_0 timeout
+RUN 11 ms

--- a/tests/issues/980/980.ino
+++ b/tests/issues/980/980.ino
@@ -1,0 +1,85 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-TapDance.h>
+
+#include "./common.h"
+
+#undef min
+#undef max
+#include <iostream>
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        Key_X, ___, ___, ___, ___, ___, ___,
+        TD(0), ___, ___, ___, ___, ___, ___,
+        LockLayer(1), ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+    [1] = KEYMAP_STACKED
+    (
+        Key_Y, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+void tapDanceAction(uint8_t tap_dance_index,
+                    KeyAddr key_addr,
+                    uint8_t tap_count,
+                    kaleidoscope::plugin::TapDance::ActionType tap_dance_action) {
+  switch (tap_dance_index) {
+  case 0:
+    return tapDanceActionKeys(tap_count, tap_dance_action,
+                              Key_A, LockLayer(1));
+  default:
+    break;
+  }
+}
+
+KALEIDOSCOPE_INIT_PLUGINS(TapDance);
+
+void setup() {
+  Kaleidoscope.setup();
+  TapDance.time_out = 25;
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/issues/980/common.h
+++ b/tests/issues/980/common.h
@@ -1,0 +1,27 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/tests/issues/980/sketch.json
+++ b/tests/issues/980/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:virtual:model01",
+    "port": ""
+  }
+}

--- a/tests/issues/980/test.ktest
+++ b/tests/issues/980/test.ktest
@@ -1,0 +1,69 @@
+VERSION 1
+
+KEYSWITCH X     0 0
+KEYSWITCH TD_0  1 0
+KEYSWITCH LL_1  2 0
+
+# ==============================================================================
+NAME TapDance issue 980 no overlap
+
+RUN 5 ms
+
+PRESS TD_0
+RUN 5 ms
+RELEASE TD_0
+RUN 10 ms
+
+PRESS TD_0
+RUN 5 ms
+
+RELEASE TD_0
+RUN 5 ms
+
+PRESS X
+RUN 2 cycles
+EXPECT keyboard-report Key_Y # The key should be mapped from layer 1 (Y), not layer 0 (X)
+RUN 5 ms
+
+RELEASE X
+RUN 1 cycle
+EXPECT keyboard-report empty # The report should be empty
+RUN 5 ms
+
+PRESS LL_1
+RUN 1 cycle
+
+RELEASE LL_1
+RUN 1 cycle
+
+# ==============================================================================
+NAME TapDance issue 980 rollover
+
+RUN 5 ms
+
+PRESS TD_0
+RUN 5 ms
+RELEASE TD_0
+RUN 10 ms
+
+PRESS TD_0
+RUN 5 ms
+
+PRESS X
+RUN 2 cycles
+EXPECT keyboard-report Key_Y # The key should be mapped from layer 1 (Y), not layer 0 (X)
+RUN 5 ms
+
+RELEASE TD_0
+RUN 5 ms
+
+RELEASE X
+RUN 1 cycle
+EXPECT keyboard-report empty # The report should be empty
+RUN 5 ms
+
+PRESS LL_1
+RUN 1 cycle
+
+RELEASE LL_1
+RUN 1 cycle

--- a/tests/plugins/TapDance/basic/test.ktest
+++ b/tests/plugins/TapDance/basic/test.ktest
@@ -20,8 +20,8 @@ RUN 5 ms
 PRESS X
 RUN 1 cycle
 EXPECT keyboard-report Key_B # The report should contain `B`
-EXPECT keyboard-report empty # Report should be empty
 RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
 EXPECT keyboard-report Key_X # Report should contain `X`
 
 RUN 5 ms
@@ -47,59 +47,57 @@ RUN 20 ms # Timeout = 25ms
 
 RUN 2 ms # Extra 2 cycles for some reason
 EXPECT keyboard-report Key_B # The report should contain `B`
+RUN 1 cycle
 EXPECT keyboard-report empty # Report should be empty
 
 # ==============================================================================
-# The testcases below are commented out because they are currently failing.
+NAME Tapdance interrupt with rollover
 
-# # ==============================================================================
-# NAME Tapdance interrupt with rollover
+RUN 5 ms
+PRESS TD_0
+RUN 5 ms
+RELEASE TD_0
 
-# RUN 5 ms
-# PRESS TD_0
-# RUN 5 ms
-# RELEASE TD_0
+RUN 10 ms
+PRESS TD_0
 
-# RUN 10 ms
-# PRESS TD_0
+RUN 5 ms
+PRESS X
+RUN 1 cycle
+EXPECT keyboard-report Key_B # The report should contain `B`
+RUN 1 cycle
+EXPECT keyboard-report Key_B Key_X # Report should contain `B` & `X`
 
-# RUN 5 ms
-# PRESS X
-# RUN 1 cycle
-# EXPECT keyboard-report Key_B # The report should contain `B`
-# RUN 1 cycle
-# EXPECT keyboard-report Key_B Key_X # Report should contain `B` & `X`
-
-# RUN 5 ms
-# RELEASE TD_0
-# RUN 1 cycle
-# EXPECT keyboard-report Key_X # Report should contain `X`
+RUN 5 ms
+RELEASE TD_0
+RUN 1 cycle
+EXPECT keyboard-report Key_X # Report should contain `X`
 
 
-# RUN 5 ms
-# RELEASE X
-# RUN 1 cycle
-# EXPECT keyboard-report empty # Report should be empty
+RUN 5 ms
+RELEASE X
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
 
-# # ==============================================================================
-# NAME Tapdance timeout while held
+# ==============================================================================
+NAME Tapdance timeout while held
 
-# RUN 5 ms
+RUN 5 ms
 
-# PRESS TD_0
-# RUN 5 ms
-# RELEASE TD_0
-# RUN 10 ms
+PRESS TD_0
+RUN 5 ms
+RELEASE TD_0
+RUN 10 ms
 
-# PRESS TD_0
-# RUN 1 cycle
-# RUN 25 ms
+PRESS TD_0
+RUN 1 cycle
+RUN 25 ms
 
-# RUN 2 cycles
-# EXPECT keyboard-report Key_B # The report should contain `B`
+RUN 2 cycles
+EXPECT keyboard-report Key_B # The report should contain `B`
 
-# RUN 10 ms
-# RELEASE TD_0
-# RUN 1 cycle
+RUN 10 ms
+RELEASE TD_0
+RUN 1 cycle
 
-# EXPECT keyboard-report empty # Report should be empty
+EXPECT keyboard-report empty # Report should be empty


### PR DESCRIPTION
## Summary

This PR introduces a new data structure that represents the full current state of the keyboard. It is implemented as an array of `Key` objects, indexed by `KeyAddr`, one per physical keyswitch on the keyboard. For each key position, the value will either be `Key_Transparent` for a key that is "off" or "idle", or it will contain the current `Key` value that the key is set to, most likely looked up from the keymap, but possibly overridden by a plugin.

Without any active plugins, the keyboard state array will mirror the state of the physical keyswitches. When a keyswitch toggles on, its entry in the array will take on that key's value from the keymap. When it toggles off, it will get the value `Key_Transparent`.

Active plugins will be able to use this structure to make the _logical_ representation of the keyboard state differ from the _physical_ state of the keyswitches. In particular, this will make it easier for a plugin to delay the activation of a keyswitch that toggles on, and to keep a key active after its keyswitch toggles off.

## Event-driven firmware (phase one)

This is the first step toward a version of Kaleidoscope that is truly event-driven, and I think that it is important to understand it in that context. Ultimately, the plan is to make extensive changes to Kaleidoscope's main loop that will improve performance and both simplicity and reliability of plugins.

A full keyswitch scan will be done each cycle, as before, but rather than calling the full set of plugin "event" handlers for each active keyswitch in sequence and building a new HID report along the way, then calling the pre-report handlers and sending the resulting report, it will respond to each keyswitch state change. Each time one toggles on or off, it will call plugin event handlers for that event. If a plugin needs information about other keys that are active, it can then consult the keyboard state array, which—unlike the HID report—is always complete and accurate. Once the event handlers are done, a new HID report will be constructed from the information in the keyboard state array (newly updated as a result of the event processing), and then the pre-report handlers called, and the report sent.

At that point, the scan will continue, so that if a second event is detected in the same cycle, it will be handled independently, and a second report sent without the need for plugins to be concerned about any corner case bugs that could be triggered by "simultaneous" keyswitch events.

This new main loop would obviate the need for re-processing keyswitches that are still held every cycle, and result in a substantial reduction in unnecessary rebuilding of the same report, only to have it suppressed by the HID module after all the work is done.

It will also make it much clearer which handler function should be used for any given task that a plugin needs to accomplish. Right now, there are quite a few plugins that use the `beforeReportingState()` handler in order to do things like check timeouts, because this function gets called once per cycle. If it gets changed to once per HID report (attempt), it's more obviously decoupled from the scan cycle, as it should be.

## A HID report is inadequate for recording state

Until this PR, Kaleidoscope has used the keyboard HID report as a mechanism for recording the state of the keyboard, and this has been problematic at best. First of all, though that report does accurately reflect the state of a non-programmable keyboard (with very minor exceptions), where each key sends one and only one unique keycode, it is inadequate to record the full state of a Kaleidoscope-powered keyboard, even if we disregard layer keys and other special `Key` values not used directly in the keyboard HID report. Keys with modifier flags complicate things quite a bit, as do duplicate keys (modifiers are probably most common, but not the only one: Redial is the most likely example I can think of, but there may well be keymaps out there with multiple <kbd>space</kbd> or <kbd>E</kbd> keys.) This is, of course, why the HID report gets cleared and re-constructed every cycle.

With a full keyboard state array, it becomes much easier to track the information that a plugin needs. For example, if the left shift keycode is active in the HID report (and a plugin would need to check the _old_ HID report, of course), it's not possible for a plugin to know from that whether that `shift` came from a key with a modifier flag (e.g. `LSHIFT(Key_X)`) or from a modifier-only key (e.g. `Key_LeftShift` or `Key_Meh`) — or both. The keyboard state array makes this straightforward to check, simplifying plugin design, and reducing the likelihood of bugs.

## The old keymap cache

The existing live composite keymap is a cache of values from the keymap, so that a full lookup down the layer stack isn't necessary for every active keyswitch in every cycle. Since the keyboard state array must be checked before the keymap, in case a plugin has altered the value of an active key, the live composite keymap becomes redundant in the vast majority of calls, and would only save lookups on key toggle on events for keys that have already been pressed once since the last layer change. These are rare enough that it not longer makes sense to keep this cache.

[Note: When I originally created this PR (and, indeed, when I first got the idea during the design stage for writing Kaleidoglyph), I had realized that it would make sense to convert the live composite keymap into a representation of the keyboard state, and so I thought about it as a re-purposing of an existing structure. I think this has caused a great deal of confusion, so I'm trying to avoid that trap again. Both the keymap cache and the keyboard state array have the same basic structure, and even similar contents and update times and mechanisms, but it's vital that we not think of them as being that closely related. The keyboard state array is _not_ a keymap cache.]

---

### Original PR description

~~This converts `Layer.live_composite_keymap_[]` from a simple cache to a representation of the keyboard's current state. Barring plugin activity, an idle key will have the value `Key_Transparent`, and a pressed key will have the value of whatever key it's currently mapped to in the keymap. A value of `Key_NoKey` will mask that key until it is released.~~

~~This change will allow plugins to deliberately alter the keymap cache by calling either `Layer.updateLiveCompositeKeymap()` directly or by calling `handleKeyswitchEvent()` with a specified `Key` value other than `Key_NoKey` or `Key_Transparent`. It also means that a plugin can abort the clearing of a cache entry for a released key by returning `EVENT_CONSUMED`. This will allow OneShot layer shift keys to become sticky even if there is another key mapped to that address on the target layer, for example.~~

~~I'm submitting this as a separate PR from the rewrite I just did of OneShot in order to call more attention to this change, which might impact other keystroke-handling plugins (other than OneShot, Escape-OneShot, Qukeys, and ActiveModColor). TapDance and Leader come to mind as plugins that would need some checking, and there may be others that I'm even less familiar with. The main thing to look out for is places where `EVENT_CONSUMED` is returned for keys that toggled off, and calls to `handleKeyswitchEvent()` that supply both (non-blank) `Key` and (valid) `KeyAddr` arguments.~~