### PR TITLE
testing: Build and run the tests separately

### DIFF
--- a/testing/makefiles/testcase.mk
+++ b/testing/makefiles/testcase.mk
@@ -21,6 +21,8 @@ else
 bundle_path = ${BOARD_HARDWARE_PATH}/keyboardio/avr/libraries
 endif
 
+build: ${BIN_DIR}/${BIN_FILE}
+
 all: run
 
 run: ${BIN_DIR}/${BIN_FILE}
@@ -76,4 +78,4 @@ ${OBJ_DIR}/%.o: ${SRC_DIR}/%.cpp
 clean:
 	rm -rf "${build_dir}"
 
-.PHONY: clean run all
+.PHONY: clean run all build

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,6 +8,9 @@ TESTS			?= $(shell find . -name 'sketch.ino' -exec dirname {} \;)
 .PHONY: clean cmake-clean all googletest
 
 all: ${TESTS}
+	@for test in ${TESTS}; do \
+		${MAKE} -s -f ${top_dir}/testing/makefiles/testcase.mk -C $${test} top_dir=${top_dir} testcase=$${test} run; \
+	done
 
 cmake-clean:
 	-${MAKE} clean
@@ -28,5 +31,8 @@ ${libcommon_a}:
 Makefile:
 	@:
 
-%: ${libcommon_a} googletest
+${TESTS}: ${libcommon_a} googletest
 	${MAKE} -f ${top_dir}/testing/makefiles/testcase.mk -C $@ top_dir=${top_dir} testcase=$@
+
+%+run:
+	${MAKE} -s -f ${top_dir}/testing/makefiles/testcase.mk -C $* top_dir=${top_dir} testcase=$* run


### PR DESCRIPTION
Instead of running the tests right after compiling them, compile them all first, then run them one after another. This way the test output is kept much closer together, which is easier to glance over.