### PR TITLE
Make compilation warning-free, and the source cpplint-clean

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - ln -s $(pwd) ../hardware/keyboardio/avr/libraries/Kaleidoscope
 script:
   - unset CC
+  - make cpplint BOARD_HARDWARE_PATH=$(pwd)/../hardware
   - make travis-install-arduino BOARD_HARDWARE_PATH=$(pwd)/../hardware
   - (cd ../hardware/keyboardio && make prepare-virtual)
   - make -C tests all BOARD_HARDWARE_PATH=$(pwd)/../hardware ARDUINO_PATH="$(pwd)/arduino-1.8.13"

--- a/examples/Internal/Sketch_Exploration/Sketch_Exploration.ino
+++ b/examples/Internal/Sketch_Exploration/Sketch_Exploration.ino
@@ -44,7 +44,7 @@ KEYMAPS(
 )
 /* *INDENT-ON* */
 
-using namespace kaleidoscope::sketch_exploration;
+using namespace kaleidoscope::sketch_exploration; // NOLINT(build/namespaces)
 
 class BPlugin : public kaleidoscope::Plugin {};
 class CPlugin : public kaleidoscope::Plugin {};

--- a/src/kaleidoscope/MatrixAddr.h
+++ b/src/kaleidoscope/MatrixAddr.h
@@ -57,8 +57,8 @@ class MatrixAddr {
   //       ridiculously bad assembler code for each copy construction,
   //       that would bloat the default firmware by 1K of PROGMEM!
   //
-  constexpr MatrixAddr(const ThisType &other) = default;
-  constexpr MatrixAddr(ThisType &&other) = default;
+  constexpr MatrixAddr(const ThisType &other) = default; // NOLINT(runtime/explicit)
+  constexpr MatrixAddr(ThisType &&other) = default; // NOLINT(runtime/explicit)
   //constexpr MatrixAddr(const ThisType &other) : offset_(other.offset_) {}
   //constexpr MatrixAddr(ThisType &&other) : offset_(other.offset_) {}
 

--- a/src/kaleidoscope/MatrixAddr.h
+++ b/src/kaleidoscope/MatrixAddr.h
@@ -47,7 +47,7 @@ class MatrixAddr {
   constexpr MatrixAddr(uint8_t row, uint8_t col)
     : offset_(row * cols + col) {}
 
-  constexpr MatrixAddr(uint8_t offset)
+  explicit constexpr MatrixAddr(uint8_t offset)
     : offset_(offset) {}
 
   // Rely on the default copy and move constructor.
@@ -57,8 +57,8 @@ class MatrixAddr {
   //       ridiculously bad assembler code for each copy construction,
   //       that would bloat the default firmware by 1K of PROGMEM!
   //
-  constexpr MatrixAddr(const ThisType &other) = default;
-  constexpr MatrixAddr(ThisType &&other) = default;
+  explicit constexpr MatrixAddr(const ThisType &other) = default;
+  explicit constexpr MatrixAddr(ThisType &&other) = default;
   //constexpr MatrixAddr(const ThisType &other) : offset_(other.offset_) {}
   //constexpr MatrixAddr(ThisType &&other) : offset_(other.offset_) {}
 
@@ -66,8 +66,7 @@ class MatrixAddr {
   ThisType &operator=(ThisType &&) = default;
 
   template<typename MatrixAddr__>
-  explicit
-  constexpr MatrixAddr(const MatrixAddr__ &other)
+  explicit constexpr MatrixAddr(const MatrixAddr__ &other)
     : MatrixAddr(other.row(), other.col()) {
     static_assert(MatrixAddr__::rows <= ThisType::rows,
                   "Matrix type conversion failed. Source type must not have greater row size than target type");

--- a/src/kaleidoscope/MatrixAddr.h
+++ b/src/kaleidoscope/MatrixAddr.h
@@ -47,7 +47,7 @@ class MatrixAddr {
   constexpr MatrixAddr(uint8_t row, uint8_t col)
     : offset_(row * cols + col) {}
 
-  constexpr MatrixAddr(uint8_t offset)
+  explicit constexpr MatrixAddr(uint8_t offset)
     : offset_(offset) {}
 
   // Rely on the default copy and move constructor.

--- a/src/kaleidoscope/MatrixAddr.h
+++ b/src/kaleidoscope/MatrixAddr.h
@@ -47,7 +47,7 @@ class MatrixAddr {
   constexpr MatrixAddr(uint8_t row, uint8_t col)
     : offset_(row * cols + col) {}
 
-  explicit constexpr MatrixAddr(uint8_t offset)
+  constexpr MatrixAddr(uint8_t offset)
     : offset_(offset) {}
 
   // Rely on the default copy and move constructor.
@@ -57,8 +57,8 @@ class MatrixAddr {
   //       ridiculously bad assembler code for each copy construction,
   //       that would bloat the default firmware by 1K of PROGMEM!
   //
-  explicit constexpr MatrixAddr(const ThisType &other) = default;
-  explicit constexpr MatrixAddr(ThisType &&other) = default;
+  constexpr MatrixAddr(const ThisType &other) = default;
+  constexpr MatrixAddr(ThisType &&other) = default;
   //constexpr MatrixAddr(const ThisType &other) : offset_(other.offset_) {}
   //constexpr MatrixAddr(ThisType &&other) : offset_(other.offset_) {}
 

--- a/src/kaleidoscope/bitfields.h
+++ b/src/kaleidoscope/bitfields.h
@@ -113,7 +113,7 @@ class Bitfield : public internal::_BaseBitfield {
   static constexpr size_t n_bytes_ = nBytesForBits(BitCount__);
 
   template<typename ... Bits__>
-  constexpr Bitfield(Bits__...bits) : bits_(bits...) {
+  explicit constexpr Bitfield(Bits__...bits) : bits_(bits...) {
     static_assert(sizeof...(Bits__) == n_bits_,
                   "Invalid number of bits supplied to Bitfield<BitCount__> constructor. \n"
                   "Compare the number of bits supplied with the provided template \n"

--- a/src/kaleidoscope/bitfields.h
+++ b/src/kaleidoscope/bitfields.h
@@ -113,7 +113,7 @@ class Bitfield : public internal::_BaseBitfield {
   static constexpr size_t n_bytes_ = nBytesForBits(BitCount__);
 
   template<typename ... Bits__>
-  explicit constexpr Bitfield(Bits__...bits) : bits_(bits...) {
+  constexpr Bitfield(Bits__...bits) : bits_(bits...) {
     static_assert(sizeof...(Bits__) == n_bits_,
                   "Invalid number of bits supplied to Bitfield<BitCount__> constructor. \n"
                   "Compare the number of bits supplied with the provided template \n"

--- a/src/kaleidoscope/device/dygma/Raise.cpp
+++ b/src/kaleidoscope/device/dygma/Raise.cpp
@@ -274,22 +274,24 @@ void RaiseKeyScanner::readMatrix() {
   if (RaiseHands::leftHand.readKeys()) {
     leftHandState = RaiseHands::leftHand.getKeyData();
     // if ANSI, then swap r3c0 and r3c1 to match the PCB
-    if (RaiseHands::layout == LAYOUT_ANSI)
+    if (RaiseHands::layout == LAYOUT_ANSI) {
       // only swap if bits are different
       if ((leftHandState.rows[3] & (1 << 0)) ^ leftHandState.rows[3] & (1 << 1)) {
         leftHandState.rows[3] ^= (1 << 0); // flip the bit
         leftHandState.rows[3] ^= (1 << 1); // flip the bit
       }
+    }
   }
 
   if (RaiseHands::rightHand.readKeys()) {
     rightHandState = RaiseHands::rightHand.getKeyData();
     // if ANSI, then swap r1c0 and r2c0 to match the PCB
-    if (RaiseHands::layout == LAYOUT_ANSI)
+    if (RaiseHands::layout == LAYOUT_ANSI) {
       if ((rightHandState.rows[1] & (1 << 0)) ^ rightHandState.rows[2] & (1 << 0)) {
         rightHandState.rows[1] ^= (1 << 0);
         rightHandState.rows[2] ^= (1 << 0);
       }
+    }
   }
 
   // if a side has just been replugged, initialise it

--- a/src/kaleidoscope/device/dygma/raise/Focus.cpp
+++ b/src/kaleidoscope/device/dygma/raise/Focus.cpp
@@ -48,7 +48,7 @@ EventHandlerResult Focus::onFocusEvent(const char *command) {
     return EventHandlerResult::EVENT_CONSUMED;
   }
 
-  if (strcmp_P(command + 9, PSTR("side_power")) == 0)
+  if (strcmp_P(command + 9, PSTR("side_power")) == 0) {
     if (::Focus.isEOL()) {
       ::Focus.send(Runtime.device().side.getPower());
       return EventHandlerResult::EVENT_CONSUMED;
@@ -58,6 +58,7 @@ EventHandlerResult Focus::onFocusEvent(const char *command) {
       Runtime.device().side.setPower(power);
       return EventHandlerResult::EVENT_CONSUMED;
     }
+  }
 
   if (strcmp_P(command + 9, PSTR("side_ver")) == 0) {
     ::Focus.send("left:");
@@ -83,7 +84,7 @@ EventHandlerResult Focus::onFocusEvent(const char *command) {
     return EventHandlerResult::EVENT_CONSUMED;
   }
 
-  if (strcmp_P(command + 9, PSTR("sled_current")) == 0)
+  if (strcmp_P(command + 9, PSTR("sled_current")) == 0) {
     if (::Focus.isEOL()) {
       ::Focus.send("left:");
       ::Focus.send(Runtime.device().side.leftSLEDCurrent());
@@ -96,6 +97,7 @@ EventHandlerResult Focus::onFocusEvent(const char *command) {
       Runtime.device().side.setSLEDCurrent(current);
       return EventHandlerResult::EVENT_CONSUMED;
     }
+  }
 
   if (strcmp_P(command + 9, PSTR("layout")) == 0) {
     static const auto ANSI = Runtime.device().settings.Layout::ANSI;

--- a/src/kaleidoscope/device/dygma/raise/Hand.h
+++ b/src/kaleidoscope/device/dygma/raise/Hand.h
@@ -56,7 +56,7 @@ typedef union {
 
 class Hand {
  public:
-  Hand(byte ad01) : ad01_(ad01), twi_(i2c_addr_base_ | ad01) {}
+  explicit Hand(byte ad01) : ad01_(ad01), twi_(i2c_addr_base_ | ad01) {}
 
   int readVersion();
   int readSLEDVersion();

--- a/src/kaleidoscope/device/dygma/raise/TWI.h
+++ b/src/kaleidoscope/device/dygma/raise/TWI.h
@@ -27,7 +27,7 @@ namespace raise {
 
 class TWI {
  public:
-  TWI(int addr) : addr_(addr), crc_errors_(0) {};
+  TWI(int addr) : addr_(addr), crc_errors_(0) {}
 
   uint8_t writeTo(uint8_t *data, size_t length);
   uint8_t readFrom(uint8_t* data, size_t length);

--- a/src/kaleidoscope/device/dygma/raise/TWI.h
+++ b/src/kaleidoscope/device/dygma/raise/TWI.h
@@ -16,6 +16,8 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #ifdef ARDUINO_SAMD_RAISE
 
 #include <Arduino.h>

--- a/src/kaleidoscope/device/dygma/raise/TWI.h
+++ b/src/kaleidoscope/device/dygma/raise/TWI.h
@@ -27,7 +27,7 @@ namespace raise {
 
 class TWI {
  public:
-  TWI(int addr) : addr_(addr), crc_errors_(0) {}
+  explicit TWI(int addr) : addr_(addr), crc_errors_(0) {}
 
   uint8_t writeTo(uint8_t *data, size_t length);
   uint8_t readFrom(uint8_t* data, size_t length);

--- a/src/kaleidoscope/device/keyboardio/Imago.cpp
+++ b/src/kaleidoscope/device/keyboardio/Imago.cpp
@@ -159,7 +159,7 @@ void ImagoLEDDriver::syncLeds() {
   twi_writeTo(LED_DRIVER_ADDR, data, LED_REGISTER_DATA0_SIZE + 1, 1, 0);
 
   // Don't reset "Last LED", because this is just us picking up from the last bank
-  // TODO - we don't use all 117 LEDs on the Imago, so we can probably stop writing earlier
+  // TODO(anyone) - we don't use all 117 LEDs on the Imago, so we can probably stop writing earlier
   // Write the second LED bank
 
   // For space efficiency, we reuse the LED sending buffer

--- a/src/kaleidoscope/device/keyboardio/Model01.cpp
+++ b/src/kaleidoscope/device/keyboardio/Model01.cpp
@@ -48,9 +48,6 @@ KeyboardioScanner Model01Hands::leftHand(0);
 KeyboardioScanner Model01Hands::rightHand(3);
 
 void Model01Hands::setup(void) {
-  // TODO: Consider not doing this until 30s after keyboard
-  // boot up, to make it easier to rescue things in case of power draw issues.
-
   // This lets the keyboard pull up to 1.6 amps from the host.
   // That violates the USB spec. But it sure is pretty looking
   DDRE |= _BV(6);

--- a/src/kaleidoscope/device/keyboardio/twi.h
+++ b/src/kaleidoscope/device/keyboardio/twi.h
@@ -16,10 +16,9 @@
   with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef __AVR__
+#pragma once
 
-#ifndef twi_h
-#define twi_h
+#ifdef __AVR__
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
@@ -55,5 +54,4 @@ void twi_stop(void);
 void twi_releaseBus(void);
 
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-#endif
 #endif

--- a/src/kaleidoscope/device/virtual/DefaultHIDReportConsumer.cpp
+++ b/src/kaleidoscope/device/virtual/DefaultHIDReportConsumer.cpp
@@ -29,7 +29,7 @@
 
 namespace kaleidoscope {
 
-using namespace logging;
+using namespace logging; // NOLINT(build/namespaces)
 
 // For each bit set in 'bitfield', output the corresponding string to 'stream'
 #define FOREACHBIT(bitfield, stream, str0, str1, str2, str3, str4, str5, str6, str7) \

--- a/src/kaleidoscope/device/virtual/Virtual.cpp
+++ b/src/kaleidoscope/device/virtual/Virtual.cpp
@@ -206,7 +206,7 @@ void VirtualKeyScanner::readMatrix() {
           }
         }
       } else {
-        // TODO: Is there a device independent
+        // TODO(anyone): Is there a device independent
         //       way to determine KeyAddr from key names?
 //         key_addr = getRCfromPhysicalKey(token);
 //

--- a/src/kaleidoscope/device/virtual/Virtual.cpp
+++ b/src/kaleidoscope/device/virtual/Virtual.cpp
@@ -53,7 +53,7 @@ namespace kaleidoscope {
 namespace device {
 namespace virt {
 
-using namespace kaleidoscope::logging;
+using namespace kaleidoscope::logging; // NOLINT(build/namespaces)
 
 //##############################################################################
 // VirtualKeyScanner

--- a/src/kaleidoscope/device/virtual/Virtual.cpp
+++ b/src/kaleidoscope/device/virtual/Virtual.cpp
@@ -167,9 +167,11 @@ void VirtualKeyScanner::readMatrix() {
     std::string token;
     std::getline(sline, token, ' ');
 
-    if (token == "") break;   // end of line
-    else if (token == "#") break;   // skip the rest of the line
-    else if ((token == "?" || token == "help") && isInteractive()) {
+    if (token == "") {
+      break;   // end of line
+    } else if (token == "#") {
+      break;   // skip the rest of the line
+    } else if ((token == "?" || token == "help") && isInteractive()) {
       printHelp();
     } else if (token == "Q") {
       exit(0);

--- a/src/kaleidoscope/device/virtual/Virtual.cpp
+++ b/src/kaleidoscope/device/virtual/Virtual.cpp
@@ -360,7 +360,7 @@ void VirtualLEDDriver::syncLeds() {
 }
 
 void VirtualLEDDriver::setCrgbAt(uint8_t i, cRGB color) {
-  if ((int)i >= (int)led_count) {
+  if (static_cast<int>(i) >= static_cast<int>(led_count)) {
     log_error("Virtual::setCrgbAt: Index %d out of bounds\n", i);
     return;
   }
@@ -368,7 +368,7 @@ void VirtualLEDDriver::setCrgbAt(uint8_t i, cRGB color) {
 }
 
 cRGB VirtualLEDDriver::getCrgbAt(uint8_t i) const {
-  if ((int)i >= (int)led_count) {
+  if (static_cast<int>(i) >= static_cast<int>(led_count)) {
     log_error("Virtual::getCrgbAt: Index %d out of bounds\n", i);
     return CRGB(0, 0, 0);
   }

--- a/src/kaleidoscope/device/virtual/Virtual.h
+++ b/src/kaleidoscope/device/virtual/Virtual.h
@@ -86,10 +86,10 @@ class VirtualKeyScanner
 
   bool read_matrix_enabled_;
 
-  KeyState keystates_[matrix_rows * matrix_columns];
-  KeyState keystates_prev_[matrix_rows * matrix_columns];
+  KeyState keystates_[matrix_rows * matrix_columns]; // NOLINT(runtime/arrays)
+  KeyState keystates_prev_[matrix_rows * matrix_columns]; // NOLINT(runtime/arrays)
 
-  bool mask_[matrix_rows * matrix_columns];
+  bool mask_[matrix_rows * matrix_columns]; // NOLINT(runtime/arrays)
 };
 
 class VirtualLEDDriver
@@ -108,7 +108,7 @@ class VirtualLEDDriver
 
  private:
 
-  cRGB led_states_[led_count];
+  cRGB led_states_[led_count]; // NOLINT(runtime/arrays)
 };
 
 // This overrides only the drivers and keeps the driver props of

--- a/src/kaleidoscope/driver/hid/base/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/base/Keyboard.h
@@ -310,7 +310,7 @@ class Keyboard {
 
     if (!isModifierKey(released_key)) {
 
-      // TODO: this code is incomplete, but is better than nothing
+      // TODO(anyone): this code is incomplete, but is better than nothing
       // If we're toggling off the most recently toggled on key, clear
       // last_keycode_toggled_on
       if (last_keycode_toggled_on == released_key.getKeyCode()) {
@@ -424,7 +424,7 @@ class Keyboard {
 
   // isModifierKey takes a Key and returns true if the key is a
   // keyboard key corresponding to a modifier like Control, Alt or Shift
-  // TODO: This function should be lifted to the Kaleidoscope core, somewhere.
+  // TODO(anyone): This function should be lifted to the Kaleidoscope core, somewhere.
 
   bool isModifierKey(Key key) {
     // If it's not a keyboard key, return false

--- a/src/kaleidoscope/driver/led/Base.h
+++ b/src/kaleidoscope/driver/led/Base.h
@@ -75,7 +75,7 @@ class Base {
     uint8_t offset_;
    public:
     LEDRangeIterator() : offset_(0) {}
-    LEDRangeIterator(uint8_t offset) : offset_(offset) {}
+    explicit LEDRangeIterator(uint8_t offset) : offset_(offset) {}
 
     typedef LEDRangeIterator ThisType;
 

--- a/src/kaleidoscope/driver/led/WS2812.h
+++ b/src/kaleidoscope/driver/led/WS2812.h
@@ -80,7 +80,7 @@ class WS2812 {
   }
 
  private:
-  Color leds_[ledCount];
+  Color leds_[ledCount]; // NOLINT(runtime/arrays)
   uint8_t pinmask_;
   bool modified_ = false;
 

--- a/src/kaleidoscope/driver/led/WS2812.h
+++ b/src/kaleidoscope/driver/led/WS2812.h
@@ -85,7 +85,7 @@ class WS2812 {
   bool modified_ = false;
 
   void sendArrayWithMask(uint8_t maskhi) {
-    uint8_t *data = (uint8_t *)leds_;
+    uint8_t *data = reinterpret_cast<uint8_t *>(leds_);
     uint16_t datalen = ledCount * sizeof(Color);
     uint8_t curbyte, ctr, masklo;
     uint8_t sreg_prev;

--- a/src/kaleidoscope/hooks.cpp
+++ b/src/kaleidoscope/hooks.cpp
@@ -59,6 +59,6 @@ __attribute__((weak))
 EventHandlerResult Hooks::exploreSketch
 <sketch_exploration::Sketch>() {
   return EventHandlerResult::OK;
-};
+}
 
 } // namespace kaleidoscope

--- a/src/kaleidoscope/key_defs.h
+++ b/src/kaleidoscope/key_defs.h
@@ -36,7 +36,7 @@ class Key {
 
   Key() = default;
 
-  constexpr Key(uint16_t raw)
+  constexpr Key(uint16_t raw) // NOLINT(runtime/explicit)
     : Key{(uint8_t)(raw & 0x00FF), (uint8_t)(raw >> 8)}
   {}
 
@@ -140,7 +140,7 @@ class Key {
 
     DataProxy() = default;
 
-    constexpr DataProxy(uint8_t value) : value_{value} {}
+    constexpr DataProxy(uint8_t value) : value_{value} {} // NOLINT(runtime/explicit)
 
     DEPRECATED(DIRECT_KEY_MEMBER_ACCESS)
     DataProxy &operator=(uint8_t value) {

--- a/src/kaleidoscope/key_defs.h
+++ b/src/kaleidoscope/key_defs.h
@@ -36,7 +36,7 @@ class Key {
 
   Key() = default;
 
-  constexpr Key(uint16_t raw)
+  explicit constexpr Key(uint16_t raw)
     : Key{(uint8_t)(raw & 0x00FF), (uint8_t)(raw >> 8)}
   {}
 
@@ -140,7 +140,7 @@ class Key {
 
     DataProxy() = default;
 
-    constexpr DataProxy(uint8_t value) : value_{value} {}
+    explicit constexpr DataProxy(uint8_t value) : value_{value} {}
 
     DEPRECATED(DIRECT_KEY_MEMBER_ACCESS)
     DataProxy &operator=(uint8_t value) {

--- a/src/kaleidoscope/key_defs.h
+++ b/src/kaleidoscope/key_defs.h
@@ -36,7 +36,7 @@ class Key {
 
   Key() = default;
 
-  explicit constexpr Key(uint16_t raw)
+  constexpr Key(uint16_t raw)
     : Key{(uint8_t)(raw & 0x00FF), (uint8_t)(raw >> 8)}
   {}
 
@@ -140,7 +140,7 @@ class Key {
 
     DataProxy() = default;
 
-    explicit constexpr DataProxy(uint8_t value) : value_{value} {}
+    constexpr DataProxy(uint8_t value) : value_{value} {}
 
     DEPRECATED(DIRECT_KEY_MEMBER_ACCESS)
     DataProxy &operator=(uint8_t value) {

--- a/src/kaleidoscope/plugin/Colormap.h
+++ b/src/kaleidoscope/plugin/Colormap.h
@@ -48,8 +48,8 @@ class ColormapEffect : public Plugin,
 
     friend class ColormapEffect;
 
-    virtual void onActivate(void) final;
-    virtual void refreshAt(KeyAddr key_addr) final;
+    void onActivate(void) final;
+    void refreshAt(KeyAddr key_addr) final;
    private:
 
     const ColormapEffect *parent_;

--- a/src/kaleidoscope/plugin/Colormap.h
+++ b/src/kaleidoscope/plugin/Colormap.h
@@ -42,7 +42,7 @@ class ColormapEffect : public Plugin,
     // for those LED modes that require access to
     // members of their parent class. Most LED modes can do without.
     //
-    TransientLEDMode(const ColormapEffect *parent) : parent_(parent) {}
+    explicit TransientLEDMode(const ColormapEffect *parent) : parent_(parent) {}
 
    protected:
 

--- a/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -19,8 +19,6 @@
 #include "kaleidoscope/keyswitch_state.h"
 #include "kaleidoscope/key_events.h"
 
-using namespace kaleidoscope::ranges;
-
 namespace kaleidoscope {
 namespace plugin {
 
@@ -200,11 +198,11 @@ void DynamicMacros::play(uint8_t macro_id) {
 }
 
 EventHandlerResult DynamicMacros::onKeyswitchEvent(Key &mappedKey, KeyAddr key_addr, uint8_t keyState) {
-  if (mappedKey.getRaw() < DYNAMIC_MACRO_FIRST || mappedKey.getRaw() > DYNAMIC_MACRO_LAST)
+  if (mappedKey.getRaw() < ranges::DYNAMIC_MACRO_FIRST || mappedKey.getRaw() > ranges::DYNAMIC_MACRO_LAST)
     return EventHandlerResult::OK;
 
   if (keyToggledOn(keyState)) {
-    play(mappedKey.getRaw() - DYNAMIC_MACRO_FIRST);
+    play(mappedKey.getRaw() - ranges::DYNAMIC_MACRO_FIRST);
   }
 
   return EventHandlerResult::EVENT_CONSUMED;

--- a/src/kaleidoscope/plugin/FingerPainter.cpp
+++ b/src/kaleidoscope/plugin/FingerPainter.cpp
@@ -57,7 +57,7 @@ EventHandlerResult FingerPainter::onKeyswitchEvent(Key &mapped_key, KeyAddr key_
   if (!key_addr.isValid())
     return EventHandlerResult::EVENT_CONSUMED;
 
-  // TODO: The following works only for keyboards with LEDs for each key.
+  // TODO(anyone): The following works only for keyboards with LEDs for each key.
 
   uint8_t color_index = ::LEDPaletteTheme.lookupColorIndexAtPosition(color_base_, Runtime.device().getLedIndex(key_addr));
 

--- a/src/kaleidoscope/plugin/HardwareTestMode.cpp
+++ b/src/kaleidoscope/plugin/HardwareTestMode.cpp
@@ -102,16 +102,13 @@ void HardwareTestMode::testMatrix() {
       // If the key is held down
       if (Runtime.device().isKeyswitchPressed(key_addr) && Runtime.device().wasKeyswitchPressed(key_addr)) {
         Runtime.device().setCrgbAt(key_addr, green);
-      }
-
-      // If we triggered chatter detection ever on this key
-      else if (state[keynum].bad == 1) {
+      } else if (state[keynum].bad == 1) {
+        // If we triggered chatter detection ever on this key
         Runtime.device().setCrgbAt(key_addr, red);
       } else if (state[keynum].tested == 0) {
         Runtime.device().setCrgbAt(key_addr, yellow);
-      }
-      // If the key is not currently pressed and was not just released and is not marked bad
-      else if (! Runtime.device().isKeyswitchPressed(key_addr)) {
+      } else if (! Runtime.device().isKeyswitchPressed(key_addr)) {
+        // If the key is not currently pressed and was not just released and is not marked bad
         Runtime.device().setCrgbAt(key_addr, blue);
       }
     }

--- a/src/kaleidoscope/plugin/Heatmap.h
+++ b/src/kaleidoscope/plugin/Heatmap.h
@@ -53,7 +53,7 @@ class Heatmap : public Plugin,
 
    protected:
 
-    virtual void update() final;
+    void update() final;
 
    private:
 

--- a/src/kaleidoscope/plugin/Heatmap.h
+++ b/src/kaleidoscope/plugin/Heatmap.h
@@ -45,7 +45,7 @@ class Heatmap : public Plugin,
     // for those LED modes that require access to
     // members of their parent class. Most LED modes can do without.
     //
-    TransientLEDMode(const Heatmap *parent);
+    explicit TransientLEDMode(const Heatmap *parent);
 
     void resetMap();
     EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);

--- a/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
+++ b/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
@@ -39,7 +39,7 @@ class LEDActiveLayerColorEffect : public Plugin,
     // for those LED modes that require access to
     // members of their parent class. Most LED modes can do without.
     //
-    TransientLEDMode(const LEDActiveLayerColorEffect *parent);
+    explicit TransientLEDMode(const LEDActiveLayerColorEffect *parent);
 
    protected:
 

--- a/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
+++ b/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
@@ -43,8 +43,8 @@ class LEDActiveLayerColorEffect : public Plugin,
 
    protected:
 
-    virtual void onActivate(void) final;
-    virtual void refreshAt(KeyAddr key_addr) final;
+    void onActivate(void) final;
+    void refreshAt(KeyAddr key_addr) final;
 
    private:
 

--- a/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
@@ -23,7 +23,7 @@ namespace plugin {
 
 uint16_t AlphaSquareEffect::length = 1000;
 
-AlphaSquareEffect::TransientLEDMode::TransientLEDMode(AlphaSquareEffect */*parent*/)
+AlphaSquareEffect::TransientLEDMode::TransientLEDMode(AlphaSquareEffect */*parent*/) // NOLINT(readability/casting)
   : last_key_left_(Key_NoKey),
     last_key_right_(Key_NoKey)
 {}

--- a/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
+++ b/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
@@ -36,7 +36,7 @@ class AlphaSquareEffect : public Plugin,
   //
   class TransientLEDMode : public LEDMode {
    public:
-    TransientLEDMode(AlphaSquareEffect *parent);
+    explicit TransientLEDMode(AlphaSquareEffect *parent);
 
    protected:
     void update(void) final;

--- a/src/kaleidoscope/plugin/LED-Stalker.h
+++ b/src/kaleidoscope/plugin/LED-Stalker.h
@@ -50,7 +50,7 @@ class StalkerEffect : public Plugin,
     // for those LED modes that require access to
     // members of their parent class. Most LED modes can do without.
     //
-    TransientLEDMode(const StalkerEffect *parent);
+    explicit TransientLEDMode(const StalkerEffect *parent);
 
    protected:
 

--- a/src/kaleidoscope/plugin/LED-Stalker.h
+++ b/src/kaleidoscope/plugin/LED-Stalker.h
@@ -54,7 +54,7 @@ class StalkerEffect : public Plugin,
 
    protected:
 
-    virtual void update() final;
+    void update() final;
 
    private:
 

--- a/src/kaleidoscope/plugin/LED-Wavepool.h
+++ b/src/kaleidoscope/plugin/LED-Wavepool.h
@@ -51,7 +51,7 @@ class WavepoolEffect : public Plugin,
     // for those LED modes that require access to
     // members of their parent class. Most LED modes can do without.
     //
-    TransientLEDMode(const WavepoolEffect *parent);
+    explicit TransientLEDMode(const WavepoolEffect *parent);
 
     EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 

--- a/src/kaleidoscope/plugin/LED-Wavepool.h
+++ b/src/kaleidoscope/plugin/LED-Wavepool.h
@@ -57,7 +57,7 @@ class WavepoolEffect : public Plugin,
 
    protected:
 
-    virtual void update() final;
+    void update() final;
 
    private:
 

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -19,7 +19,7 @@
 #include "kaleidoscope_internal/LEDModeManager.h"
 #include "kaleidoscope/keyswitch_state.h"
 
-using namespace kaleidoscope::internal;
+using namespace kaleidoscope::internal; // NOLINT(build/namespaces)
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/LEDEffect-BootGreeting.h
+++ b/src/kaleidoscope/plugin/LEDEffect-BootGreeting.h
@@ -24,7 +24,7 @@ namespace plugin {
 class BootGreetingEffect : public kaleidoscope::Plugin {
  public:
   BootGreetingEffect(void) {}
-  BootGreetingEffect(KeyAddr key_addr);
+  explicit BootGreetingEffect(KeyAddr key_addr);
 
   static KeyAddr user_key_addr;
   static Key search_key;

--- a/src/kaleidoscope/plugin/LEDEffect-Breathe.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Breathe.h
@@ -37,7 +37,7 @@ class LEDBreatheEffect : public Plugin,
     // for those LED modes that require access to
     // members of their parent class. Most LED modes can do without.
     //
-    TransientLEDMode(const LEDBreatheEffect *parent)
+    explicit TransientLEDMode(const LEDBreatheEffect *parent)
       : parent_(parent) {}
 
    protected:

--- a/src/kaleidoscope/plugin/LEDEffect-Breathe.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Breathe.h
@@ -41,7 +41,7 @@ class LEDBreatheEffect : public Plugin,
       : parent_(parent) {}
 
    protected:
-    virtual void update(void) final;
+    void update(void) final;
 
    private:
 

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.h
@@ -52,7 +52,7 @@ class LEDChaseEffect : public Plugin,
 
    protected:
 
-    virtual void update() final;
+    void update() final;
 
    private:
 

--- a/src/kaleidoscope/plugin/LEDEffect-Chase.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Chase.h
@@ -47,7 +47,7 @@ class LEDChaseEffect : public Plugin,
     // for those LED modes that require access to
     // members of their parent class. Most LED modes can do without.
     //
-    TransientLEDMode(const LEDChaseEffect *parent)
+    explicit TransientLEDMode(const LEDChaseEffect *parent)
       : parent_(parent), last_update_(Runtime.millisAtCycleStart()) {}
 
    protected:

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
@@ -46,7 +46,7 @@ class LEDRainbowEffect : public Plugin,
     TransientLEDMode(const LEDRainbowEffect *parent)
       : parent_(parent) {}
 
-    virtual void update() final;
+    void update() final;
 
    private:
 
@@ -91,7 +91,7 @@ class LEDRainbowWaveEffect : public Plugin, public LEDModeInterface {
     TransientLEDMode(const LEDRainbowWaveEffect *parent)
       : parent_(parent) {}
 
-    virtual void update() final;
+    void update() final;
 
    private:
 

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
@@ -43,7 +43,7 @@ class LEDRainbowEffect : public Plugin,
     // for those LED modes that require access to
     // members of their parent class. Most LED modes can do without.
     //
-    TransientLEDMode(const LEDRainbowEffect *parent)
+    explicit TransientLEDMode(const LEDRainbowEffect *parent)
       : parent_(parent) {}
 
     void update() final;
@@ -88,7 +88,7 @@ class LEDRainbowWaveEffect : public Plugin, public LEDModeInterface {
     // for those LED modes that require access to
     // members of their parent class. Most LED modes can do without.
     //
-    TransientLEDMode(const LEDRainbowWaveEffect *parent)
+    explicit TransientLEDMode(const LEDRainbowWaveEffect *parent)
       : parent_(parent) {}
 
     void update() final;

--- a/src/kaleidoscope/plugin/LEDEffect-SolidColor.h
+++ b/src/kaleidoscope/plugin/LEDEffect-SolidColor.h
@@ -41,8 +41,8 @@ class LEDSolidColor : public Plugin,
       : parent_(parent) {}
 
    protected:
-    virtual void onActivate(void) final;
-    virtual void refreshAt(KeyAddr key_addr) final;
+    void onActivate(void) final;
+    void refreshAt(KeyAddr key_addr) final;
 
    private:
 

--- a/src/kaleidoscope/plugin/LEDEffect-SolidColor.h
+++ b/src/kaleidoscope/plugin/LEDEffect-SolidColor.h
@@ -37,7 +37,7 @@ class LEDSolidColor : public Plugin,
     // for those LED modes that require access to
     // members of their parent class. Most LED modes can do without.
     //
-    TransientLEDMode(const LEDSolidColor *parent)
+    explicit TransientLEDMode(const LEDSolidColor *parent)
       : parent_(parent) {}
 
    protected:

--- a/src/kaleidoscope/plugin/Model01-TestMode.h
+++ b/src/kaleidoscope/plugin/Model01-TestMode.h
@@ -35,7 +35,7 @@ namespace plugin {
 
 class TestMode : public kaleidoscope::Plugin {
  public:
-  DEPRECATED(MODEL01_TESTMODE) EventHandlerResult beforeReportingState() {};
+  DEPRECATED(MODEL01_TESTMODE) EventHandlerResult beforeReportingState() {}
 };
 }
 }

--- a/src/kaleidoscope/plugin/Qukeys/KeyAddrEventQueue.h
+++ b/src/kaleidoscope/plugin/Qukeys/KeyAddrEventQueue.h
@@ -45,7 +45,7 @@ class KeyAddrEventQueue {
  private:
   uint8_t    length_{0};
   KeyAddr    addrs_[_capacity];
-  _Timestamp timestamps_[_capacity];
+  _Timestamp timestamps_[_capacity]; // NOLINT(runtime/arrays)
   _Bitfield  release_event_bits_;
 
  public:

--- a/src/kaleidoscope/plugin/TriColor.h
+++ b/src/kaleidoscope/plugin/TriColor.h
@@ -42,7 +42,7 @@ class TriColor : public Plugin,
 
    protected:
 
-    virtual void update(void) final;
+    void update(void) final;
 
    private:
 

--- a/src/kaleidoscope/plugin/TriColor.h
+++ b/src/kaleidoscope/plugin/TriColor.h
@@ -37,7 +37,7 @@ class TriColor : public Plugin,
     // for those LED modes that require access to
     // members of their parent class. Most LED modes can do without.
     //
-    TransientLEDMode(const TriColor *parent)
+    explicit TransientLEDMode(const TriColor *parent)
       : parent_(parent) {}
 
    protected:

--- a/src/kaleidoscope/plugin/Turbo.h
+++ b/src/kaleidoscope/plugin/Turbo.h
@@ -19,6 +19,8 @@
 #include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
 
+#pragma once
+
 #define Key_Turbo Key{kaleidoscope::ranges::TURBO }
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/util/crc16.h
+++ b/src/kaleidoscope/util/crc16.h
@@ -31,8 +31,7 @@
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE. */
 
-#ifndef _UTIL_CRC16_H_
-#define _UTIL_CRC16_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -89,6 +88,3 @@ static inline uint8_t _crc_ibutton_update(uint8_t crc, uint8_t data) {
   }
   return crc;
 }
-
-#endif
-

--- a/src/kaleidoscope_internal/LEDModeManager.h
+++ b/src/kaleidoscope_internal/LEDModeManager.h
@@ -338,9 +338,8 @@ class LEDModeManager {
                         0 /*dummy*/
                       )
                     );
-    parent_plugin->registerLEDModeActivated(255 /* dymmy to disable access
-            to transient LED modes through LEDControl */
-                                           );
+    // dummy to disable access to transient LED modes through LEDControl
+    parent_plugin->registerLEDModeActivated(255);
 
     return led_mode;
   }

--- a/src/kaleidoscope_internal/LEDModeManager.h
+++ b/src/kaleidoscope_internal/LEDModeManager.h
@@ -405,9 +405,9 @@ class LEDModeManager {
    LEDModeManager::setupLEDMode(&::PLUGIN);
 
 #define _INIT_LED_MODE_MANAGER(...)                                            \
-   namespace kaleidoscope {                                             __NL__ \
-   namespace internal {                                                 __NL__ \
-   namespace led_mode_management {                                      __NL__ \
+   namespace kaleidoscope { /* NOLINT(build/namespaces) */              __NL__ \
+   namespace internal { /* NOLINT(build/namespaces) */                  __NL__ \
+   namespace led_mode_management { /* NOLINT(build/namespaces) */       __NL__ \
                                                                         __NL__ \
       /* Setup the array-like data structure that stores                __NL__ \
        * LEDModeFactories */                                            __NL__ \

--- a/src/kaleidoscope_internal/array_like_storage.h
+++ b/src/kaleidoscope_internal/array_like_storage.h
@@ -85,7 +85,7 @@ struct ArrayLikeStorage<StoredType__, true /* is of appropriate type */> {
 
  public:
 
-  constexpr ArrayLikeStorage(StoredType__ entry)
+  explicit constexpr ArrayLikeStorage(StoredType__ entry)
     : entry_(entry)
   {}
 
@@ -103,7 +103,7 @@ struct ArrayLikeStorage<StoredType__, false /* not of appropriate type */> {
  public:
 
   template<typename AnyType__>
-  constexpr ArrayLikeStorage(AnyType__/* non-matching entity */) {}
+  explicit constexpr ArrayLikeStorage(AnyType__/* non-matching entity */) {}
 
   static constexpr uint8_t n_entries = 0;
 

--- a/src/kaleidoscope_internal/array_like_storage.h
+++ b/src/kaleidoscope_internal/array_like_storage.h
@@ -85,7 +85,7 @@ struct ArrayLikeStorage<StoredType__, true /* is of appropriate type */> {
 
  public:
 
-  explicit constexpr ArrayLikeStorage(StoredType__ entry)
+  constexpr ArrayLikeStorage(StoredType__ entry)
     : entry_(entry)
   {}
 
@@ -103,7 +103,7 @@ struct ArrayLikeStorage<StoredType__, false /* not of appropriate type */> {
  public:
 
   template<typename AnyType__>
-  explicit constexpr ArrayLikeStorage(AnyType__/* non-matching entity */) {}
+  constexpr ArrayLikeStorage(AnyType__/* non-matching entity */) {}
 
   static constexpr uint8_t n_entries = 0;
 

--- a/src/kaleidoscope_internal/event_dispatch.h
+++ b/src/kaleidoscope_internal/event_dispatch.h
@@ -131,10 +131,10 @@
             = HookVersionImplemented_##HOOK_NAME<                         __NL__ \
                  Plugin__, HOOK_VERSION>::value;                          __NL__ \
                                                                           __NL__ \
-         /* The caller type adds another level of indirection that        __NL__ \
-          * is required to enable some hooks not to be implemented        __NL__ \
-          * by plugins.                                                   __NL__ \
-          */                                                              __NL__ \
+         /* The caller type adds another level of indirection that */     __NL__ \
+         /* is required to enable some hooks not to be implemented */     __NL__ \
+         /* by plugins.                                            */     __NL__ \
+                                                                          __NL__ \
          typedef _NAME5(EventHandler_, HOOK_NAME, _v, HOOK_VERSION, _caller) __NL__ \
             <                                                             __NL__ \
                derived_implements_hook,                                   __NL__ \
@@ -147,7 +147,7 @@
       }                                                                   __NL__ \
     };                                                                    __NL__ \
                                                                           __NL__ \
-   } 	                                                                    __NL__ \
+   } 	                                                                  __NL__ \
                                                                           __NL__ \
    namespace kaleidoscope {                                               __NL__ \
                                                                           __NL__ \

--- a/src/kaleidoscope_internal/event_dispatch.h
+++ b/src/kaleidoscope_internal/event_dispatch.h
@@ -99,9 +99,9 @@
       }                                                                   __NL__ \
    };                                                                     __NL__ \
                                                                           __NL__ \
-   /* This specialization is used for those hooks that a plugin does not  __NL__ \
-    * implement.                                                          __NL__ \
-    */                                                                    __NL__ \
+   /* This specialization is used for those hooks that a plugin does */   __NL__ \
+   /* not implement. */                                                   __NL__ \
+                                                                          __NL__ \
    template<typename Plugin__                                             __NL__ \
             UNWRAP TMPL_PARAM_TYPE_LIST /* may evaluate empty */          __NL__ \
             , typename... Args__>                                         __NL__ \

--- a/src/kaleidoscope_internal/eventhandler_signature_check.h
+++ b/src/kaleidoscope_internal/eventhandler_signature_check.h
@@ -77,16 +77,16 @@ template<typename Plugin__> struct
 
 #define _DEFINE_IMPLEMENTATION_CHECK_CLASSES(HOOK_NAME, ...)                   \
                                                                         __NL__ \
-   /* Defines a traits class Plugin_HasMember_HOOK_NAME                 __NL__ \
-    * where HOOK_NAME is replaced with the actual hook name             __NL__ \
-    * that is passed in as a parameter to this macro.                   __NL__ \
-    */                                                                  __NL__ \
+   /* Defines a traits class Plugin_HasMember_HOOK_NAME        */       __NL__ \
+   /* where HOOK_NAME is replaced with the actual hook name    */       __NL__ \
+   /* that is passed in as a parameter to this macro.          */       __NL__ \
+                                                                      __NL__ \
    DEFINE_HAS_MEMBER_TRAITS(Plugin, HOOK_NAME)                          __NL__ \
                                                                         __NL__ \
-   /* Specializations of this helper class check if a plugin            __NL__ \
-    * implements a handler with the specific signature that is          __NL__ \
-    * identified by a hook version.                                     __NL__ \
-    */                                                                  __NL__ \
+   /* Specializations of this helper class check if a plugin    */      __NL__ \
+   /* implements a handler with the specific signature that is  */      __NL__ \
+   /* identified by a hook version.                             */      __NL__ \
+                                                                        __NL__ \
    template<typename Plugin__, int hook_version_id_>                    __NL__ \
    struct HookVersionImplemented_##HOOK_NAME {};
 
@@ -96,19 +96,19 @@ template<typename Plugin__> struct
     TMPL_PARAM_TYPE_LIST, TMPL_PARAM_LIST, TMPL_DUMMY_ARGS_LIST,               \
     SIGNATURE, ARGS_LIST)                                                      \
                                                                                \
-    /* We use the generalized traits class found in header has_method.h __NL__ \
-     * to do check if a plugin defines a hook method with a specific    __NL__ \
-     * signature.                                                       __NL__ \
-     */                                                                 __NL__ \
+    /* We use the generalized traits class found in header has_method.h */ __NL__ \
+    /* to do check if a plugin defines a hook method with a specific    */ __NL__ \
+    /* signature.                                                       */ __NL__ \
+                                                                        __NL__ \
     DEFINE_HAS_METHOD_TRAITS(GLUE2(Plugin, HOOK_VERSION),               __NL__ \
                              TMPL_PARAM_TYPE_LIST, TMPL_PARAM_LIST,     __NL__ \
                              HOOK_NAME,                                 __NL__ \
                              kaleidoscope::EventHandlerResult,          __NL__ \
                              SIGNATURE)                                 __NL__ \
                                                                         __NL__ \
-   /* This specialization checks if a plugin of type Plugin__           __NL__ \
-    * implements a handler with given signature SIGNATURE.              __NL__ \
-    */                                                                  __NL__ \
+   /* This specialization checks if a plugin of type Plugin__  */       __NL__ \
+   /* implements a handler with given signature SIGNATURE.     */       __NL__ \
+                                                                        __NL__ \
    template<typename Plugin__>                                          __NL__ \
    struct HookVersionImplemented_##HOOK_NAME<Plugin__, HOOK_VERSION>    __NL__ \
       : public GLUE4(Plugin, HOOK_VERSION, _HasMethod_, HOOK_NAME)      __NL__ \
@@ -117,20 +117,20 @@ template<typename Plugin__> struct
 
 #define _PREPARE_EVENT_HANDLER_SIGNATURE_CHECK_START(HOOK_NAME, ...)           \
                                                                         __NL__ \
-   /* This struct enables checking if a handler of a specific type      __NL__ \
-    * has been implemented. If so, there must be exactly one overload   __NL__ \
-    * with correct signature.                                           __NL__ \
-    */                                                                  __NL__ \
+   /* This struct enables checking if a handler of a specific type    */__NL__ \
+   /* has been implemented. If so, there must be exactly one overload */__NL__ \
+   /* with correct signature.                                         */__NL__ \
+                                                                        __NL__ \
    template <class Plugin__>                                            __NL__ \
    struct NumberOfImplementationsOf_##HOOK_NAME                         __NL__ \
    {                                                                    __NL__ \
       static constexpr int value =                                      __NL__ \
          0                                                              __NL__ \
-         /* What follows is a list of handler implementation            __NL__ \
-          * checks for different versions of a handler                  __NL__ \
-          * generated by several calls to                               __NL__ \
-          * _PREPARE_EVENT_HANDLER_SIGNATURE_CHECK_OP.                  __NL__ \
-          */
+         /* What follows is a list of handler implementation   */       __NL__ \
+         /* checks for different versions of a handler         */       __NL__ \
+         /* generated by several calls to                      */       __NL__ \
+         /* _PREPARE_EVENT_HANDLER_SIGNATURE_CHECK_OP.         */
+
 
 // This is invoked for every version of a hook.
 //
@@ -151,16 +151,16 @@ template<typename Plugin__> struct
    static constexpr int n_implementations                               __NL__ \
          = NumberOfImplementationsOf_##HOOK_NAME<PLUGIN_TYPE>::value;   __NL__ \
                                                                         __NL__ \
-   /* A handler is acceptable if it is either not implemented           __NL__ \
-      * by the derived class or if there is only one implementation     __NL__ \
-      * with correct signature.                                         __NL__ \
-      * Please note that any other methods with different names         __NL__ \
-      * but other, unrelated signatures are ignored as long             __NL__ \
-      * as there is one correct implementation.                         __NL__ \
-      * Only if there are several versions supported at a time          __NL__ \
-      * and more than one of them has been implemented, we              __NL__ \
-      * treat this as an ambiguity and raise an error.                  __NL__ \
-      */                                                                __NL__ \
+     /* A handler is acceptable if it is either not implemented     */  __NL__ \
+     /* by the derived class or if there is only one implementation */  __NL__ \
+     /* with correct signature.                                     */  __NL__ \
+     /* Please note that any other methods with different names     */  __NL__ \
+     /* but other, unrelated signatures are ignored as long         */  __NL__ \
+     /* as there is one correct implementation.                     */  __NL__ \
+     /* Only if there are several versions supported at a time      */  __NL__ \
+     /* and more than one of them has been implemented, we          */  __NL__ \
+     /* treat this as an ambiguity and raise an error.              */  __NL__ \
+                                                                        __NL__ \
    static constexpr bool handler_has_wrong_signature =                  __NL__ \
          derived_implements_handler && (n_implementations == 0);        __NL__ \
                                                                         __NL__ \
@@ -187,11 +187,11 @@ template<typename Plugin__> struct
     VERBOSE_STATIC_ASSERT_FOOTER                                        __NL__ \
   );                                                                    __NL__ \
                                                                         __NL__ \
-  /* The following construct is necessary enable reporting of the       __NL__ \
-   * type of a plugin that implements an event handler with an          __NL__ \
-   * incorrect signature, because it's not possible to include any      __NL__ \
-   * non-literal string constant in a static_assert error message.      __NL__ \
-   */                                                                   __NL__ \
+  /* The following construct is necessary enable reporting of the   */  __NL__ \
+  /* type of a plugin that implements an event handler with an      */  __NL__ \
+  /* incorrect signature, because it's not possible to include any  */  __NL__ \
+  /* non-literal string constant in a static_assert error message.  */  __NL__ \
+  /*                                                                */  __NL__ \
   __attribute__((unused)) constexpr bool dummy1                         __NL__ \
                        = ___________Culprit_Plugin___________           __NL__ \
        <PLUGIN_TYPE, !handler_has_wrong_signature>::value;              __NL__ \
@@ -217,11 +217,11 @@ template<typename Plugin__> struct
     VERBOSE_STATIC_ASSERT_FOOTER                                        __NL__ \
   );                                                                    __NL__ \
                                                                         __NL__ \
-  /* The following construct is necessary enable reporting of the       __NL__ \
-   * type of a plugin that implements an event handler with an          __NL__ \
-   * incorrect signature, because it's not possible to include any      __NL__ \
-   * non-literal string constant in a static_assert error message.      __NL__ \
-   */                                                                   __NL__ \
+  /* The following construct is necessary enable reporting of the   */  __NL__ \
+  /* type of a plugin that implements an event handler with an      */  __NL__ \
+  /* incorrect signature, because it's not possible to include any  */  __NL__ \
+  /* non-literal string constant in a static_assert error message.  */  __NL__ \
+                                                                        __NL__ \
   __attribute__((unused)) constexpr bool dummy2                         __NL__ \
                        = ___________Culprit_Plugin___________           __NL__ \
        <PLUGIN_TYPE, !handler_ambiguously_implemented>::value;          __NL__ \

--- a/src/kaleidoscope_internal/sketch_exploration/keymap_exploration.h
+++ b/src/kaleidoscope_internal/sketch_exploration/keymap_exploration.h
@@ -35,7 +35,7 @@ class KeymapAdaptor {
   static constexpr uint8_t n_layers = _n_layers;
   static constexpr uint8_t layer_size = _layer_size;
 
-  constexpr KeymapAdaptor(const Key(&keymap)[_n_layers][_layer_size])
+  explicit constexpr KeymapAdaptor(const Key(&keymap)[_n_layers][_layer_size])
     :  keymap_{keymap}
   {}
 
@@ -119,7 +119,7 @@ class EmptyKeymapAccumulationHelper {
 
  public:
 
-  constexpr EmptyKeymapAccumulationHelper(const _Accumulation &op)
+  explicit constexpr EmptyKeymapAccumulationHelper(const _Accumulation &op)
     :   op_{op}
   {}
 
@@ -147,7 +147,7 @@ struct NumKeysEqual {
   typedef uint8_t ResultType;
   static constexpr ResultType init_value = 0;
 
-  constexpr NumKeysEqual(Key k) : k_{k} {}
+  explicit constexpr NumKeysEqual(Key k) : k_{k} {}
 
   constexpr ResultType apply(Key test_key, ResultType r) const {
     return (test_key == k_) ? r + 1 : r;
@@ -163,7 +163,7 @@ struct HasKey {
   typedef bool ResultType;
   static constexpr ResultType init_value = false;
 
-  constexpr HasKey(Key k) : k_{k} {}
+  explicit constexpr HasKey(Key k) : k_{k} {}
 
   constexpr ResultType apply(Key test_key, ResultType r) const {
     return (test_key == k_) ? true : r;

--- a/src/kaleidoscope_internal/sketch_exploration/keymap_exploration.h
+++ b/src/kaleidoscope_internal/sketch_exploration/keymap_exploration.h
@@ -18,8 +18,8 @@
 
 #include "kaleidoscope/key_defs.h"
 
-namespace kaleidoscope {
-namespace sketch_exploration {
+namespace kaleidoscope { // NOLINT(build/namespaces)
+namespace sketch_exploration { // NOLINT(build/namespaces)
 
 // A simple keymap adaptor class that makes the keymap conveniently accessible.
 // at compiletime.
@@ -214,7 +214,7 @@ extern void pluginsExploreSketch();
 // exploreSketch<_Sketch>(...)-hook.
 //
 #define _INIT_KEYMAP_EXPLORATION                                               \
-  namespace kaleidoscope {                                                     \
+  namespace kaleidoscope { /* NOLINT(build/namespaces) */                      \
   namespace sketch_exploration {                                               \
                                                                                \
      template<bool _keymap_is_empty>                                           \

--- a/src/kaleidoscope_internal/sketch_exploration/keymap_exploration.h
+++ b/src/kaleidoscope_internal/sketch_exploration/keymap_exploration.h
@@ -35,7 +35,7 @@ class KeymapAdaptor {
   static constexpr uint8_t n_layers = _n_layers;
   static constexpr uint8_t layer_size = _layer_size;
 
-  explicit constexpr KeymapAdaptor(const Key(&keymap)[_n_layers][_layer_size])
+  constexpr KeymapAdaptor(const Key(&keymap)[_n_layers][_layer_size])
     :  keymap_{keymap}
   {}
 
@@ -119,7 +119,7 @@ class EmptyKeymapAccumulationHelper {
 
  public:
 
-  explicit constexpr EmptyKeymapAccumulationHelper(const _Accumulation &op)
+  constexpr EmptyKeymapAccumulationHelper(const _Accumulation &op)
     :   op_{op}
   {}
 
@@ -147,7 +147,7 @@ struct NumKeysEqual {
   typedef uint8_t ResultType;
   static constexpr ResultType init_value = 0;
 
-  explicit constexpr NumKeysEqual(Key k) : k_{k} {}
+  constexpr NumKeysEqual(Key k) : k_{k} {}
 
   constexpr ResultType apply(Key test_key, ResultType r) const {
     return (test_key == k_) ? r + 1 : r;
@@ -163,7 +163,7 @@ struct HasKey {
   typedef bool ResultType;
   static constexpr ResultType init_value = false;
 
-  explicit constexpr HasKey(Key k) : k_{k} {}
+  constexpr HasKey(Key k) : k_{k} {}
 
   constexpr ResultType apply(Key test_key, ResultType r) const {
     return (test_key == k_) ? true : r;

--- a/src/kaleidoscope_internal/sketch_preprocessing/sketch_footer.h
+++ b/src/kaleidoscope_internal/sketch_preprocessing/sketch_footer.h
@@ -1,1 +1,2 @@
 // Any code that appears here is added to the bottom of the preprocessed sketch file.
+// NOLINT(build/header_guard)

--- a/src/kaleidoscope_internal/sketch_preprocessing/sketch_header.h
+++ b/src/kaleidoscope_internal/sketch_preprocessing/sketch_header.h
@@ -1,3 +1,3 @@
 // Any code that appears here is added to the top of the preprocessed sketch file.
-
+// NOLINT(build/header_guard)
 #define KALEIDOSCOPE_SKETCH

--- a/src/kaleidoscope_internal/type_traits/has_member.h
+++ b/src/kaleidoscope_internal/type_traits/has_member.h
@@ -40,89 +40,89 @@
 
 #define DEFINE_HAS_MEMBER_TRAITS(PREFIX, MEMBER_NAME)                   __NL__ \
                                                                         __NL__ \
-   /* This defines a templated class PREFIX##_HasMember_##MEMBER_NAME.  __NL__ \
-    * The double hashes just glue together the value of macro           __NL__ \
-    * parameters like PREFIX or MEMBER_NAME and other                   __NL__ \
-    * string tokens to form new identifiers (here the struct name).     __NL__ \
-    */                                                                  __NL__ \
+   /* This defines a templated class PREFIX##_HasMember_##MEMBER_NAME.*/__NL__ \
+   /* The double hashes just glue together the value of macro        */ __NL__ \
+   /* parameters like PREFIX or MEMBER_NAME and other                */ __NL__ \
+   /* string tokens to form new identifiers (here the struct name).  */ __NL__ \
+   /*/                                                               */ __NL__ \
    template<typename T>                                                 __NL__ \
    struct CAT3(PREFIX, _HasMember_, MEMBER_NAME) {                      __NL__ \
                                                                         __NL__ \
-      /* This code defines an inner class, Fallback, with one           __NL__ \
-       * member – named MEMBER_NAME (remember that MEMBER_NAME is a     __NL__ \
-       * macro parameter, so it will be replaced with the name of the   __NL__ \
-       * actual member. Using proper terminology, this class is         __NL__ \
-       * essentially a Mixin.                                           __NL__ \
-       */                                                               __NL__ \
+      /* This code defines an inner class, Fallback, with one        */ __NL__ \
+      /* member – named MEMBER_NAME (remember that MEMBER_NAME is a  */ __NL__ \
+      /* macro parameter, so it will be replaced with the name of the*/ __NL__ \
+      /* actual member. Using proper terminology, this class is      */ __NL__ \
+      /* essentially a Mixin.                                        */ __NL__ \
+                                                                        __NL__ \
       struct Fallback {                                                 __NL__ \
          int MEMBER_NAME;                                               __NL__ \
       };                                                                __NL__ \
                                                                         __NL__ \
-      /* Next, we introduce a new class: Derived. It inherits both      __NL__ \
-       * from the class T we’re templated on, and the previous Fallback __NL__ \
-       * class. Note that the Derived class inherits the MEMBER_NAME    __NL__ \
-       * member from class Fallback and possibly another MEMBER_NAME    __NL__ \
-       * from T. Keep this (possible) ambiguity in mind.                __NL__ \
-       */                                                               __NL__ \
+      /* Next, we introduce a new class: Derived. It inherits both   */ __NL__ \
+      /* from the class T we’re templated on, & the previous Fallback*/ __NL__ \
+      /* class. Note that the Derived class inherits the MEMBER_NAME */ __NL__ \
+      /* member from class Fallback and possibly another MEMBER_NAME */ __NL__ \
+      /* from T. Keep this (possible) ambiguity in mind.             */ __NL__ \
+                                                                        __NL__ \
       struct Derived : T, Fallback { };                                 __NL__ \
                                                                         __NL__ \
-      /* The ChT class is templated on a typename C, and an object      __NL__ \
-       * of that type. As a side note, only compile time constant       __NL__ \
-       * fixed types are possible here. We will use this class to       __NL__ \
-       * generate the ambiguity mentioned above.                        __NL__ \
-       */                                                               __NL__ \
+      /* The ChT class is templated on a typename C, and an object   */ __NL__ \
+      /* of that type. As a side note, only compile time constant    */ __NL__ \
+      /* fixed types are possible here. We will use this class to    */ __NL__ \
+      /* generate the ambiguity mentioned above.                     */ __NL__ \
+                                                                        __NL__ \
       template<typename C, C>                                           __NL__ \
       struct ChT;                                                       __NL__ \
                                                                         __NL__ \
-      /* This is where the fun starts. These two lines form a           __NL__ \
-       * declaration of a templated function f. That function           __NL__ \
-       * receives a pointer to the ChT class, instantiated with a       __NL__ \
-       * pointer-to-member type whose parameter is the                  __NL__ \
-       * address-of-member MEMBER_NAME in class C. Note that            __NL__ \
-       * if we attempt to instantiate this with                         __NL__ \
-       * the Derived class, one of two things will happen: either we    __NL__ \
-       * will have a substitution failure due to the aforementioned     __NL__ \
-       * ambiguity (if T also has a member by that name), or it will    __NL__ \
-       * be successful (if there is no member called MEMBER_NAME, in T). __NL__ \
-       * This function returns a reference to a char array of size 1.   __NL__ \
-       *                                                                __NL__ \
-       * How returning arrays by reference works becomes a little       __NL__ \
-       * clearer by means of a more simple example. The definition      __NL__ \
-       * of a function that returns a reference to a char-array of      __NL__ \
-       * size 1 e.g. reads                                              __NL__ \
-       *                                                                __NL__ \
-       * char (&f())[1];                                                __NL__ \
-       */                                                               __NL__ \
+      /* This is where the fun starts. These two lines form a        */ __NL__ \
+      /* declaration of a templated function f. That function        */ __NL__ \
+      /* receives a pointer to the ChT class, instantiated with a    */ __NL__ \
+      /* pointer-to-member type whose parameter is the               */ __NL__ \
+      /* address-of-member MEMBER_NAME in class C. Note that         */ __NL__ \
+      /* if we attempt to instantiate this with                      */ __NL__ \
+      /* the Derived class, one of two things will happen: either we */ __NL__ \
+      /* will have a substitution failure due to the aforementioned  */ __NL__ \
+      /* ambiguity (if T also has a member by that name), or it will */ __NL__ \
+      /* be successful (if there is no member called MEMBER_NAME, in T).*/ __NL__ \
+      /* This function returns a reference to a char array of size 1.*/ __NL__ \
+      /*                                                             */ __NL__ \
+      /* How returning arrays by reference works becomes a little    */ __NL__ \
+      /* clearer by means of a more simple example. The definition   */ __NL__ \
+      /* of a function that returns a reference to a char-array of   */ __NL__ \
+      /* size 1 e.g. reads                                           */ __NL__ \
+      /*                                                             */ __NL__ \
+      /* char (&f())[1];                                             */ __NL__ \
+                                                                        __NL__ \
       template<typename C>                                              __NL__ \
       static char (&f(ChT<int Fallback::*, &C::MEMBER_NAME>*))[1];      __NL__ \
-	                                                                     __NL__ \
-      /* This is what gets instantiated if the previous template        __NL__ \
-       * can’t be instantiated and SFINAE kicks in (since variadic      __NL__ \
-       * functions have the lowest possible priority when selecting     __NL__ \
-       * which overloaded function to call). This variadic function     __NL__ \
-       * returns a reference to a char array of size 2. Note that       __NL__ \
-       * instantiation of this function means that the previous         __NL__ \
-       * one failed, implying that class T has a member                 __NL__ \
-       * named MEMBER_NAME.                                             __NL__ \
-       */                                                               __NL__ \
+	                                                                __NL__ \
+      /* This is what gets instantiated if the previous template     */ __NL__ \
+      /* can’t be instantiated and SFINAE kicks in (since variadic   */ __NL__ \
+      /* functions have the lowest possible priority when selecting  */ __NL__ \
+      /* which overloaded function to call). This variadic function  */ __NL__ \
+      /* returns a reference to a char array of size 2. Note that    */ __NL__ \
+      /* instantiation of this function means that the previous      */ __NL__ \
+      /* one failed, implying that class T has a member              */ __NL__ \
+      /* named MEMBER_NAME.                                          */ __NL__ \
+                                                                        __NL__ \
       template<typename C>                                              __NL__ \
       static char (&f(...))[2];                                         __NL__ \
                                                                         __NL__ \
-      /* As you could guess, we will try to check which f function      __NL__ \
-       * can be instantiated. We will do this by checking the sizeof    __NL__ \
-       * of the return value of that f. If the first signature did      __NL__ \
-       * not fit (could not be instantiated), then according to         __NL__ \
-       * SFINAE the second one will be the chosen one                   __NL__ \
-       * (since it can’t fail) and we will take the sizeof of a         __NL__ \
-       * char array of size 2, which is 2. Therefore, the value         __NL__ \
-       * will be evaluated to true – meaning that class T really        __NL__ \
-       * has a member by the name MEMBER_NAME. Otherwise, the first     __NL__ \
-       * function can be successfully instantiated, and we will measure __NL__ \
-       * the sizeof of a char array of size 1, which is 1. In that case __NL__ \
-       * the value is evaluated to false – which is good for us, since  __NL__ \
-       * that means there was no ambiguity when using                   __NL__ \
-       * Derived::MEMBER_NAME, and that means there was no other        __NL__ \
-       * MEMBER_NAME but the one in Fallback.                           __NL__ \
-       */                                                               __NL__ \
+      /* As you could guess, we will try to check which f function   */ __NL__ \
+      /* can be instantiated. We will do this by checking the sizeof */ __NL__ \
+      /* of the return value of that f. If the first signature did   */ __NL__ \
+      /* not fit (could not be instantiated), then according to      */ __NL__ \
+      /* SFINAE the second one will be the chosen one                */ __NL__ \
+      /* (since it can’t fail) and we will take the sizeof of a      */ __NL__ \
+      /* char array of size 2, which is 2. Therefore, the value      */ __NL__ \
+      /* will be evaluated to true – meaning that class T really     */ __NL__ \
+      /* has a member by the name MEMBER_NAME. Otherwise, the first  */ __NL__ \
+      /* function can be successfully instantiated, and we will      */ __NL__ \
+      /* measure the sizeof of a char array of size 1, which is 1.   */ __NL__ \
+      /* In that case, the value is evaluated to false – which is    */ __NL__ \
+      /* good for us sincethat means there was no ambiguity when     */ __NL__ \
+      /* using Derived::MEMBER_NAME, and that means there was no     */ __NL__ \
+      /* other MEMBER_NAME but the one in Fallback.                  */ __NL__ \
+                                                                        __NL__ \
       static bool const value = sizeof(f<Derived>(0)) == 2;             __NL__ \
 };

--- a/src/kaleidoscope_internal/type_traits/has_method.h
+++ b/src/kaleidoscope_internal/type_traits/has_method.h
@@ -62,7 +62,7 @@
                METHOD_NAME ADD_TEMPLATE_BRACES(UNWRAP TMPL_PARAM_LIST)  __NL__ \
          ), bool{}                                                      __NL__ \
       )                                                                 __NL__ \
-      test(int /* unused */)                                            __NL__ \
+      test(int /* unused */) /* NOLINT(readability/casting) */          __NL__ \
       {                                                                 __NL__ \
          return true;                                                   __NL__ \
       }                                                                 __NL__ \
@@ -75,4 +75,3 @@
                                                                         __NL__ \
       static constexpr bool value = test<Class__>(int{});               __NL__ \
    };
-

--- a/src/kaleidoscope_internal/type_traits/has_method.h
+++ b/src/kaleidoscope_internal/type_traits/has_method.h
@@ -23,40 +23,40 @@
                                  METHOD_NAME,                                  \
                                  RETURN_TYPE, ARGUMENTS)                       \
                                                                         __NL__ \
-   /* This traits checks if a class of type Class__                     __NL__ \
-    * implements a method with given signature.                         __NL__ \
-    */                                                                  __NL__ \
+   /* This traits checks if a class of type Class__                   */ __NL__ \
+   /* implements a method with given signature.                       */ __NL__ \
+                                                                        __NL__ \
    template<typename Class__ UNWRAP TMPL_PARAM_TYPE_LIST>               __NL__ \
    struct GLUE3(PREFIX, _HasMethod_, METHOD_NAME)                       __NL__ \
    {                                                                    __NL__ \
-      /* Define a pointer to member function with the correct           __NL__ \
-       * argument signature. The newly defined type is named            __NL__ \
-       * MethodType__.                                                  __NL__ \
-       */                                                               __NL__ \
+      /* Define a pointer to member function with the correct        */ __NL__ \
+      /* argument signature. The newly defined type is named         */ __NL__ \
+      /* MethodType__.                                               */ __NL__ \
+      /* */                                                             __NL__ \
       typedef RETURN_TYPE (Class__::*MethodType__)ARGUMENTS;            __NL__ \
                                                                         __NL__ \
-      /* This is an application of the SFINAE concept.                  __NL__ \
-       * We check if Class__ defines a method with given name and       __NL__ \
-       * signature. This is done by forcing the compiler                __NL__ \
-       * through a static cast to select the respective method          __NL__ \
-       * if possible. If the method signature cannot be found,          __NL__ \
-       * the substitution fails and the first version of method "test"  __NL__ \
-       * will not be defined.                                           __NL__ \
-       */                                                               __NL__ \
+      /* This is an application of the SFINAE concept.                */ __NL__ \
+      /* We check if Class__ defines a method with given name and     */ __NL__ \
+      /* signature. This is done by forcing the compiler              */ __NL__ \
+      /* through a static cast to select the respective method        */ __NL__ \
+      /* if possible. If the method signature cannot be found,        */ __NL__ \
+      /* the substitution fails and the first version of method "test"*/ __NL__ \
+      /* will not be defined.                                         */ __NL__ \
+                                                                        __NL__ \
       template <typename ClassAux__>                                    __NL__ \
       static constexpr                                                  __NL__ \
-      /* The following decltype-clause defines the function return type __NL__ \
-       */                                                               __NL__ \
+      /* The following decltype-clause defines the function return type */ __NL__ \
+                                                                        __NL__ \
       decltype(                                                         __NL__ \
-         /* If &ClassAux__::METHOD_NAME exists and is of type           __NL__ \
-          * MethodType__, the list below evaluates to bool{} whose      __NL__ \
-          * type can be determined. Otherwise the comma expression      __NL__ \
-          * cannot be evaluated and the content                         __NL__ \
-          * of decltype is undefined and this function overload         __NL__ \
-          * is ignored by the compiler                                  __NL__ \
-          * (SFINAE = substitution failure is not an error)             __NL__ \
-          * and the test(...) overload is used instead.                 __NL__ \
-          */                                                            __NL__ \
+         /* If &ClassAux__::METHOD_NAME exists and is of type        */ __NL__ \
+         /* MethodType__, the list below evaluates to bool{} whose   */ __NL__ \
+         /* type can be determined. Otherwise the comma expression   */ __NL__ \
+         /* cannot be evaluated and the content                      */ __NL__ \
+         /* of decltype is undefined and this function overload      */ __NL__ \
+         /* is ignored by the compiler                               */ __NL__ \
+         /* (SFINAE = substitution failure is not an error)          */ __NL__ \
+         /* and the test(...) overload is used instead.              */ __NL__ \
+                                                                        __NL__ \
          static_cast<MethodType__>(                                     __NL__ \
             &ClassAux__::TEMPLATE_KEYWORD(UNWRAP TMPL_PARAM_LIST)       __NL__ \
                METHOD_NAME ADD_TEMPLATE_BRACES(UNWRAP TMPL_PARAM_LIST)  __NL__ \

--- a/testing/setup-googletest.h
+++ b/testing/setup-googletest.h
@@ -36,5 +36,7 @@
     /* Turn off virtual_io's input. */ \
     Kaleidoscope.device().keyScanner().setEnableReadMatrix(false); \
     testing::InitGoogleTest(); \
-    RUN_ALL_TESTS(); \
+    /* We assign the return value of RUN_ALL_TESTS, to */ \
+    /* silence a compiler warning. */                     \
+    int __ignore__ = RUN_ALL_TESTS();           \
   }


### PR DESCRIPTION
Once the codebase is cpplint clean, cpplint checks will become mandatory.