### PR TITLE
Add Qukeys "tap-repeat" feature

### DIFF
--- a/docs/NEWS.md
+++ b/docs/NEWS.md
@@ -12,6 +12,24 @@ See [UPGRADING.md](UPGRADING.md) for more detailed instructions about upgrading 
 
 ## New features
 
+### New Qukeys features
+
+#### Tap-repeat
+
+It is now possible to get the "tap" value of a qukey to repeat (as if that key
+for that character was simply being held down on a normal keyboard) by tapping
+the qukey, then quickly pressing and holding it down. The result on the OS will
+be as if the key was pressed and held just once, so that users of macOS apps
+that use the Cocoa input system can get the menu for characters with diacritics
+without an extra character in the output.
+
+The maximum interval between the two keypresses that will trigger a tap repeat
+can be configured via the `Qukeys.setMaxIntervalForTapRepeat(ms)` function,
+where the argument specifies the number of milliseconds Qukeys will wait after a
+qukey is tapped for it to be pressed a second time. If it is, but the qukey is
+released within that same interval from the first tap's release, it will be
+treated as a double-tap, and both taps will be sent to the OS.
+
 ### Better protection against unintended modifiers from Qukeys
 
 Qukeys has two new configuration options for preventing unintended modifiers in

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -32,6 +32,35 @@ any API we've included in a release. Typically, this means that any code that us
 
 ## New features
 
+### Keymap cache changes
+
+The keymap cache (`Layer_::live_composite_keymap_[]`) has been replaced by an "active keys" cache (`Runtime_::active_keys_[]`). The top-level function that handles keyswitch events has been updated to make the new cache a representation of the current state of the keyboard, with corresponding `Key` values for any keys that are active (physically held or activated by a plugin).
+
+#### For end-users
+
+There should be no user-visible changes for anyone who simply uses core plugins. A few functions have been deprecated (`Layer.eventHandler()` & `Layer.updateLiveCompositeKeymap()`), but there are straightforward replacements for both.
+
+#### For developers
+
+The major changes are to the `handleKeyswitchEvent()` function, which has been reorganized in order to update the new active keys cache with correct values at the appropriate times. In addition to that, two new facilities are available:
+
+##### `EventHandlerResult::ABORT`
+
+This is a new return value available to plugin event handlers, which is similar to `EVENT_CONSUMED` in that it causes the calling hook function to return early (stopping any subsequent handlers from seeing the event), but is treated differently by `handleKeyswitchEvent()`. If a handler returns `EVENT_CONSUMED`, the active keys cache will still be updated by `handleKeyswitchEvent()`, but if it returns `ABORT`, it will not. In both cases, no further event processing will be done by the built-in event handler.
+
+##### `Runtime.activeKey(key_addr)`
+
+This is a new function that can be used to check the value of an entry in the active keys cache. For example, it could be used in a range-based `for` loop to check for values of interest:
+
+```c++
+for (KeyAddr key_addr : KeyAddr::all()) {
+  Key key = Runtime.activeKey(key_addr);
+  if (key == Key_LeftShift || key == Key_RightShift) {
+    // do something special...
+  }
+}
+```
+
 ### New device API
 
 We are introducing - or rather, replacing - the older hardware plugins, with a system that's much more composable, more extensible, and will allow us to better support new devices, different MCUs, and so on.
@@ -564,6 +593,14 @@ The following headers and names have changed:
 - [SpaceCadet](plugins/SpaceCadet.md) had the `kaleidoscope::SpaceCadet::KeyBinding` type replaced by `kaleidoscope::plugin::SpaceCadet::KeyBinding`.
 - [Syster](plugins/Syster.md) had the `kaleidoscope::Syster::action_t` type replaced by `kaleidoscope::plugin::Syster::action_t`.
 - [TapDance](plugins/TapDance.md) had the `kaleidoscope::TapDance::ActionType` type replaced by `kaleidoscope::plugin::TapDance::ActionType`.
+
+### Live Composite Keymap Cache
+
+The live composite keymap, which contained a lazily-updated version of the current keymap, has been replaced. The `Layer.updateLiveCompositeKeymap()` functions have been deprecated, and depending on the purpose of the caller, it might be appropriate to use `Runtime.updateActiveKey()` instead.
+
+When `handleKeyswitchEvent()` is looking up a `Key` value for an event, it first checks the value in the active keys cache before calling `Layer.lookup()` to get the value from the keymap. In the vast majority of cases, it won't be necessary to call `Runtime.updateActiveKey()` manually, however, because simply changing the value of the `Key` parameter of an `onKeyswitchEvent()` handler will have the same effect.
+
+Second, the `Layer.eventHandler()` function has been deprecated. There wasn't much need for this to be available to plugins, and it's possible to call `Layer.handleKeymapKeyswitchEvent()` directly instead.
 
 # Removed APIs
 

--- a/docs/plugins/Qukeys.md
+++ b/docs/plugins/Qukeys.md
@@ -75,6 +75,22 @@ likely to generate errors and out-of-order events.
 >
 > Defaults to `250`.
 
+### `.setMaxIntervalForTapRepeat(timeout)`
+
+> Sets the time (in milliseconds) that limits the tap-repeat window. If the same
+> qukey is pressed, released, and pressed again within this timeframe, then
+> held, Qukeys will turn it into a single press and hold event, using the
+> primary key value (which cannot otherwise be held). If the second press is
+> also a tap, and the two _release_ events occur within the same timeframe, it
+> will instead be treated as a double tap (of the primary key value).
+>
+> To effectively shut off the tap-repeat feature, set this value to `0`. The
+> maximum value is `255`; anything higher than `250` could result in key repeat
+> being triggered on the host before Qukeys determines whether it's a tap-repeat
+> or a double-tap sequence, because most systems delay the key repeat by 500 ms.
+>
+> Defaults to `200`.
+
 ### `.setOverlapThreshold(percentage)`
 
 > This sets a variable that allows the user to roll over from a qukey to a
@@ -203,6 +219,16 @@ There is a special value (`Qukeys::layer_wildcard`) that can be used in place of
 the layer number in the definition of a `Qukey`. This will define a qukey with
 the given alternate value on all layers, regardless of what the primary value is
 for that key on the top currently active layer.
+
+
+### Tap-Repeat Behaviour
+
+If a qukey is tapped, then immediately pressed and held, Qukeys will turn that
+sequence of events into a single press and hold of the primary key value
+(whereas merely holding the key yeilds the alternate value). This is
+particularly useful on macOS apps that use Apple's Cocoa input system, where
+holding a key gives the user access to a menu of accented characters, rather
+than merely repeating the same character until the key is released.
 
 
 ## Design & Implementation

--- a/examples/Keystrokes/Qukeys/Qukeys.ino
+++ b/examples/Keystrokes/Qukeys/Qukeys.ino
@@ -74,6 +74,7 @@ void setup() {
   Qukeys.setOverlapThreshold(50);
   Qukeys.setMinimumHoldTime(100);
   Qukeys.setMinimumPriorInterval(80);
+  Qukeys.setMaxIntervalForTapRepeat(150);
 
   Kaleidoscope.setup();
 }

--- a/src/kaleidoscope/Runtime.cpp
+++ b/src/kaleidoscope/Runtime.cpp
@@ -21,6 +21,7 @@
 namespace kaleidoscope {
 
 uint32_t Runtime_::millis_at_cycle_start_;
+Key Runtime_::active_keys_[kaleidoscope_internal::device.numKeys()];
 
 Runtime_::Runtime_(void) {
 }
@@ -41,6 +42,11 @@ Runtime_::setup(void) {
   kaleidoscope::Hooks::onSetup();
 
   device().setup();
+
+  // Clear the active keys array (all keys idle at start)
+  for (auto key_addr : KeyAddr::all()) {
+    updateActiveKey(key_addr, Key_Transparent);
+  }
 
   Layer.setup();
 }

--- a/src/kaleidoscope/Runtime.h
+++ b/src/kaleidoscope/Runtime.h
@@ -128,8 +128,16 @@ class Runtime_ {
     return kaleidoscope::Hooks::onFocusEvent(command);
   }
 
+  static Key activeKey(KeyAddr key_addr) {
+    return active_keys_[key_addr.toInt()];
+  }
+  static void updateActiveKey(KeyAddr key_addr, Key key) {
+    active_keys_[key_addr.toInt()] = key;
+  }
+
  private:
   static uint32_t millis_at_cycle_start_;
+  static Key active_keys_[kaleidoscope_internal::device.numKeys()];
 };
 
 extern kaleidoscope::Runtime_ Runtime;

--- a/src/kaleidoscope/event_handler_result.h
+++ b/src/kaleidoscope/event_handler_result.h
@@ -21,6 +21,7 @@ namespace kaleidoscope {
 enum class EventHandlerResult {
   OK,
   EVENT_CONSUMED,
+  ABORT,
   ERROR,
 };
 

--- a/src/kaleidoscope/event_handler_result.h
+++ b/src/kaleidoscope/event_handler_result.h
@@ -18,6 +18,29 @@
 
 namespace kaleidoscope {
 
+// This is the set of return values for event handlers. Event handlers for
+// plugins are called in sequence by the corresponding hook function, in plugin
+// initialization order. The interpretation of these return values can vary
+// based on the needs of the hook function, but should be as follows:
+//
+// - OK: Continue processing the event. The calling hook function should
+//       continue calling next event handler in the sequence. If all event
+//       handlers return `OK`, finish processing the event.
+//
+// - EVENT_CONSUMED: Stop processing event handlers. The calling hook function
+//       should not call any further handlers, but may continue to take some
+//       actions to finish processing the event. This should be used to indicate
+//       that the event has been successfully handled.
+//
+// - ABORT: Ignore the event. The calling hook function should not call any
+//       further handlers, and should treat the event as if it didn't
+//       happen. This should be used by plugin handlers that need to either
+//       suppress an event or queue the event in order to delay it.
+//
+// - ERROR: Undefined error. The calling hook function should not call any
+//       further handlers. There is currently no specification for what should
+//       happen if this is returned.
+
 enum class EventHandlerResult {
   OK,
   EVENT_CONSUMED,

--- a/src/kaleidoscope/key_events.cpp
+++ b/src/kaleidoscope/key_events.cpp
@@ -40,7 +40,7 @@ static bool handleSyntheticKeyswitchEvent(Key mappedKey, uint8_t keyState) {
   } else if (mappedKey.getFlags() & IS_INTERNAL) {
     return false;
   } else if (mappedKey.getFlags() & SWITCH_TO_KEYMAP) {
-    // Should not happen, handled elsewhere.
+    Layer.handleKeymapKeyswitchEvent(mappedKey, keyState);
   }
 
   return true;
@@ -139,6 +139,5 @@ void handleKeyswitchEvent(Key mappedKey, KeyAddr key_addr, uint8_t keyState) {
     return;
 
   // Handle all built-in key types.
-  Layer.eventHandler(mappedKey, key_addr, keyState);
   handleKeyswitchEventDefault(mappedKey, key_addr, keyState);
 }

--- a/src/kaleidoscope/keyswitch_state.h
+++ b/src/kaleidoscope/keyswitch_state.h
@@ -20,7 +20,6 @@
 #include <Arduino.h>
 
 #define INJECTED    B10000000
-#define EPHEMERAL   B01000000
 #define IS_PRESSED  B00000010
 #define WAS_PRESSED B00000001
 

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -121,6 +121,9 @@ class Layer_ {
     return layer_state_;
   }
 
+  static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState);
+
+  DEPRECATED(LAYER_EVENTHANDLER)
   static Key eventHandler(Key mappedKey, KeyAddr key_addr, uint8_t keyState);
 
   typedef Key(*GetKeyFunction)(uint8_t layer, KeyAddr key_addr);
@@ -147,8 +150,6 @@ class Layer_ {
   static uint8_t active_layer_count_;
   static int8_t active_layers_[31];
   static uint8_t active_layer_keymap_[kaleidoscope_internal::device.numKeys()];
-
-  static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState);
 };
 }
 

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -20,6 +20,7 @@
 #include "kaleidoscope/key_defs.h"
 #include "kaleidoscope/keymaps.h"
 #include "kaleidoscope/device/device.h"
+#include "kaleidoscope/Runtime.h"
 #include "kaleidoscope_internal/device.h"
 #include "kaleidoscope_internal/sketch_exploration/sketch_exploration.h"
 #include "kaleidoscope_internal/shortname.h"
@@ -83,7 +84,13 @@ class Layer_ {
    * `lookupOnActiveLayer`.
    */
   static Key lookup(KeyAddr key_addr) {
-    return live_composite_keymap_[key_addr.toInt()];
+    // First check the active keys array
+    Key key = Runtime.activeKey(key_addr);
+    // If that entry is clear, look up the entry from the active keymap layers
+    if (key == Key_Transparent) {
+      key = lookupOnActiveLayer(key_addr);
+    }
+    return key;
   }
   static Key lookupOnActiveLayer(KeyAddr key_addr) {
     uint8_t layer = active_layer_keymap_[key_addr.toInt()];
@@ -121,9 +128,11 @@ class Layer_ {
 
   static Key getKeyFromPROGMEM(uint8_t layer, KeyAddr key_addr);
 
+  DEPRECATED(LAYER_UPDATELIVECOMPOSITEKEYMAP)
   static void updateLiveCompositeKeymap(KeyAddr key_addr, Key mappedKey) {
-    live_composite_keymap_[key_addr.toInt()] = mappedKey;
+    Runtime.updateActiveKey(key_addr, mappedKey);
   }
+  DEPRECATED(LAYER_UPDATELIVECOMPOSITEKEYMAP)
   static void updateLiveCompositeKeymap(KeyAddr key_addr);
   static void updateActiveLayers(void);
 
@@ -137,7 +146,6 @@ class Layer_ {
   static uint32_t layer_state_;
   static uint8_t active_layer_count_;
   static int8_t active_layers_[31];
-  static Key live_composite_keymap_[kaleidoscope_internal::device.numKeys()];
   static uint8_t active_layer_keymap_[kaleidoscope_internal::device.numKeys()];
 
   static void handleKeymapKeyswitchEvent(Key keymapEntry, uint8_t keyState);

--- a/src/kaleidoscope/plugin/Qukeys.cpp
+++ b/src/kaleidoscope/plugin/Qukeys.cpp
@@ -67,7 +67,7 @@ EventHandlerResult Qukeys::onKeyswitchEvent(Key& key, KeyAddr k, uint8_t key_sta
     }
     // Any event that gets added to the queue gets re-processed later, so we
     // need to abort processing now.
-    return EventHandlerResult::EVENT_CONSUMED;
+    return EventHandlerResult::ABORT;
   }
 
   // The key is being held. We need to determine if we should block it because
@@ -84,7 +84,7 @@ EventHandlerResult Qukeys::onKeyswitchEvent(Key& key, KeyAddr k, uint8_t key_sta
       }
       // Otherwise, the first matching event was a key press, so we need to
       // suppress it for now.
-      return EventHandlerResult::EVENT_CONSUMED;
+      return EventHandlerResult::ABORT;
     }
   }
 

--- a/src/kaleidoscope/plugin/Qukeys.h
+++ b/src/kaleidoscope/plugin/Qukeys.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Qukeys -- Assign two keycodes to a single key
- * Copyright (C) 2017-2019  Michael Richters
+ * Copyright (C) 2017-2020  Michael Richters
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -103,6 +103,17 @@ class Qukeys : public kaleidoscope::Plugin {
   // value is a modifier -- i.e. a SpaceCadet type key).
   void setHoldTimeout(uint16_t hold_timeout) {
     hold_timeout_ = hold_timeout;
+  }
+
+  // Set the timeout (in milliseconds) for the tap-repeat feature. If a qukey is
+  // tapped twice in a row in less time than this amount, it will allow the user
+  // to hold the key with its primary value (unless it's a SpaceCadet type key,
+  // in which case it will repeat the alternate value instead). This requires a
+  // quick tap immediately followed by a press and hold, and will result in a
+  // single press-and-hold on the host system. If a double tap is done instead,
+  // it will result in two independent taps.
+  void setMaxIntervalForTapRepeat(uint8_t ttl) {
+    tap_repeat_.timeout = ttl;
   }
 
   // Set the percentage of the duration of a subsequent key's press that must
@@ -226,6 +237,14 @@ class Qukeys : public kaleidoscope::Plugin {
   bool isDualUseKey(Key key);
   bool releaseDelayed(uint16_t overlap_start, uint16_t overlap_end) const;
   bool isKeyAddrInQueueBeforeIndex(KeyAddr k, uint8_t index) const;
+
+  // Tap-repeat feature support.
+  struct {
+    KeyAddr addr{KeyAddr::invalid_state};
+    uint16_t start_time;
+    uint8_t timeout{200};
+  } tap_repeat_;
+  bool shouldWaitForTapRepeat();
 };
 
 // This function returns true for any key that we expect to be used chorded with

--- a/src/kaleidoscope_internal/deprecations.h
+++ b/src/kaleidoscope_internal/deprecations.h
@@ -46,3 +46,10 @@
   "Layers are now in activation-order, please use" __NL__ \
   "`Layer.forEachActiveLayer()` instead."
 
+#define _DEPRECATED_MESSAGE_LAYER_UPDATELIVECOMPOSITEKEYMAP             __NL__ \
+  "`Layer.updateLiveCompositeKeymap()` is deprecated.\n"                __NL__ \
+  "The 'live composite keymap' cache has been replaced with the\n"      __NL__ \
+  "'active keys' cache, which now represents the state of the active\n" __NL__ \
+  "keys at any given time. It is probably not necessary to directly\n"  __NL__ \
+  "update that cache from a plugin, but if you need to, please use\n"   __NL__ \
+  "the `Runtime.updateActiveKey(key_addr, key)` function instead."

--- a/src/kaleidoscope_internal/deprecations.h
+++ b/src/kaleidoscope_internal/deprecations.h
@@ -53,3 +53,7 @@
   "keys at any given time. It is probably not necessary to directly\n"  __NL__ \
   "update that cache from a plugin, but if you need to, please use\n"   __NL__ \
   "the `Runtime.updateActiveKey(key_addr, key)` function instead."
+
+#define _DEPRECATED_MESSAGE_LAYER_EVENTHANDLER               __NL__ \
+  "`Layer.eventHandler()` is deprecated.\n"                  __NL__ \
+  "Please use `Layer.handleKeymapKeyswitchEvent()` instead."

--- a/src/kaleidoscope_internal/event_dispatch.h
+++ b/src/kaleidoscope_internal/event_dispatch.h
@@ -167,7 +167,7 @@
    result = EventHandler__::call(PLUGIN, hook_args...);              __NL__ \
                                                                      __NL__ \
    if (EventHandler__::shouldAbortOnConsumedEvent() &&               __NL__ \
-       result == kaleidoscope::EventHandlerResult::EVENT_CONSUMED) { __NL__ \
+       result != kaleidoscope::EventHandlerResult::OK) {             __NL__ \
       return result;                                                 __NL__ \
    }                                                                 __NL__
 

--- a/src/kaleidoscope_internal/event_dispatch.h
+++ b/src/kaleidoscope_internal/event_dispatch.h
@@ -80,7 +80,7 @@
 
 #define _REGISTER_EVENT_HANDLER(                                                 \
     HOOK_NAME, HOOK_VERSION, DEPRECATION_TAG,                                    \
-    SHOULD_ABORT_ON_CONSUMED_EVENT,                                              \
+    SHOULD_EXIT_IF_RESULT_NOT_OK,                                                \
     TMPL_PARAM_TYPE_LIST, TMPL_PARAM_LIST, TMPL_DUMMY_ARGS_LIST,                 \
     SIGNATURE, ARGS_LIST)                                                 __NL__ \
                                                                           __NL__ \
@@ -116,8 +116,8 @@
    MAKE_TEMPLATE_SIGNATURE(UNWRAP TMPL_PARAM_TYPE_LIST)                   __NL__ \
    struct _NAME4(EventHandler_, HOOK_NAME, _v, HOOK_VERSION) {            __NL__ \
                                                                           __NL__ \
-      static bool shouldAbortOnConsumedEvent() {                          __NL__ \
-        return SHOULD_ABORT_ON_CONSUMED_EVENT;                            __NL__ \
+      static bool shouldExitIfResultNotOk() {                             __NL__ \
+        return SHOULD_EXIT_IF_RESULT_NOT_OK;                              __NL__ \
       }                                                                   __NL__ \
                                                                           __NL__ \
       template<typename Plugin__,                                         __NL__ \
@@ -166,7 +166,7 @@
                                                                      __NL__ \
    result = EventHandler__::call(PLUGIN, hook_args...);              __NL__ \
                                                                      __NL__ \
-   if (EventHandler__::shouldAbortOnConsumedEvent() &&               __NL__ \
+   if (EventHandler__::shouldExitIfResultNotOk() &&                  __NL__ \
        result != kaleidoscope::EventHandlerResult::OK) {             __NL__ \
       return result;                                                 __NL__ \
    }                                                                 __NL__

--- a/tests/features/events/active-keys/macros/common.h
+++ b/tests/features/events/active-keys/macros/common.h
@@ -1,0 +1,27 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/tests/features/events/active-keys/macros/sketch.ino
+++ b/tests/features/events/active-keys/macros/sketch.ino
@@ -1,0 +1,82 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-Macros.h>
+
+#include "./common.h"
+
+#undef min
+#undef max
+#include <iostream>
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        Key_A, ___, ___, ___, ___, ___, ___,
+        ShiftToLayer(1), ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+    [1] = KEYMAP_STACKED
+    (
+        M(0), ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+const macro_t *macroAction(uint8_t index, uint8_t key_state) {
+  if (keyToggledOn(key_state)) {
+    switch (index) {
+    case 0:
+      Kaleidoscope.hid().keyboard().pressKey(Key_Y);
+      break;
+    }
+  }
+  return MACRO_NONE;
+}
+
+KALEIDOSCOPE_INIT_PLUGINS(Macros);
+
+void setup() {
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/features/events/active-keys/macros/test.ktest
+++ b/tests/features/events/active-keys/macros/test.ktest
@@ -1,0 +1,51 @@
+VERSION 1
+
+KEYSWITCH A 0 0
+KEYSWITCH LAYER_SHIFT 1 0
+
+# ==============================================================================
+# Active Keys Cache
+NAME Active keys cache cleared
+
+RUN 10 ms
+
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # Report should contain only `A`
+
+RUN 5 ms
+
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+
+RUN 5 ms
+
+# Press and hold `ShiftToLayer(1)`, changing the `A` key to `X`
+PRESS LAYER_SHIFT
+RUN 5 ms
+
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_Y # Report should contain only `Y`
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+
+RUN 5 ms
+
+RELEASE A
+
+RUN 5 ms
+
+RELEASE LAYER_SHIFT
+RUN 5 ms
+
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # Report should contain only `A`
+
+RUN 5 ms
+
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty

--- a/tests/features/events/active-keys/release-cleared/common.h
+++ b/tests/features/events/active-keys/release-cleared/common.h
@@ -1,0 +1,27 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/tests/features/events/active-keys/release-cleared/sketch.ino
+++ b/tests/features/events/active-keys/release-cleared/sketch.ino
@@ -1,0 +1,104 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+
+#include "./common.h"
+
+#undef min
+#undef max
+#include <iostream>
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        Key_A, ___, ___, ___, ___, ___, ___,
+        ShiftToLayer(1), ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+    [1] = KEYMAP_STACKED
+    (
+        Key_X, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+namespace kaleidoscope {
+namespace plugin {
+
+class ConvertXtoY : public kaleidoscope::Plugin {
+ public:
+  EventHandlerResult onKeyswitchEvent(Key &key, KeyAddr key_addr, uint8_t key_state) {
+    if (keyToggledOn(key_state)) {
+      if (key == Key_X)
+        key = Key_Y;
+    }
+    // It should be impossible to get a `Key_X` at this point, because the
+    // previous block changes any `Key_X` to `Key_Y`, which results in the
+    // active keys cache storing that value. On subsequent cycles (while the key
+    // is still pressed), the `key` value should be `Key_Y`.
+    if (keyIsPressed(key_state) && key == Key_X) {
+      std::cerr << "t=" << Runtime.millisAtCycleStart() << ": "
+                << "Error: we shouldn't see a key with value `X`" << std::endl;
+    }
+    // When `Key_Y` toggles off, return `EVENT_CONSUMED`. Despite this, the
+    // active keys cache entry should be cleared. If it's not, then a subsequent
+    // press of the same key without the layer shift in effect will still result
+    // in `Key_Y` instead of `Key_A`.
+    if (keyToggledOff(key_state) && (key == Key_Y)) {
+      return EventHandlerResult::EVENT_CONSUMED;
+    }
+    return EventHandlerResult::OK;
+  }
+};
+
+} // namespace plugin
+} // namespace kaleidoscope
+
+kaleidoscope::plugin::ConvertXtoY ConvertXtoY;
+
+KALEIDOSCOPE_INIT_PLUGINS(ConvertXtoY);
+
+void setup() {
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/features/events/active-keys/release-cleared/test.ktest
+++ b/tests/features/events/active-keys/release-cleared/test.ktest
@@ -1,0 +1,59 @@
+VERSION 1
+
+KEYSWITCH A 0 0
+KEYSWITCH LAYER_SHIFT 1 0
+
+# ==============================================================================
+# Active Keys Cache
+NAME Active keys cache cleared
+
+RUN 10 ms
+
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # Report should contain only `A`
+
+RUN 5 ms
+
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+
+RUN 5 ms
+
+# Press and hold `ShiftToLayer(1)`, changing the `A` key to `X`
+PRESS LAYER_SHIFT
+RUN 5 ms
+
+# Press `X`, which gets converted to `Y` by the `ConvertXtoY` plugin defined in
+# the sketch. The plugin simply changes the value of the key, which causes it to
+# get set to `Key_Y` in the active keys cache.
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_Y # Report should contain only `Y`
+
+RUN 5 ms
+
+# Release the `X` key (on Layer 1), which has become a `Y` key in the active
+# keys cache. This should clear its entry in that cache.
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+
+RUN 5 ms
+
+# Release `ShiftToLayer(1)`. This should restore the `A` key to its base layer
+# value on subsequent presses, unless the Macros key gets "stuck" in the active
+# keys array because it returns `EVENT_CONSUMED`.
+RELEASE LAYER_SHIFT
+RUN 5 ms
+
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # Report should contain only `A`
+
+RUN 5 ms
+
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty

--- a/tests/issues/970/common.h
+++ b/tests/issues/970/common.h
@@ -27,6 +27,7 @@ constexpr uint16_t QUKEYS_HOLD_TIMEOUT = 200;
 constexpr uint8_t QUKEYS_OVERLAP_THRESHOLD = 90;
 constexpr uint8_t QUKEYS_MINIMUM_HOLD_TIME = 10;
 constexpr uint8_t QUKEYS_MIN_PRIOR_INTERVAL = 20;
+constexpr uint8_t QUKEYS_MAX_INTERVAL_FOR_TAP_REPEAT = 0;
 
 }
 }

--- a/tests/issues/970/sketch.ino
+++ b/tests/issues/970/sketch.ino
@@ -90,6 +90,7 @@ void setup() {
   Qukeys.setOverlapThreshold(kaleidoscope::testing::QUKEYS_OVERLAP_THRESHOLD);
   Qukeys.setMinimumHoldTime(kaleidoscope::testing::QUKEYS_MINIMUM_HOLD_TIME);
   Qukeys.setMinimumPriorInterval(kaleidoscope::testing::QUKEYS_MIN_PRIOR_INTERVAL);
+  Qukeys.setMaxIntervalForTapRepeat(kaleidoscope::testing::QUKEYS_MAX_INTERVAL_FOR_TAP_REPEAT);
 
   Kaleidoscope.setup();
 }

--- a/tests/plugins/Qukeys/TapRepeat/common.h
+++ b/tests/plugins/Qukeys/TapRepeat/common.h
@@ -1,0 +1,33 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+constexpr uint16_t QUKEYS_HOLD_TIMEOUT = 200;
+constexpr uint8_t QUKEYS_OVERLAP_THRESHOLD = 0;
+constexpr uint8_t QUKEYS_MINIMUM_HOLD_TIME = 0;
+constexpr uint8_t QUKEYS_MIN_PRIOR_INTERVAL = 0;
+constexpr uint8_t QUKEYS_MAX_TAP_REPEAT_INTERVAL = 20;
+
+}
+}

--- a/tests/plugins/Qukeys/TapRepeat/sketch.ino
+++ b/tests/plugins/Qukeys/TapRepeat/sketch.ino
@@ -1,0 +1,62 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-Qukeys.h>
+
+#include "./common.h"
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        Key_A, Key_LeftAlt, ___, ___, ___, ___, ___,
+        SFT_T(J), ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+// Use Qukeys
+KALEIDOSCOPE_INIT_PLUGINS(Qukeys);
+
+void setup() {
+  QUKEYS(
+    kaleidoscope::plugin::Qukey(0, KeyAddr(0, 0), Key_LeftGui),
+    kaleidoscope::plugin::Qukey(0, KeyAddr(0, 1), Key_B)
+  )
+  Qukeys.setHoldTimeout(kaleidoscope::testing::QUKEYS_HOLD_TIMEOUT);
+  Qukeys.setOverlapThreshold(kaleidoscope::testing::QUKEYS_OVERLAP_THRESHOLD);
+  Qukeys.setMinimumHoldTime(kaleidoscope::testing::QUKEYS_MINIMUM_HOLD_TIME);
+  Qukeys.setMinimumPriorInterval(kaleidoscope::testing::QUKEYS_MIN_PRIOR_INTERVAL);
+  Qukeys.setMaxIntervalForTapRepeat(kaleidoscope::testing::QUKEYS_MAX_TAP_REPEAT_INTERVAL);
+
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/plugins/Qukeys/TapRepeat/test.ktest
+++ b/tests/plugins/Qukeys/TapRepeat/test.ktest
@@ -1,0 +1,134 @@
+VERSION 1
+
+KEYSWITCH A 0 0
+KEYSWITCH B 0 1
+KEYSWITCH J 1 0
+
+# ==============================================================================
+# Qukey tap-repeat test
+NAME TapRepeat Generic Qukey
+
+RUN 10 ms
+
+PRESS A
+RUN 5 ms
+
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # Report should contain only A
+RUN 5 ms
+
+PRESS A
+RUN 5 ms
+
+RELEASE A
+RUN 2 cycles
+EXPECT keyboard-report empty # Report should be empty
+EXPECT keyboard-report Key_A # Report should contain only A
+
+RUN 16 ms
+EXPECT keyboard-report empty # Report should be empty
+
+RUN 100 ms
+
+PRESS A
+RUN 5 ms
+
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # Report should contain only A
+RUN 5 ms
+
+PRESS A
+RUN 50 ms
+
+RELEASE A
+# I'm not sure why this takes 2 cycles instead of just one
+RUN 2 cycles
+EXPECT keyboard-report empty # Report should be empty
+
+# ==============================================================================
+# DualUse Qukey tap-repeat test
+NAME TapRepeat DualUse Qukey
+
+RUN 10 ms
+
+PRESS J
+RUN 5 ms
+
+RELEASE J
+RUN 1 cycle
+EXPECT keyboard-report Key_J # Report should contain only J
+RUN 5 ms
+
+PRESS J
+RUN 5 ms
+
+RELEASE J
+RUN 2 cycles
+EXPECT keyboard-report empty # Report should be empty
+EXPECT keyboard-report Key_J # Report should contain only J
+
+RUN 16 ms
+EXPECT keyboard-report empty # Report should be empty
+
+RUN 100 ms
+
+PRESS J
+RUN 5 ms
+
+RELEASE J
+RUN 1 cycle
+EXPECT keyboard-report Key_J # Report should contain only J
+RUN 5 ms
+
+PRESS J
+RUN 50 ms
+
+RELEASE J
+# I'm not sure why this takes 2 cycles instead of just one
+RUN 2 cycles
+EXPECT keyboard-report empty # Report should be empty
+
+# ==============================================================================
+# SpaceCadet Qukey tap-repeat test
+NAME TapRepeat SpaceCadet Qukey
+
+RUN 10 ms
+
+PRESS B
+RUN 5 ms
+
+RELEASE B
+RUN 1 cycle
+EXPECT keyboard-report Key_B # Report should contain only B
+RUN 5 ms
+
+PRESS B
+RUN 5 ms
+
+RELEASE B
+RUN 2 cycles
+EXPECT keyboard-report empty # Report should be empty
+EXPECT keyboard-report Key_B # Report should contain only B
+
+RUN 16 ms
+EXPECT keyboard-report empty # Report should be empty
+
+RUN 100 ms
+
+PRESS B
+RUN 5 ms
+
+RELEASE B
+RUN 1 cycle
+EXPECT keyboard-report Key_B # Report should contain only B
+RUN 5 ms
+
+PRESS B
+RUN 50 ms
+
+RELEASE B
+# I'm not sure why this takes 2 cycles instead of just one
+RUN 2 cycles
+EXPECT keyboard-report empty # Report should be empty

--- a/tests/plugins/Qukeys/basic/common.h
+++ b/tests/plugins/Qukeys/basic/common.h
@@ -27,6 +27,7 @@ constexpr uint16_t QUKEYS_HOLD_TIMEOUT = 200;
 constexpr uint8_t QUKEYS_OVERLAP_THRESHOLD = 90;
 constexpr uint8_t QUKEYS_MINIMUM_HOLD_TIME = 10;
 constexpr uint8_t QUKEYS_MIN_PRIOR_INTERVAL = 20;
+constexpr uint8_t QUKEYS_MAX_TAP_REPEAT_INTERVAL = 0;
 
 }
 }

--- a/tests/plugins/Qukeys/basic/sketch.ino
+++ b/tests/plugins/Qukeys/basic/sketch.ino
@@ -90,6 +90,7 @@ void setup() {
   Qukeys.setOverlapThreshold(kaleidoscope::testing::QUKEYS_OVERLAP_THRESHOLD);
   Qukeys.setMinimumHoldTime(kaleidoscope::testing::QUKEYS_MINIMUM_HOLD_TIME);
   Qukeys.setMinimumPriorInterval(kaleidoscope::testing::QUKEYS_MIN_PRIOR_INTERVAL);
+  Qukeys.setMaxIntervalForTapRepeat(kaleidoscope::testing::QUKEYS_MAX_TAP_REPEAT_INTERVAL);
 
   Kaleidoscope.setup();
 }


### PR DESCRIPTION
This change gives Qukeys the ability to repeat a primary keycode by tapping the key, then immediately pressing and holding it. While doing this, the extra release and press of the key are suppressed, so it looks to the host just like a simple press-and-hold event, which is particularly nice for users of macOS apps that use Cocoa, where holding letter keys is the "standard" way of accessing accented characters.

Closes #399