### PR TITLE
Correct plugin order for Atreus example

### DIFF
--- a/examples/Devices/Keyboardio/Atreus/Atreus.ino
+++ b/examples/Devices/Keyboardio/Atreus/Atreus.ino
@@ -106,11 +106,11 @@ KALEIDOSCOPE_INIT_PLUGINS(
   Focus,
   FocusEEPROMCommand,
   FocusSettingsCommand,
-  OneShot,
+  Qukeys,
   SpaceCadet,
-  MouseKeys,
+  OneShot,
   Macros,
-  Qukeys
+  MouseKeys
 );
 
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {


### PR DESCRIPTION
The biggest problem here is that Qukeys was listed last. It doesn't matter whether it comes before or after things like Focus, but it really needs to handle events before other keystroke-handling plugins like OneShot, TapDance, Macros, et cetera.

I also moved SpaceCadet up, since it does similar key value resolution, and MousKeys down, because it never changes the value of a key event.

I noticed this because of a comment inside [a user sketch posted on the forum](https://community.keyboard.io/t/atreus-german-qwerty-layout-firmware-with-umlaute/4159), reporting Qukeys causing key repetition.