### PR TITLE
Fix key macros

### DIFF
--- a/src/kaleidoscope/device/technomancy/Atreus.h
+++ b/src/kaleidoscope/device/technomancy/Atreus.h
@@ -107,9 +107,9 @@ class Atreus;
           R2C7, R2C8, R2C9, R2C10, R2C11,                                     \
     R3C6, R3C7, R3C8, R3C9, R3C10, R3C11                                      \
   )                                                                           \
-    R0C0, R0C1, R0C2, R0C3, R0C4, XXX,   R0C7, R0C8, R0C9, R0C10, R0C11, XXX  \
-    R1C0, R1C1, R1C2, R1C3, R1C4, XXX,   R1C7, R1C8, R1C9, R1C10, R1C11, XXX  \
-    R2C0, R2C1, R2C2, R2C3, R2C4, R3C5,  R2C7, R2C8, R2C9, R2C10, R2C11, XXX  \
+    R0C0, R0C1, R0C2, R0C3, R0C4, XXX,   R0C7, R0C8, R0C9, R0C10, R0C11, XXX,  \
+    R1C0, R1C1, R1C2, R1C3, R1C4, XXX,   R1C7, R1C8, R1C9, R1C10, R1C11, XXX,  \
+    R2C0, R2C1, R2C2, R2C3, R2C4, R3C5,  R2C7, R2C8, R2C9, R2C10, R2C11, XXX,  \
     R3C0, R3C1, R3C2, R3C3, R3C4, R3C6,  R3C7, R3C8, R3C9, R3C10, R3C11, XXX
 }
 }

--- a/src/kaleidoscope/device/technomancy/Atreus.h
+++ b/src/kaleidoscope/device/technomancy/Atreus.h
@@ -91,10 +91,10 @@ class Atreus;
     R3C0, R3C1, R3C2, R3C3, R3C4, R3C5, R3C6, R3C7, R3C8, R3C9, R3C10, R3C11  \
   )                                                                           \
                                                                               \
-    R0C0, R0C1, R0C2, R0C3, R0C4, XXX,    R0C7, R0C8, R0C9, R0C10, R0C11,     \
-    R1C0, R1C1, R1C2, R1C3, R1C4, XXX,    R1C7, R1C8, R1C9, R1C10, R1C11,     \
-    R2C0, R2C1, R2C2, R2C3, R2C4, R3C5,   R2C7, R2C8, R2C9, R2C10, R2C11,     \
-    R3C0, R3C1, R3C2, R3C3, R3C4, R3C6,   R3C7, R3C8, R3C9, R3C10, R3C11
+    R0C0, R0C1, R0C2, R0C3, R0C4, XXX,   R0C7, R0C8, R0C9, R0C10, R0C11, XXX, \
+    R1C0, R1C1, R1C2, R1C3, R1C4, XXX,   R1C7, R1C8, R1C9, R1C10, R1C11, XXX, \
+    R2C0, R2C1, R2C2, R2C3, R2C4, R3C5,  R2C7, R2C8, R2C9, R2C10, R2C11, XXX, \
+    R3C0, R3C1, R3C2, R3C3, R3C4, R3C6,  R3C7, R3C8, R3C9, R3C10, R3C11, XXX
 
 #define PER_KEY_DATA_STACKED(dflt,                                          \
     R0C0, R0C1, R0C2, R0C3, R0C4,                                             \
@@ -107,10 +107,10 @@ class Atreus;
           R2C7, R2C8, R2C9, R2C10, R2C11,                                     \
     R3C6, R3C7, R3C8, R3C9, R3C10, R3C11                                      \
   )                                                                           \
-    R0C0, R0C1, R0C2, R0C3, R0C4, dflt,   R0C7, R0C8, R0C9, R0C10, R0C11,     \
-    R1C0, R1C1, R1C2, R1C3, R1C4, dflt,   R1C7, R1C8, R1C9, R1C10, R1C11,     \
-    R2C0, R2C1, R2C2, R2C3, R2C4, R3C5,   R2C7, R2C8, R2C9, R2C10, R2C11,     \
-    R3C0, R3C1, R3C2, R3C3, R3C4, R3C6,   R3C7, R3C8, R3C9, R3C10, R3C11
+    R0C0, R0C1, R0C2, R0C3, R0C4, XXX,   R0C7, R0C8, R0C9, R0C10, R0C11, XXX  \
+    R1C0, R1C1, R1C2, R1C3, R1C4, XXX,   R1C7, R1C8, R1C9, R1C10, R1C11, XXX  \
+    R2C0, R2C1, R2C2, R2C3, R2C4, R3C5,  R2C7, R2C8, R2C9, R2C10, R2C11, XXX  \
+    R3C0, R3C1, R3C2, R3C3, R3C4, R3C6,  R3C7, R3C8, R3C9, R3C10, R3C11, XXX
 }
 }
 


### PR DESCRIPTION
The macros are causing keymaps to be offset by one column after every row due to missing values.

Signed-off-by: Jason Koh <WildlyManifest@fastmail.net>