### PR TITLE
Remove deprecated direct key access

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -13,7 +13,6 @@ If any of this does not make sense to you, or you have trouble updating your .in
     - [Consistent timing](#consistent-timing)
   + [Breaking changes](#breaking-changes)
     - [Layer system switched to activation-order](#layer-system-switched-to-activation-order)
-    - [Implementation of type Key internally changed from C++ union to class](#implementation-of-type-key-internally-changed-from-union-to-class)
     - [The `RxCy` macros and peeking into the keyswitch state](#the-rxcy-macros-and-peeking-into-the-keyswitch-state)
     - [HostOS](#hostos)
     - [MagicCombo](#magiccombo)
@@ -334,10 +333,6 @@ This means that the following functions are deprecated, and will be removed by *
   `Layer.forEachActiveLayer()` to walk the active layers in order (from least
   recent to most).
 
-### Implementation of type Key internally changed from C++ union to class
-
-The deprecated functions continue to work, but they will be removed by **2020-09-16**.
-
 #### For end-users
 
 This is a breaking change only if your code accesses the member `raw` of
@@ -546,6 +541,10 @@ The following headers and names have changed:
 ### Deprecation of the HID facade
 
 With the new Device APIs it became possible to replace the HID facade (the `kaleidoscope::hid` family of functions) with a driver. As such, the old APIs are deprecated, and was removed on 2020-10-10. Please use `Kaleidoscope.hid()` instead.
+
+### Implementation of type Key internally changed from C++ union to class
+
+The deprecated functions were removed on 2020-10-10.
 
 ### Removed on 2020-06-16
 

--- a/src/kaleidoscope_internal/deprecations.h
+++ b/src/kaleidoscope_internal/deprecations.h
@@ -46,20 +46,3 @@
   "Layers are now in activation-order, please use" __NL__ \
   "`Layer.forEachActiveLayer()` instead."
 
-#define _DEPRECATED_MESSAGE_DIRECT_KEY_MEMBER_ACCESS                           \
-  "Direct access to `Key` class' data members is deprecated.\n"                \
-  "Please use `Key::setKeyCode()`/`Key::getKeyCode()` or\n"                    \
-  "`Key::setFlags()`/`Key::getFlags()` instead.\n"                             \
-  "\n"                                                                         \
-  "For further information and examples on how to do that, \n"                 \
-  "please see UPGRADING.md."
-
-#define _DEPRECATED_MESSAGE_KEY_MEMBER_RAW_ACCESS                              \
-  "The member variable `raw` of class Key had to be removed. Please \n"        \
-  "use `Key::setRaw()`/`Key::getRaw()` to set and get raw data.\n"             \
-  "\n"                                                                         \
-  "Important: This is not a deprecation. Your code will compile but fail\n"    \
-  "           to link until all access to `Key::raw` has been replaced.\n"     \
-  "\n"                                                                         \
-  "For further information and examples on how to do that, \n"                 \
-  "please see UPGRADING.md."


### PR DESCRIPTION
@algernon - I'm embarrassed that I don't quite see how to remove the DataProxy. If you've got a moment, can you have a poke?