### PR TITLE
Doing some cleanup to the makefile and builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,14 @@ endif
 
 include $(BOARD_HARDWARE_PATH)/$(KALEIDOSCOPE_PLUGIN_MAKEFILE_DIR)/rules.mk
 
+
+prepare-virtual:
+	$(MAKE) -C $(BOARD_HARDWARE_PATH)/keyboardio prepare-virtual
+
+run-tests: prepare-virtual build-gtest-gmock
+	$(MAKE) -c tests
+	@: # blah
+
 build-gtest-gmock:
 	(cd testing/googletest && cmake .)
 	$(MAKE) -C testing/googletest

--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,7 @@ $(info )
 endif
 
 include $(BOARD_HARDWARE_PATH)/$(KALEIDOSCOPE_PLUGIN_MAKEFILE_DIR)/rules.mk
+
+build-gtest-gmock:
+	(cd testing/googletest && cmake .)
+	$(MAKE) -C testing/googletest

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,13 @@ include $(BOARD_HARDWARE_PATH)/$(KALEIDOSCOPE_PLUGIN_MAKEFILE_DIR)/rules.mk
 prepare-virtual:
 	$(MAKE) -C $(BOARD_HARDWARE_PATH)/keyboardio prepare-virtual
 
+
+simulator-tests: prepare-virtual
+	$(MAKE) -C tests all
+
+docker-simulator-tests:
+	BOARD_HARDWARE_PATH="$(BOARD_HARDWARE_PATH)" ./bin/run-docker "make simulator-tests"
+
 run-tests: prepare-virtual build-gtest-gmock
 	$(MAKE) -c tests
 	@: # blah
@@ -82,3 +89,22 @@ run-tests: prepare-virtual build-gtest-gmock
 build-gtest-gmock:
 	(cd testing/googletest && cmake .)
 	$(MAKE) -C testing/googletest
+
+adjust-git-timestamps:
+	bin/set-timestamps-from-git
+
+find-filename-conflicts:
+	@if [ -d "bin" ]; then \
+		bin/find-filename-conflicts; \
+	fi
+
+SMOKE_SKETCHES=$(shell if [ -d ./examples ]; then find ./examples -type f -name \*ino | xargs -n 1 dirname; fi)
+
+smoke-sketches: $(SMOKE_SKETCHES)
+	@echo "Smoke-tested all the sketches"
+
+.PHONY: force
+
+
+$(SMOKE_SKETCHES): force
+	@BOARD_HARDWARE_PATH="$(BOARD_HARDWARE_PATH)" $(KALEIDOSCOPE_BUILDER_DIR)/kaleidoscope-builder $@ compile

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -592,11 +592,6 @@ EOF
     fi
 }
 
-build_gtest_gmock() {
-    kaleidoscope_dir="$(dirname "$0")/.."
-    (cd "${kaleidoscope_dir}/testing/googletest" && cmake . && make)
-}
-
 run_tests() {
     (cd "${BOARD_HARDWARE_PATH}/keyboardio" && make prepare-virtual)
     build_gtest_gmock

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -592,19 +592,6 @@ EOF
     fi
 }
 
-run_tests() {
-    (cd "${BOARD_HARDWARE_PATH}/keyboardio" && make prepare-virtual)
-    build_gtest_gmock
-    kaleidoscope_dir="$(dirname "$0")/.."
-    cd "${kaleidoscope_dir}/tests"
-    ${MAKE:-make}
-}
-
-docker_tests() {
-    kaleidoscope_dir="$(dirname "$0")/.."
-    cd "${kaleidoscope_dir}"
-    bin/run-docker make -C tests all
-}
 
 usage () {
     cat <<- EOF
@@ -644,8 +631,6 @@ usage () {
 		  build-all
 		    Build all Sketches we can find.
 
-      run-tests | docker-tests
-        Builds and runs the test suite, on the host, and in docker, respectively.
 		EOF
 }
 

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -260,14 +260,14 @@ check_bootloader_port_and_flash () {
 
 flash_over_usb () {
 
-    FLASH_CMD=${AVRDUDE} \
+    FLASH_CMD=$(${AVRDUDE} \
 		-C "${AVRDUDE_CONF}" \
 		-p"${MCU}" \
  		-cavr109 \
 		-D \
 		-P "${DEVICE_PORT_BOOTLOADER}" \
 		-b57600 \
-		"-Uflash:w:${HEX_FILE_PATH}:i"
+		"-Uflash:w:${HEX_FILE_PATH}:i")
 
     if [ "${ARDUINO_VERBOSE}" != "-verbose" ]; then
 	${FLASH_CMD} 2>&1 |grep -v ^avrdude | grep -v '^$' |grep -v '^ ' | grep -vi programmer

--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -259,19 +259,8 @@ check_bootloader_port_and_flash () {
 }
 
 flash_over_usb () {
-    if [ "${ARDUINO_VERBOSE}" != "-verbose" ]; then
-    	${AVRDUDE} \
-		-C "${AVRDUDE_CONF}" \
-		-p"${MCU}" \
- 		-cavr109 \
-		-D \
-		-P "${DEVICE_PORT_BOOTLOADER}" \
-		-b57600 \
-		"-Uflash:w:${HEX_FILE_PATH}:i" \
-		2>&1 |grep -v ^avrdude | grep -v '^$' |grep -v '^ ' | grep -vi programmer
-    	return "${PIPESTATUS[0]}"
-    else
-    	${AVRDUDE} \
+
+    FLASH_CMD=${AVRDUDE} \
 		-C "${AVRDUDE_CONF}" \
 		-p"${MCU}" \
  		-cavr109 \
@@ -279,6 +268,12 @@ flash_over_usb () {
 		-P "${DEVICE_PORT_BOOTLOADER}" \
 		-b57600 \
 		"-Uflash:w:${HEX_FILE_PATH}:i"
+
+    if [ "${ARDUINO_VERBOSE}" != "-verbose" ]; then
+	${FLASH_CMD} 2>&1 |grep -v ^avrdude | grep -v '^$' |grep -v '^ ' | grep -vi programmer
+    	return "${PIPESTATUS[0]}"
+    else
+        ${FLASH_CMD}
 	return $?
     fi
 }


### PR DESCRIPTION
My goal here is to start moving more of the kaleidoscope-the-project makefile targets into Kaleidoscope's makefile, instead of the sketch makefile or kaleidoscope-builder.

Once this is merged, I'll push a change to the shared makefile in the Bundle that removes the newly-moved targets.