### PR TITLE
Attempt to add KeyAddr versions of Press() & Release()

### DIFF
--- a/testing/SimHarness.cpp
+++ b/testing/SimHarness.cpp
@@ -14,7 +14,6 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope.h"
 #include "testing/SimHarness.h"
 
 #include "testing/fix-macros.h"
@@ -31,16 +30,24 @@ void SimHarness::RunCycles(size_t n) {
   for (size_t i = 0; i < n; ++i) RunCycle();
 }
 
-void SimHarness::Press(uint8_t row, uint8_t col) {
+void SimHarness::Press(KeyAddr key_addr) {
   Kaleidoscope.device().keyScanner().setKeystate(
-    KeyAddr{row, col},
+    key_addr,
     kaleidoscope::Device::Props::KeyScanner::KeyState::Pressed);
 }
 
-void SimHarness::Release(uint8_t row, uint8_t col) {
+void SimHarness::Release(KeyAddr key_addr) {
   Kaleidoscope.device().keyScanner().setKeystate(
-    KeyAddr{row, col},
+    key_addr,
     kaleidoscope::Device::Props::KeyScanner::KeyState::NotPressed);
+}
+
+void SimHarness::Press(uint8_t row, uint8_t col) {
+  Press(KeyAddr{row, col});
+}
+
+void SimHarness::Release(uint8_t row, uint8_t col) {
+  Release(KeyAddr{row, col});
 }
 
 }  // namespace testing

--- a/testing/SimHarness.h
+++ b/testing/SimHarness.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "Kaleidoscope.h"
 #include <cstddef>
 #include <cstdint>
 
@@ -27,6 +28,8 @@ class SimHarness {
   void RunCycle();
   void RunCycles(size_t n);
 
+  void Press(KeyAddr key_addr);
+  void Release(KeyAddr key_addr);
   void Press(uint8_t row, uint8_t col);
   void Release(uint8_t row, uint8_t col);
 };

--- a/tests/examples/basic-keypress/test/testcase.cpp
+++ b/tests/examples/basic-keypress/test/testcase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "testing/setup-googletest.h"
+#include "Kaleidoscope.h"
 
 SETUP_GOOGLETEST();
 
@@ -22,12 +23,14 @@ namespace kaleidoscope {
 namespace testing {
 namespace {
 
+constexpr KeyAddr key_addr_A{2, 1};
+
 using ::testing::IsEmpty;
 
 class KeyboardReports : public VirtualDeviceTest {};
 
 TEST_F(KeyboardReports, KeysActiveWhenPressed) {
-  sim_.Press(2, 1); // A
+  sim_.Press(key_addr_A); // A
   auto state = RunCycle();
 
   ASSERT_EQ(state->HIDReports()->Keyboard().size(), 1);
@@ -35,7 +38,7 @@ TEST_F(KeyboardReports, KeysActiveWhenPressed) {
     state->HIDReports()->Keyboard(0).ActiveKeycodes(),
     Contains(Key_A));
 
-  sim_.Release(2, 1);  // A
+  sim_.Release(key_addr_A);  // A
   state = RunCycle();
 
   ASSERT_EQ(state->HIDReports()->Keyboard().size(), 1);


### PR DESCRIPTION
I don't understand why this doesn't work. I'm trying to add a versions of the `SimHarness::Press()` and `SimHarness::Release()` functions that use a `KeyAddr` parameter instead of row & column integers, but I get a linker error when trying to build the test.

If you've got some time to look at this, @algernon and/or @obra (or @paniag), I would appreciate the help. Using a single `KeyAddr` as the parameter makes it easier to define constants that can be used in testcases to make them less error-prone.