### PR TITLE
Testcase for simultaneous keypresses

### DIFF
--- a/tests/issues/941/sketch.ino
+++ b/tests/issues/941/sketch.ino
@@ -1,0 +1,537 @@
+// -*- mode: c++ -*-
+// Copyright 2016 Keyboardio, inc. <jesse@keyboard.io>
+// See "LICENSE" for license details
+
+#ifndef BUILD_INFORMATION
+#define BUILD_INFORMATION "locally built"
+#endif
+
+
+/**
+ * These #include directives pull in the Kaleidoscope firmware core,
+ * as well as the Kaleidoscope plugins we use in the Model 01's firmware
+ */
+
+
+// The Kaleidoscope core
+#include "Kaleidoscope.h"
+
+// Support for storing the keymap in EEPROM
+#include "Kaleidoscope-EEPROM-Settings.h"
+#include "Kaleidoscope-EEPROM-Keymap.h"
+
+// Support for communicating with the host via a simple Serial protocol
+#include "Kaleidoscope-FocusSerial.h"
+
+// Support for keys that move the mouse
+#include "Kaleidoscope-MouseKeys.h"
+
+// Support for macros
+#include "Kaleidoscope-Macros.h"
+
+// Support for controlling the keyboard's LEDs
+#include "Kaleidoscope-LEDControl.h"
+
+// Support for "Numpad" mode, which is mostly just the Numpad specific LED mode
+#include "Kaleidoscope-NumPad.h"
+
+// Support for the "Boot greeting" effect, which pulses the 'LED' button for 10s
+// when the keyboard is connected to a computer (or that computer is powered on)
+#include "Kaleidoscope-LEDEffect-BootGreeting.h"
+
+// Support for LED modes that set all LEDs to a single color
+#include "Kaleidoscope-LEDEffect-SolidColor.h"
+
+// Support for an LED mode that makes all the LEDs 'breathe'
+#include "Kaleidoscope-LEDEffect-Breathe.h"
+
+// Support for an LED mode that makes a red pixel chase a blue pixel across the keyboard
+#include "Kaleidoscope-LEDEffect-Chase.h"
+
+// Support for LED modes that pulse the keyboard's LED in a rainbow pattern
+#include "Kaleidoscope-LEDEffect-Rainbow.h"
+
+// Support for an LED mode that lights up the keys as you press them
+#include "Kaleidoscope-LED-Stalker.h"
+
+// Support for an LED mode that prints the keys you press in letters 4px high
+#include "Kaleidoscope-LED-AlphaSquare.h"
+
+// Support for an LED mode that lets one configure per-layer color maps
+#include "Kaleidoscope-Colormap.h"
+
+// Support for Keyboardio's internal keyboard testing mode
+#include "Kaleidoscope-HardwareTestMode.h"
+
+// Support for host power management (suspend & wakeup)
+#include "Kaleidoscope-HostPowerManagement.h"
+
+// Support for magic combos (key chords that trigger an action)
+#include "Kaleidoscope-MagicCombo.h"
+
+// Support for USB quirks, like changing the key state report protocol
+#include "Kaleidoscope-USB-Quirks.h"
+
+/** This 'enum' is a list of all the macros used by the Model 01's firmware
+  * The names aren't particularly important. What is important is that each
+  * is unique.
+  *
+  * These are the names of your macros. They'll be used in two places.
+  * The first is in your keymap definitions. There, you'll use the syntax
+  * `M(MACRO_NAME)` to mark a specific keymap position as triggering `MACRO_NAME`
+  *
+  * The second usage is in the 'switch' statement in the `macroAction` function.
+  * That switch statement actually runs the code associated with a macro when
+  * a macro key is pressed.
+  */
+
+enum { MACRO_VERSION_INFO,
+       MACRO_ANY
+     };
+
+
+
+/** The Model 01's key layouts are defined as 'keymaps'. By default, there are three
+  * keymaps: The standard QWERTY keymap, the "Function layer" keymap and the "Numpad"
+  * keymap.
+  *
+  * Each keymap is defined as a list using the 'KEYMAP_STACKED' macro, built
+  * of first the left hand's layout, followed by the right hand's layout.
+  *
+  * Keymaps typically consist mostly of `Key_` definitions. There are many, many keys
+  * defined as part of the USB HID Keyboard specification. You can find the names
+  * (if not yet the explanations) for all the standard `Key_` defintions offered by
+  * Kaleidoscope in these files:
+  *    https://github.com/keyboardio/Kaleidoscope/blob/master/src/key_defs_keyboard.h
+  *    https://github.com/keyboardio/Kaleidoscope/blob/master/src/key_defs_consumerctl.h
+  *    https://github.com/keyboardio/Kaleidoscope/blob/master/src/key_defs_sysctl.h
+  *    https://github.com/keyboardio/Kaleidoscope/blob/master/src/key_defs_keymaps.h
+  *
+  * Additional things that should be documented here include
+  *   using ___ to let keypresses fall through to the previously active layer
+  *   using XXX to mark a keyswitch as 'blocked' on this layer
+  *   using ShiftToLayer() and LockLayer() keys to change the active keymap.
+  *   keeping NUM and FN consistent and accessible on all layers
+  *
+  * The PROG key is special, since it is how you indicate to the board that you
+  * want to flash the firmware. However, it can be remapped to a regular key.
+  * When the keyboard boots, it first looks to see whether the PROG key is held
+  * down; if it is, it simply awaits further flashing instructions. If it is
+  * not, it continues loading the rest of the firmware and the keyboard
+  * functions normally, with whatever binding you have set to PROG. More detail
+  * here: https://community.keyboard.io/t/how-the-prog-key-gets-you-into-the-bootloader/506/8
+  *
+  * The "keymaps" data structure is a list of the keymaps compiled into the firmware.
+  * The order of keymaps in the list is important, as the ShiftToLayer(#) and LockLayer(#)
+  * macros switch to key layers based on this list.
+  *
+  *
+
+  * A key defined as 'ShiftToLayer(FUNCTION)' will switch to FUNCTION while held.
+  * Similarly, a key defined as 'LockLayer(NUMPAD)' will switch to NUMPAD when tapped.
+  */
+
+/**
+  * Layers are "0-indexed" -- That is the first one is layer 0. The second one is layer 1.
+  * The third one is layer 2.
+  * This 'enum' lets us use names like QWERTY, FUNCTION, and NUMPAD in place of
+  * the numbers 0, 1 and 2.
+  *
+  */
+
+enum { PRIMARY, NUMPAD, FUNCTION }; // layers
+
+
+/**
+  * To change your keyboard's layout from QWERTY to DVORAK or COLEMAK, comment out the line
+  *
+  * #define PRIMARY_KEYMAP_QWERTY
+  *
+  * by changing it to
+  *
+  * // #define PRIMARY_KEYMAP_QWERTY
+  *
+  * Then uncomment the line corresponding to the layout you want to use.
+  *
+  */
+
+#define PRIMARY_KEYMAP_QWERTY
+// #define PRIMARY_KEYMAP_COLEMAK
+// #define PRIMARY_KEYMAP_DVORAK
+// #define PRIMARY_KEYMAP_CUSTOM
+
+
+
+/* This comment temporarily turns off astyle's indent enforcement
+ *   so we can make the keymaps actually resemble the physical key layout better
+ */
+// *INDENT-OFF*
+
+KEYMAPS(
+
+#if defined (PRIMARY_KEYMAP_QWERTY)
+  [PRIMARY] = KEYMAP_STACKED
+  (___,          Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext,
+   Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+   Key_PageUp,   Key_A, Key_S, Key_D, Key_F, Key_G,
+   Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+   Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+   ShiftToLayer(FUNCTION),
+
+   M(MACRO_ANY),  Key_6, Key_7, Key_8,     Key_9,         Key_0,         LockLayer(NUMPAD),
+   Key_Enter,     Key_Y, Key_U, Key_I,     Key_O,         Key_P,         Key_Equals,
+                  Key_H, Key_J, Key_K,     Key_L,         Key_Semicolon, Key_Quote,
+   Key_RightAlt,  Key_N, Key_M, Key_Comma, Key_Period,    Key_Slash,     Key_Minus,
+   Key_RightShift, Key_LeftAlt, Key_Spacebar, Key_RightControl,
+   ShiftToLayer(FUNCTION)),
+
+#elif defined (PRIMARY_KEYMAP_DVORAK)
+
+  [PRIMARY] = KEYMAP_STACKED
+  (___,          Key_1,         Key_2,     Key_3,      Key_4, Key_5, Key_LEDEffectNext,
+   Key_Backtick, Key_Quote,     Key_Comma, Key_Period, Key_P, Key_Y, Key_Tab,
+   Key_PageUp,   Key_A,         Key_O,     Key_E,      Key_U, Key_I,
+   Key_PageDown, Key_Semicolon, Key_Q,     Key_J,      Key_K, Key_X, Key_Escape,
+   Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+   ShiftToLayer(FUNCTION),
+
+   M(MACRO_ANY),   Key_6, Key_7, Key_8, Key_9, Key_0, LockLayer(NUMPAD),
+   Key_Enter,      Key_F, Key_G, Key_C, Key_R, Key_L, Key_Slash,
+                   Key_D, Key_H, Key_T, Key_N, Key_S, Key_Minus,
+   Key_RightAlt,   Key_B, Key_M, Key_W, Key_V, Key_Z, Key_Equals,
+   Key_RightShift, Key_LeftAlt, Key_Spacebar, Key_RightControl,
+   ShiftToLayer(FUNCTION)),
+
+#elif defined (PRIMARY_KEYMAP_COLEMAK)
+
+  [PRIMARY] = KEYMAP_STACKED
+  (___,          Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext,
+   Key_Backtick, Key_Q, Key_W, Key_F, Key_P, Key_G, Key_Tab,
+   Key_PageUp,   Key_A, Key_R, Key_S, Key_T, Key_D,
+   Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+   Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+   ShiftToLayer(FUNCTION),
+
+   M(MACRO_ANY),  Key_6, Key_7, Key_8,     Key_9,         Key_0,         LockLayer(NUMPAD),
+   Key_Enter,     Key_J, Key_L, Key_U,     Key_Y,         Key_Semicolon, Key_Equals,
+                  Key_H, Key_N, Key_E,     Key_I,         Key_O,         Key_Quote,
+   Key_RightAlt,  Key_K, Key_M, Key_Comma, Key_Period,    Key_Slash,     Key_Minus,
+   Key_RightShift, Key_LeftAlt, Key_Spacebar, Key_RightControl,
+   ShiftToLayer(FUNCTION)),
+
+#elif defined (PRIMARY_KEYMAP_CUSTOM)
+  // Edit this keymap to make a custom layout
+  [PRIMARY] = KEYMAP_STACKED
+  (___,          Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext,
+   Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+   Key_PageUp,   Key_A, Key_S, Key_D, Key_F, Key_G,
+   Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+   Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+   ShiftToLayer(FUNCTION),
+
+   M(MACRO_ANY),  Key_6, Key_7, Key_8,     Key_9,         Key_0,         LockLayer(NUMPAD),
+   Key_Enter,     Key_Y, Key_U, Key_I,     Key_O,         Key_P,         Key_Equals,
+                  Key_H, Key_J, Key_K,     Key_L,         Key_Semicolon, Key_Quote,
+   Key_RightAlt,  Key_N, Key_M, Key_Comma, Key_Period,    Key_Slash,     Key_Minus,
+   Key_RightShift, Key_LeftAlt, Key_Spacebar, Key_RightControl,
+   ShiftToLayer(FUNCTION)),
+
+#else
+
+#error "No default keymap defined. You should make sure that you have a line like '#define PRIMARY_KEYMAP_QWERTY' in your sketch"
+
+#endif
+
+
+
+  [NUMPAD] =  KEYMAP_STACKED
+  (___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___,
+   ___,
+
+   M(MACRO_VERSION_INFO),  ___, Key_7, Key_8,      Key_9,              Key_KeypadSubtract, ___,
+   ___,                    ___, Key_4, Key_5,      Key_6,              Key_KeypadAdd,      ___,
+                           ___, Key_1, Key_2,      Key_3,              Key_Equals,         ___,
+   ___,                    ___, Key_0, Key_Period, Key_KeypadMultiply, Key_KeypadDivide,   Key_Enter,
+   ___, ___, ___, ___,
+   ___),
+
+  [FUNCTION] =  KEYMAP_STACKED
+  (___,      Key_F1,           Key_F2,      Key_F3,     Key_F4,        Key_F5,           Key_CapsLock,
+   Key_Tab,  ___,              Key_mouseUp, ___,        Key_mouseBtnR, Key_mouseWarpEnd, Key_mouseWarpNE,
+   Key_Home, Key_mouseL,       Key_mouseDn, Key_mouseR, Key_mouseBtnL, Key_mouseWarpNW,
+   Key_End,  Key_PrintScreen,  Key_Insert,  ___,        Key_mouseBtnM, Key_mouseWarpSW,  Key_mouseWarpSE,
+   ___, Key_Delete, ___, ___,
+   ___,
+
+   Consumer_ScanPreviousTrack, Key_F6,                 Key_F7,                   Key_F8,                   Key_F9,          Key_F10,          Key_F11,
+   Consumer_PlaySlashPause,    Consumer_ScanNextTrack, Key_LeftCurlyBracket,     Key_RightCurlyBracket,    Key_LeftBracket, Key_RightBracket, Key_F12,
+                               Key_LeftArrow,          Key_DownArrow,            Key_UpArrow,              Key_RightArrow,  ___,              ___,
+   Key_PcApplication,          Consumer_Mute,          Consumer_VolumeDecrement, Consumer_VolumeIncrement, ___,             Key_Backslash,    Key_Pipe,
+   ___, ___, Key_Enter, ___,
+   ___)
+) // KEYMAPS(
+
+/* Re-enable astyle's indent enforcement */
+// *INDENT-ON*
+
+/** versionInfoMacro handles the 'firmware version info' macro
+ *  When a key bound to the macro is pressed, this macro
+ *  prints out the firmware build information as virtual keystrokes
+ */
+
+static void versionInfoMacro(uint8_t keyState) {
+  if (keyToggledOn(keyState)) {
+    Macros.type(PSTR("Keyboardio Model 01 - Kaleidoscope "));
+    Macros.type(PSTR(BUILD_INFORMATION));
+  }
+}
+
+/** anyKeyMacro is used to provide the functionality of the 'Any' key.
+ *
+ * When the 'any key' macro is toggled on, a random alphanumeric key is
+ * selected. While the key is held, the function generates a synthetic
+ * keypress event repeating that randomly selected key.
+ *
+ */
+
+static void anyKeyMacro(uint8_t keyState) {
+  static Key lastKey;
+  bool toggledOn = false;
+  if (keyToggledOn(keyState)) {
+    lastKey.setKeyCode(Key_A.getKeyCode() + (uint8_t)(millis() % 36));
+    toggledOn = true;
+  }
+
+  if (keyIsPressed(keyState))
+    Kaleidoscope.hid().keyboard().pressKey(lastKey, toggledOn);
+}
+
+
+/** macroAction dispatches keymap events that are tied to a macro
+    to that macro. It takes two uint8_t parameters.
+
+    The first is the macro being called (the entry in the 'enum' earlier in this file).
+    The second is the state of the keyswitch. You can use the keyswitch state to figure out
+    if the key has just been toggled on, is currently pressed or if it's just been released.
+
+    The 'switch' statement should have a 'case' for each entry of the macro enum.
+    Each 'case' statement should call out to a function to handle the macro in question.
+
+ */
+
+const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
+  switch (macroIndex) {
+
+  case MACRO_VERSION_INFO:
+    versionInfoMacro(keyState);
+    break;
+
+  case MACRO_ANY:
+    anyKeyMacro(keyState);
+    break;
+  }
+  return MACRO_NONE;
+}
+
+
+
+// These 'solid' color effect definitions define a rainbow of
+// LED color modes calibrated to draw 500mA or less on the
+// Keyboardio Model 01.
+
+static constexpr uint8_t solid_red_level = 160;
+static kaleidoscope::plugin::LEDSolidColor solidRed(solid_red_level, 0, 0);
+static kaleidoscope::plugin::LEDSolidColor solidOrange(140, 70, 0);
+static kaleidoscope::plugin::LEDSolidColor solidYellow(130, 100, 0);
+static kaleidoscope::plugin::LEDSolidColor solidGreen(0, 160, 0);
+static kaleidoscope::plugin::LEDSolidColor solidBlue(0, 70, 130);
+static kaleidoscope::plugin::LEDSolidColor solidIndigo(0, 0, 170);
+static kaleidoscope::plugin::LEDSolidColor solidViolet(130, 0, 120);
+
+/** toggleLedsOnSuspendResume toggles the LEDs off when the host goes to sleep,
+ * and turns them back on when it wakes up.
+ */
+void toggleLedsOnSuspendResume(kaleidoscope::plugin::HostPowerManagement::Event event) {
+  switch (event) {
+  case kaleidoscope::plugin::HostPowerManagement::Suspend:
+    LEDControl.disable();
+    break;
+  case kaleidoscope::plugin::HostPowerManagement::Resume:
+    LEDControl.enable();
+    break;
+  case kaleidoscope::plugin::HostPowerManagement::Sleep:
+    break;
+  }
+}
+
+/** hostPowerManagementEventHandler dispatches power management events (suspend,
+ * resume, and sleep) to other functions that perform action based on these
+ * events.
+ */
+void hostPowerManagementEventHandler(kaleidoscope::plugin::HostPowerManagement::Event event) {
+  toggleLedsOnSuspendResume(event);
+}
+
+/** A tiny wrapper, to be used by MagicCombo.
+ * This simply toggles the keyboard protocol via USBQuirks, and wraps it within
+ * a function with an unused argument, to match what MagicCombo expects.
+ */
+static void toggleKeyboardProtocol(uint8_t combo_index) {
+  USBQuirks.toggleKeyboardProtocol();
+}
+
+/** Magic combo list, a list of key combo and action pairs the firmware should
+ * recognise.
+ */
+USE_MAGIC_COMBOS({.action = toggleKeyboardProtocol,
+                  // Left Fn + Esc + Shift
+                  .keys = { R3C6, R2C6, R3C7 }
+                 });
+
+// First, tell Kaleidoscope which plugins you want to use.
+// The order can be important. For example, LED effects are
+// added in the order they're listed here.
+KALEIDOSCOPE_INIT_PLUGINS(
+  // The EEPROMSettings & EEPROMKeymap plugins make it possible to have an
+  // editable keymap in EEPROM.
+  EEPROMSettings,
+  EEPROMKeymap,
+
+  // Focus allows bi-directional communication with the host, and is the
+  // interface through which the keymap in EEPROM can be edited.
+  Focus,
+
+  // FocusSettingsCommand adds a few Focus commands, intended to aid in
+  // changing some settings of the keyboard, such as the default layer (via the
+  // `settings.defaultLayer` command)
+  FocusSettingsCommand,
+
+  // FocusEEPROMCommand adds a set of Focus commands, which are very helpful in
+  // both debugging, and in backing up one's EEPROM contents.
+  FocusEEPROMCommand,
+
+  // The boot greeting effect pulses the LED button for 10 seconds after the
+  // keyboard is first connected
+  BootGreetingEffect,
+
+  // The hardware test mode, which can be invoked by tapping Prog, LED and the
+  // left Fn button at the same time.
+  HardwareTestMode,
+
+  // LEDControl provides support for other LED modes
+  LEDControl,
+
+  // We start with the LED effect that turns off all the LEDs.
+  LEDOff,
+
+  // The rainbow effect changes the color of all of the keyboard's keys at the same time
+  // running through all the colors of the rainbow.
+  LEDRainbowEffect,
+
+  // The rainbow wave effect lights up your keyboard with all the colors of a rainbow
+  // and slowly moves the rainbow across your keyboard
+  LEDRainbowWaveEffect,
+
+  // The chase effect follows the adventure of a blue pixel which chases a red pixel across
+  // your keyboard. Spoiler: the blue pixel never catches the red pixel
+  LEDChaseEffect,
+
+  // These static effects turn your keyboard's LEDs a variety of colors
+  solidRed, solidOrange, solidYellow, solidGreen, solidBlue, solidIndigo, solidViolet,
+
+  // The breathe effect slowly pulses all of the LEDs on your keyboard
+  LEDBreatheEffect,
+
+  // The AlphaSquare effect prints each character you type, using your
+  // keyboard's LEDs as a display
+  AlphaSquareEffect,
+
+  // The stalker effect lights up the keys you've pressed recently
+  StalkerEffect,
+
+  // The Colormap effect makes it possible to set up per-layer colormaps
+  ColormapEffect,
+
+  // The numpad plugin is responsible for lighting up the 'numpad' mode
+  // with a custom LED effect
+  NumPad,
+
+  // The macros plugin adds support for macros
+  Macros,
+
+  // The MouseKeys plugin lets you add keys to your keymap which move the mouse.
+  MouseKeys,
+
+  // The HostPowerManagement plugin allows us to turn LEDs off when then host
+  // goes to sleep, and resume them when it wakes up.
+  HostPowerManagement,
+
+  // The MagicCombo plugin lets you use key combinations to trigger custom
+  // actions - a bit like Macros, but triggered by pressing multiple keys at the
+  // same time.
+  MagicCombo,
+
+  // The USBQuirks plugin lets you do some things with USB that we aren't
+  // comfortable - or able - to do automatically, but can be useful
+  // nevertheless. Such as toggling the key report protocol between Boot (used
+  // by BIOSes) and Report (NKRO).
+  USBQuirks
+);
+
+/** The 'setup' function is one of the two standard Arduino sketch functions.
+ * It's called when your keyboard first powers up. This is where you set up
+ * Kaleidoscope and any plugins.
+ */
+void setup() {
+  // First, call Kaleidoscope's internal setup function
+  Kaleidoscope.setup();
+
+  // While we hope to improve this in the future, the NumPad plugin
+  // needs to be explicitly told which keymap layer is your numpad layer
+  NumPad.numPadLayer = NUMPAD;
+
+  // We configure the AlphaSquare effect to use RED letters
+  AlphaSquare.color = CRGB(255, 0, 0);
+
+  // We set the brightness of the rainbow effects to 150 (on a scale of 0-255)
+  // This draws more than 500mA, but looks much nicer than a dimmer effect
+  LEDRainbowEffect.brightness(150);
+  LEDRainbowWaveEffect.brightness(150);
+
+  // The LED Stalker mode has a few effects. The one we like is called
+  // 'BlazingTrail'. For details on other options, see
+  // https://github.com/keyboardio/Kaleidoscope/blob/master/doc/plugin/LED-Stalker.md
+  StalkerEffect.variant = STALKER(BlazingTrail);
+
+  // We want to make sure that the firmware starts with LED effects off
+  // This avoids over-taxing devices that don't have a lot of power to share
+  // with USB devices
+  LEDOff.activate();
+
+  // To make the keymap editable without flashing new firmware, we store
+  // additional layers in EEPROM. For now, we reserve space for five layers. If
+  // one wants to use these layers, just set the default layer to one in EEPROM,
+  // by using the `settings.defaultLayer` Focus command, or by using the
+  // `keymap.onlyCustom` command to use EEPROM layers only.
+  EEPROMKeymap.setup(5);
+
+  // We need to tell the Colormap plugin how many layers we want to have custom
+  // maps for. To make things simple, we set it to five layers, which is how
+  // many editable layers we have (see above).
+  ColormapEffect.max_layers(5);
+}
+
+/** loop is the second of the standard Arduino sketch functions.
+  * As you might expect, it runs in a loop, never exiting.
+  *
+  * For Kaleidoscope-based keyboard firmware, you usually just want to
+  * call Kaleidoscope.loop(); and not do anything custom here.
+  */
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/issues/941/test/testcase.cpp
+++ b/tests/issues/941/test/testcase.cpp
@@ -1,0 +1,126 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testing/setup-googletest.h"
+
+SETUP_GOOGLETEST();
+
+namespace kaleidoscope {
+namespace testing {
+namespace {
+
+constexpr KeyAddr key_addr_A{2, 1};
+constexpr KeyAddr key_addr_S{2, 2};
+constexpr KeyAddr key_addr_D{2, 3};
+
+using ::testing::IsEmpty;
+
+class Issue941 : public VirtualDeviceTest {};
+
+TEST_F(Issue941, OneKeypressPerCycle) {
+
+  std::unique_ptr<State> state{nullptr};
+  std::set<uint8_t> expected_keycodes{};
+
+  // Press `A`
+  sim_.Press(key_addr_A);
+  expected_keycodes.insert(Key_A.getKeyCode());
+
+  state = VirtualDeviceTest::RunCycle();
+
+  // Press `S`
+  sim_.Press(key_addr_S);
+  expected_keycodes.insert(Key_S.getKeyCode());
+
+  state = VirtualDeviceTest::RunCycle();
+
+  ASSERT_EQ(state->HIDReports()->Keyboard().size(), 1);
+  EXPECT_THAT(
+    state->HIDReports()->Keyboard(0).ActiveKeycodes(),
+    ::testing::ElementsAreArray(expected_keycodes)
+  );
+
+  // Release `A`
+  sim_.Release(key_addr_A);
+  expected_keycodes.erase(Key_A.getKeyCode());
+
+  // Release `S`
+  sim_.Release(key_addr_S);
+  expected_keycodes.erase(Key_S.getKeyCode());
+
+  // Run one cycle with two keys toggled off
+  state = VirtualDeviceTest::RunCycle();
+
+  ASSERT_EQ(state->HIDReports()->Keyboard().size(), 1);
+  EXPECT_THAT(
+    state->HIDReports()->Keyboard(0).ActiveKeycodes(),
+    IsEmpty()
+  );
+}
+
+TEST_F(Issue941, SimultaneousKeypresses) {
+
+  std::unique_ptr<State> state{nullptr};
+  std::set<uint8_t> expected_keycodes{};
+
+  // Press `A`
+  sim_.Press(key_addr_A);
+  expected_keycodes.insert(Key_A.getKeyCode());
+
+  // state = VirtualDeviceTest::RunCycle();
+
+  // Press `S`
+  sim_.Press(key_addr_S);
+  expected_keycodes.insert(Key_S.getKeyCode());
+
+  // Press `D`
+  sim_.Press(key_addr_D);
+  expected_keycodes.insert(Key_D.getKeyCode());
+
+  // Run one cycle with two keys toggled on
+  state = VirtualDeviceTest::RunCycle();
+
+  EXPECT_THAT(state->HIDReports()->Keyboard().size(), ::testing::Ge(1));
+  int n = state->HIDReports()->Keyboard().size();
+  EXPECT_THAT(
+    state->HIDReports()->Keyboard(n - 1).ActiveKeycodes(),
+    ::testing::ElementsAreArray(expected_keycodes)
+  );
+
+  // Release `A`
+  sim_.Release(key_addr_A);
+  expected_keycodes.erase(Key_A.getKeyCode());
+
+  // Release `S`
+  sim_.Release(key_addr_S);
+  expected_keycodes.erase(Key_S.getKeyCode());
+
+  // Release `D`
+  sim_.Release(key_addr_D);
+  expected_keycodes.erase(Key_D.getKeyCode());
+
+  // Run one cycle with two keys toggled off
+  state = VirtualDeviceTest::RunCycle();
+
+  EXPECT_THAT(
+    state->HIDReports()->Keyboard(0).ActiveKeycodes(),
+    IsEmpty()
+  );
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace kaleidoscope


### PR DESCRIPTION
This test runs two keypresses in the same cycle, and checks to see that only one report is generated, and that it contains both active keycodes (and no others).

This test currently fails; see #941.