### PR TITLE
"make clean" needs to clear out build and output paths

### DIFF
--- a/bin/kaleidoscope-builder
+++ b/bin/kaleidoscope-builder
@@ -512,12 +512,16 @@ decompile () {
 }
 
 clean () {
+    find_sketch
+    build_paths
     rm -rf -- "${OUTPUT_PATH}"
+    rm -rf -- "${BUILD_PATH}"
     kaleidoscope_dir="$(dirname "$0")/.."
-    (install -d "${kaleidoscope_dir}/testing/googletest/build" &&
-         cd "${kaleidoscope_dir}/testing/googletest/build" &&
+    if [ -d "${kaleidoscope_dir}/testing/googletest/build" ]; then
+         ( cd "${kaleidoscope_dir}/testing/googletest/build" &&
          cmake .. &&
          make clean)
+    fi
 }
 
 reset_device() {


### PR DESCRIPTION
It previously did not. Also, try -not- to clean out google test if the build dir doesn't even exist