### PR TITLE
testing: Do not ignore the return value of RUN_ALL_TESTS

### DIFF
--- a/testing/setup-googletest.h
+++ b/testing/setup-googletest.h
@@ -36,7 +36,6 @@
     /* Turn off virtual_io's input. */ \
     Kaleidoscope.device().keyScanner().setEnableReadMatrix(false); \
     testing::InitGoogleTest(); \
-    /* We assign the return value of RUN_ALL_TESTS, to */ \
-    /* silence a compiler warning. */                     \
-    int __ignore__ = RUN_ALL_TESTS();           \
+    int result = RUN_ALL_TESTS();           \
+    exit(result); \
   }


### PR DESCRIPTION
Instead of ignoring the return value of RUN_ALL_TESTS, exit with the same status code. This will make failing tests actually fail the build, instead of logging the error, and then exiting successfully.
