### PR TITLE
Improve consistency and readability of code in testing/*

### DIFF
--- a/testing/SimHarness.cpp
+++ b/testing/SimHarness.cpp
@@ -66,11 +66,11 @@ void SimHarness::Release(uint8_t row, uint8_t col) {
 }
 
 void SimHarness::SetCycleTime(uint8_t millis) {
-  millis_per_cycle = millis;
+  millis_per_cycle_ = millis;
 }
 
 uint8_t SimHarness::CycleTime() const {
-  return millis_per_cycle;
+  return millis_per_cycle_;
 }
 
 

--- a/testing/SimHarness.cpp
+++ b/testing/SimHarness.cpp
@@ -69,7 +69,7 @@ void SimHarness::SetCycleTime(uint8_t millis) {
   millis_per_cycle = millis;
 }
 
-uint8_t SimHarness::CycleTime() {
+uint8_t SimHarness::CycleTime() const {
   return millis_per_cycle;
 }
 

--- a/testing/SimHarness.h
+++ b/testing/SimHarness.h
@@ -36,6 +36,7 @@ class SimHarness {
   void Release(uint8_t row, uint8_t col);
   void SetCycleTime(uint8_t millis);
   uint8_t CycleTime() const;
+
  private:
   uint8_t millis_per_cycle_ = 1;
 };

--- a/testing/SimHarness.h
+++ b/testing/SimHarness.h
@@ -37,7 +37,7 @@ class SimHarness {
   void SetCycleTime(uint8_t millis);
   uint8_t CycleTime() const;
  private:
-  uint8_t millis_per_cycle = 1;
+  uint8_t millis_per_cycle_ = 1;
 };
 
 }  // namespace testing

--- a/testing/SimHarness.h
+++ b/testing/SimHarness.h
@@ -35,7 +35,7 @@ class SimHarness {
   void Press(uint8_t row, uint8_t col);
   void Release(uint8_t row, uint8_t col);
   void SetCycleTime(uint8_t millis);
-  uint8_t CycleTime();
+  uint8_t CycleTime() const;
  private:
   uint8_t millis_per_cycle = 1;
 };

--- a/testing/setup-googletest.h
+++ b/testing/setup-googletest.h
@@ -30,12 +30,12 @@
 #include "testing/matchers.h"
 #include "testing/VirtualDeviceTest.h"
 
-#define SETUP_GOOGLETEST() \
-  void executeTestFunction() { \
-    setup(); /* setup Kaleidoscope */ \
-    /* Turn off virtual_io's input. */ \
-    Kaleidoscope.device().keyScanner().setEnableReadMatrix(false); \
-    testing::InitGoogleTest(); \
-    int result = RUN_ALL_TESTS();           \
-    exit(result); \
+#define SETUP_GOOGLETEST()                                              \
+  void executeTestFunction() {                                          \
+    setup(); /* setup Kaleidoscope */                                   \
+    /* Turn off virtual_io's input. */                                  \
+    Kaleidoscope.device().keyScanner().setEnableReadMatrix(false);      \
+    testing::InitGoogleTest();                                          \
+    int result = RUN_ALL_TESTS();                                       \
+    exit(result);                                                       \
   }


### PR DESCRIPTION
Just a few very minor changes:

- renamed a private variable with a trailing underscore
- made a function `const`-correct
- added some whitespace for readability