### PR TITLE
Add timestamps to simulator HID report classes

### DIFF
--- a/testing/AbsoluteMouseReport.cpp
+++ b/testing/AbsoluteMouseReport.cpp
@@ -16,6 +16,9 @@
 
 #include "testing/AbsoluteMouseReport.h"
 
+#include "Kaleidoscope.h"
+#include "testing/fix-macros.h"
+
 #include <cstring>
 
 #include "MouseButtons.h"
@@ -27,6 +30,11 @@ AbsoluteMouseReport::AbsoluteMouseReport(const void* data) {
   const ReportData& report_data =
     *static_cast<const ReportData*>(data);
   memcpy(&report_data_, &report_data, sizeof(report_data_));
+  timestamp_ = Runtime.millisAtCycleStart();
+}
+
+uint32_t AbsoluteMouseReport::Timestamp() const {
+  return timestamp_;
 }
 
 std::vector<uint8_t> AbsoluteMouseReport::Buttons() const {

--- a/testing/AbsoluteMouseReport.h
+++ b/testing/AbsoluteMouseReport.h
@@ -33,12 +33,14 @@ class AbsoluteMouseReport {
 
   AbsoluteMouseReport(const void* data);
 
+  uint32_t Timestamp() const;
   std::vector<uint8_t> Buttons() const;
   uint16_t XAxis() const;
   uint16_t YAxis() const;
   int8_t Wheel() const;
 
  private:
+  uint32_t timestamp_;
   ReportData report_data_;
 };
 

--- a/testing/ConsumerControlReport.cpp
+++ b/testing/ConsumerControlReport.cpp
@@ -16,6 +16,9 @@
 
 #include "testing/ConsumerControlReport.h"
 
+#include "Kaleidoscope.h"
+#include "testing/fix-macros.h"
+
 #include <cstring>
 
 namespace kaleidoscope {
@@ -25,6 +28,11 @@ ConsumerControlReport::ConsumerControlReport(const void *data) {
   const ReportData& report_data =
     *static_cast<const ReportData*>(data);
   memcpy(&report_data_, &report_data, sizeof(report_data_));
+  timestamp_ = Runtime.millisAtCycleStart();
+}
+
+uint32_t ConsumerControlReport::Timestamp() const {
+  return timestamp_;
 }
 
 std::vector<uint16_t> ConsumerControlReport::ActiveKeycodes() const {

--- a/testing/ConsumerControlReport.h
+++ b/testing/ConsumerControlReport.h
@@ -33,9 +33,11 @@ class ConsumerControlReport {
 
   ConsumerControlReport(const void *data);
 
+  uint32_t Timestamp() const;
   std::vector<uint16_t> ActiveKeycodes() const;
 
  private:
+  uint32_t timestamp_;
   ReportData report_data_;
 };
 

--- a/testing/KeyboardReport.cpp
+++ b/testing/KeyboardReport.cpp
@@ -16,6 +16,9 @@
 
 #include "testing/KeyboardReport.h"
 
+#include "Kaleidoscope.h"
+#include "testing/fix-macros.h"
+
 #include <cstring>
 
 namespace kaleidoscope {
@@ -25,6 +28,11 @@ KeyboardReport::KeyboardReport(const void* data) {
   const ReportData& report_data =
     *static_cast<const ReportData*>(data);
   memcpy(&report_data_, &report_data, sizeof(report_data_));
+  timestamp_ = Runtime.millisAtCycleStart();
+}
+
+uint32_t KeyboardReport::Timestamp() const {
+  return timestamp_;
 }
 
 std::vector<uint8_t> KeyboardReport::ActiveKeycodes() const {

--- a/testing/KeyboardReport.h
+++ b/testing/KeyboardReport.h
@@ -33,11 +33,13 @@ class KeyboardReport {
 
   KeyboardReport(const void* data);
 
+  uint32_t Timestamp() const;
   std::vector<uint8_t> ActiveKeycodes() const;
   std::vector<uint8_t> ActiveModifierKeycodes() const;
   std::vector<uint8_t> ActiveNonModifierKeycodes() const;
 
  private:
+  uint32_t timestamp_;
   ReportData report_data_;
 };
 

--- a/testing/SystemControlReport.cpp
+++ b/testing/SystemControlReport.cpp
@@ -16,6 +16,9 @@
 
 #include "testing/SystemControlReport.h"
 
+#include "Kaleidoscope.h"
+#include "testing/fix-macros.h"
+
 #include <cstring>
 
 namespace kaleidoscope {
@@ -28,6 +31,11 @@ SystemControlReport::SystemControlReport(const void* data) {
   if (report_data_.key != 0) {
     this->push_back(report_data_.key);
   }
+  timestamp_ = Runtime.millisAtCycleStart();
+}
+
+uint32_t SystemControlReport::Timestamp() const {
+  return timestamp_;
 }
 
 uint8_t SystemControlReport::ActiveKeycode() const {

--- a/testing/SystemControlReport.h
+++ b/testing/SystemControlReport.h
@@ -33,9 +33,11 @@ class SystemControlReport : public std::vector<uint8_t> {
 
   SystemControlReport(const void* data);
 
+  uint32_t Timestamp() const;
   uint8_t ActiveKeycode() const;
 
  private:
+  uint32_t timestamp_;
   ReportData report_data_;
 };
 

--- a/tests/simulator/timestamps/sketch.ino
+++ b/tests/simulator/timestamps/sketch.ino
@@ -1,0 +1,36 @@
+// -*- mode: c++ -*-
+// Copyright 2016 Keyboardio, inc. <jesse@keyboard.io>
+// See "LICENSE" for license details
+
+// The Kaleidoscope core
+#include "Kaleidoscope.h"
+
+// *INDENT-OFF*
+
+KEYMAPS(
+  KEYMAP_STACKED
+  (___,          Key_1, Key_2, Key_3, Key_4, Key_5, ___,
+   Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+   Key_PageUp,   Key_A, Key_S, Key_D, Key_F, Key_G,
+   Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+   Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+   ___,
+
+   ___,  Key_6, Key_7, Key_8,     Key_9,         Key_0,         ___,
+   Key_Enter,     Key_Y, Key_U, Key_I,     Key_O,         Key_P,         Key_Equals,
+                  Key_H, Key_J, Key_K,     Key_L,         Key_Semicolon, Key_Quote,
+   Key_RightAlt,  Key_N, Key_M, Key_Comma, Key_Period,    Key_Slash,     Key_Minus,
+   Key_RightShift, Key_LeftAlt, Key_Spacebar, Key_RightControl,
+   ___)
+
+) // KEYMAPS(
+
+// *INDENT-ON*
+
+void setup() {
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/simulator/timestamps/test/testcase.cpp
+++ b/tests/simulator/timestamps/test/testcase.cpp
@@ -1,0 +1,59 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Eric Paniagua (epaniagua@google.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testing/setup-googletest.h"
+#include "Kaleidoscope.h"
+
+SETUP_GOOGLETEST();
+
+namespace kaleidoscope {
+namespace testing {
+namespace {
+
+constexpr KeyAddr key_addr_A{2, 1};
+
+class ReportTimestamps : public VirtualDeviceTest {};
+
+TEST_F(ReportTimestamps, Keyboard) {
+  int delay = 10;
+  int current_time = 0;
+
+  sim_.RunForMillis(delay);
+  current_time += delay;
+
+  sim_.Press(key_addr_A);
+  auto state = RunCycle();
+  current_time += sim_.CycleTime();
+
+  ASSERT_EQ(state->HIDReports()->Keyboard().size(), 1);
+  EXPECT_THAT(state->HIDReports()->Keyboard(0).Timestamp(), current_time)
+      << "The report should have a correct timestamp";
+
+  sim_.RunForMillis(delay);
+  current_time += delay;
+
+  sim_.Release(key_addr_A);
+  state = RunCycle();
+  current_time += sim_.CycleTime();
+
+  ASSERT_EQ(state->HIDReports()->Keyboard().size(), 1);
+  EXPECT_THAT(state->HIDReports()->Keyboard(0).Timestamp(), current_time)
+      << "The report should have a correct timestamp";
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace kaleidoscope


### PR DESCRIPTION
This will be very useful in testcases, especially anything that involves timeouts.