### PR TITLE
Set BOARD_HARDWARE_PATH correctly for run-docker on macOS

### DIFF
--- a/bin/run-docker
+++ b/bin/run-docker
@@ -4,12 +4,12 @@ set -e
 
 uname_S=$(uname -s 2>/dev/null || echo not)
 
-ARDUINO_LOCAL_LIB_PATH="${ARDUINO_LOCAL_LIB_PATH:-${HOME}/Arduino}"
-
 if [ "${uname_S}" = "Darwin" ]; then
     ARDUINO_LOCAL_LIB_PATH="${ARDUINO_LOCAL_LIB_PATH:-${HOME}/Documents/Arduino}"
     # This stops macos from copying resource forks into thigns like tar
     export COPYFILE_DISABLE=true
+else
+    ARDUINO_LOCAL_LIB_PATH="${ARDUINO_LOCAL_LIB_PATH:-${HOME}/Arduino}"
 fi
 
 BOARD_HARDWARE_PATH="${BOARD_HARDWARE_PATH:-${ARDUINO_LOCAL_LIB_PATH}/hardware}"


### PR DESCRIPTION
Because `ARDUINO_LOCAL_LIB_PATH` was being set to a default value for other operating systems before checking the OS version, it would never get set correctly for macOS (unless it was already set externally). This change fixes that problem so that it's no longer necessary to set `BOARD_HARDWARE_PATH` externally when executing `run-docker`.