### PR TITLE
Add event queues for expected HID reports and keyswitch events to testing simulator

### DIFF
--- a/testing/AbsoluteMouseReport.cpp
+++ b/testing/AbsoluteMouseReport.cpp
@@ -16,6 +16,9 @@
 
 #include "testing/AbsoluteMouseReport.h"
 
+#include "Kaleidoscope.h"
+#include "testing/fix-macros.h"
+
 #include <cstring>
 
 #include "MouseButtons.h"
@@ -27,6 +30,11 @@ AbsoluteMouseReport::AbsoluteMouseReport(const void* data) {
   const ReportData& report_data =
     *static_cast<const ReportData*>(data);
   memcpy(&report_data_, &report_data, sizeof(report_data_));
+  timestamp_ = Runtime.millisAtCycleStart();
+}
+
+uint32_t AbsoluteMouseReport::Timestamp() const {
+  return timestamp_;
 }
 
 std::vector<uint8_t> AbsoluteMouseReport::Buttons() const {

--- a/testing/AbsoluteMouseReport.h
+++ b/testing/AbsoluteMouseReport.h
@@ -33,12 +33,14 @@ class AbsoluteMouseReport {
 
   AbsoluteMouseReport(const void* data);
 
+  uint32_t Timestamp() const;
   std::vector<uint8_t> Buttons() const;
   uint16_t XAxis() const;
   uint16_t YAxis() const;
   int8_t Wheel() const;
 
  private:
+  uint32_t timestamp_;
   ReportData report_data_;
 };
 

--- a/testing/ConsumerControlReport.cpp
+++ b/testing/ConsumerControlReport.cpp
@@ -16,6 +16,9 @@
 
 #include "testing/ConsumerControlReport.h"
 
+#include "Kaleidoscope.h"
+#include "testing/fix-macros.h"
+
 #include <cstring>
 
 namespace kaleidoscope {
@@ -25,6 +28,11 @@ ConsumerControlReport::ConsumerControlReport(const void *data) {
   const ReportData& report_data =
     *static_cast<const ReportData*>(data);
   memcpy(&report_data_, &report_data, sizeof(report_data_));
+  timestamp_ = Runtime.millisAtCycleStart();
+}
+
+uint32_t ConsumerControlReport::Timestamp() const {
+  return timestamp_;
 }
 
 std::vector<uint16_t> ConsumerControlReport::ActiveKeycodes() const {

--- a/testing/ConsumerControlReport.h
+++ b/testing/ConsumerControlReport.h
@@ -33,9 +33,11 @@ class ConsumerControlReport {
 
   ConsumerControlReport(const void *data);
 
+  uint32_t Timestamp() const;
   std::vector<uint16_t> ActiveKeycodes() const;
 
  private:
+  uint32_t timestamp_;
   ReportData report_data_;
 };
 

--- a/testing/ExpectedKeyboardReport.cpp
+++ b/testing/ExpectedKeyboardReport.cpp
@@ -1,0 +1,43 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testing/ExpectedKeyboardReport.h"
+
+namespace kaleidoscope {
+namespace testing {
+
+ExpectedKeyboardReport::ExpectedKeyboardReport(uint32_t timestamp,
+    const std::set<uint8_t> &keycodes,
+    std::string message) {
+  timestamp_ = timestamp;
+  keycodes_ = std::set<uint8_t>(keycodes);
+  failure_message_ = message;
+}
+
+const std::set<uint8_t> & ExpectedKeyboardReport::Keycodes() const {
+  return keycodes_;
+}
+
+uint32_t ExpectedKeyboardReport::Timestamp() const {
+  return timestamp_;
+}
+
+const std::string & ExpectedKeyboardReport::Message() const {
+  return failure_message_;
+}
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/testing/ExpectedKeyboardReport.h
+++ b/testing/ExpectedKeyboardReport.h
@@ -1,0 +1,46 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <set>
+#include <string>
+
+namespace kaleidoscope {
+namespace testing {
+
+class ExpectedKeyboardReport {
+ public:
+  ExpectedKeyboardReport(uint32_t timestamp,
+                         const std::set<uint8_t> & keycodes,
+                         std::string message = "");
+
+  const std::set<uint8_t> & Keycodes() const;
+
+  uint32_t Timestamp() const;
+
+  const std::string & Message() const;
+
+ private:
+  uint32_t timestamp_;
+  std::set<uint8_t> keycodes_;
+  std::string failure_message_;
+};
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/testing/KeyboardReport.cpp
+++ b/testing/KeyboardReport.cpp
@@ -16,6 +16,9 @@
 
 #include "testing/KeyboardReport.h"
 
+#include "Kaleidoscope.h"
+#include "testing/fix-macros.h"
+
 #include <cstring>
 
 namespace kaleidoscope {
@@ -25,6 +28,11 @@ KeyboardReport::KeyboardReport(const void* data) {
   const ReportData& report_data =
     *static_cast<const ReportData*>(data);
   memcpy(&report_data_, &report_data, sizeof(report_data_));
+  timestamp_ = Runtime.millisAtCycleStart();
+}
+
+uint32_t KeyboardReport::Timestamp() const {
+  return timestamp_;
 }
 
 std::vector<uint8_t> KeyboardReport::ActiveKeycodes() const {

--- a/testing/KeyboardReport.h
+++ b/testing/KeyboardReport.h
@@ -33,11 +33,13 @@ class KeyboardReport {
 
   KeyboardReport(const void* data);
 
+  uint32_t Timestamp() const;
   std::vector<uint8_t> ActiveKeycodes() const;
   std::vector<uint8_t> ActiveModifierKeycodes() const;
   std::vector<uint8_t> ActiveNonModifierKeycodes() const;
 
  private:
+  uint32_t timestamp_;
   ReportData report_data_;
 };
 

--- a/testing/SystemControlReport.cpp
+++ b/testing/SystemControlReport.cpp
@@ -16,6 +16,9 @@
 
 #include "testing/SystemControlReport.h"
 
+#include "Kaleidoscope.h"
+#include "testing/fix-macros.h"
+
 #include <cstring>
 
 namespace kaleidoscope {
@@ -28,6 +31,11 @@ SystemControlReport::SystemControlReport(const void* data) {
   if (report_data_.key != 0) {
     this->push_back(report_data_.key);
   }
+  timestamp_ = Runtime.millisAtCycleStart();
+}
+
+uint32_t SystemControlReport::Timestamp() const {
+  return timestamp_;
 }
 
 uint8_t SystemControlReport::ActiveKeycode() const {

--- a/testing/SystemControlReport.h
+++ b/testing/SystemControlReport.h
@@ -33,9 +33,11 @@ class SystemControlReport : public std::vector<uint8_t> {
 
   SystemControlReport(const void* data);
 
+  uint32_t Timestamp() const;
   uint8_t ActiveKeycode() const;
 
  private:
+  uint32_t timestamp_;
   ReportData report_data_;
 };
 

--- a/testing/VirtualDeviceTest.cpp
+++ b/testing/VirtualDeviceTest.cpp
@@ -31,5 +31,117 @@ std::unique_ptr<State> VirtualDeviceTest::RunCycle() {
   return State::Snapshot();
 }
 
+// =============================================================================
+void VirtualDeviceTest::LoadState() {
+  output_state_ = State::Snapshot();
+}
+
+const HIDState* VirtualDeviceTest::HIDReports() const {
+  if (output_state_ == nullptr) return nullptr;
+  return output_state_->HIDReports();
+}
+
+uint32_t VirtualDeviceTest::ReportTimestamp(size_t index) const {
+  return output_state_->HIDReports()->Keyboard(index).Timestamp();
+}
+
+// -----------------------------------------------------------------------------
+uint32_t VirtualDeviceTest::EventTimestamp(size_t index) const {
+  return input_timestamps_[index];
+}
+
+// =============================================================================
+void VirtualDeviceTest::PressKey(KeyAddr addr) {
+  sim_.Press(addr);
+  input_timestamps_.push_back(Runtime.millisAtCycleStart());
+}
+void VirtualDeviceTest::ReleaseKey(KeyAddr addr) {
+  sim_.Release(addr);
+  input_timestamps_.push_back(Runtime.millisAtCycleStart());
+}
+
+// -----------------------------------------------------------------------------
+void VirtualDeviceTest::PressKey(Cycles n, KeyAddr addr) {
+  sim_.RunCycles(n.value);
+  PressKey(addr);
+}
+void VirtualDeviceTest::ReleaseKey(Cycles n, KeyAddr addr) {
+  sim_.RunCycles(n.value);
+  ReleaseKey(addr);
+}
+
+// -----------------------------------------------------------------------------
+void VirtualDeviceTest::PressKey(Millis t, KeyAddr addr) {
+  sim_.RunForMillis(t.value);
+  PressKey(addr);
+}
+void VirtualDeviceTest::ReleaseKey(Millis t, KeyAddr addr) {
+  sim_.RunForMillis(t.value);
+  ReleaseKey(addr);
+}
+
+// =============================================================================
+void VirtualDeviceTest::ExpectReport(AddKeycodes added_keys,
+                                     RemoveKeycodes removed_keys,
+                                     std::string description) {
+  uint32_t report_timestamp = Runtime.millisAtCycleStart();
+  for (Key key : added_keys) {
+    AddToReport(key);
+  }
+  for (Key key : removed_keys) {
+    RemoveFromReport(key);
+  }
+  ExpectedKeyboardReport new_report(report_timestamp,
+                                    current_keyboard_keycodes_,
+                                    description);
+  expected_reports_.push_back(new_report);
+}
+
+// -----------------------------------------------------------------------------
+void VirtualDeviceTest::ExpectReport(AddKeycodes added_keys,
+                                     std::string description) {
+  ExpectReport(added_keys, RemoveKeycodes{}, description);
+}
+void VirtualDeviceTest::ExpectReport(RemoveKeycodes removed_keys,
+                                     std::string description) {
+  ExpectReport(AddKeycodes{}, removed_keys, description);
+}
+
+// -----------------------------------------------------------------------------
+void VirtualDeviceTest::ExpectReport(Cycles n,
+                                     AddKeycodes added_keys,
+                                     std::string description) {
+  sim_.RunCycles(n.value);
+  ExpectReport(added_keys, description);
+}
+void VirtualDeviceTest::ExpectReport(Cycles n,
+                                     RemoveKeycodes removed_keys,
+                                     std::string description) {
+  sim_.RunCycles(n.value);
+  ExpectReport(removed_keys, description);
+}
+
+// -----------------------------------------------------------------------------
+void VirtualDeviceTest::ExpectReport(Millis t,
+                                     AddKeycodes added_keys,
+                                     std::string description) {
+  sim_.RunForMillis(t.value);
+  ExpectReport(added_keys, description);
+}
+void VirtualDeviceTest::ExpectReport(Millis t,
+                                     RemoveKeycodes removed_keys,
+                                     std::string description) {
+  sim_.RunForMillis(t.value);
+  ExpectReport(removed_keys, description);
+}
+
+// =============================================================================
+void VirtualDeviceTest::AddToReport(Key key) {
+  current_keyboard_keycodes_.insert(key.getKeyCode());
+}
+void VirtualDeviceTest::RemoveFromReport(Key key) {
+  current_keyboard_keycodes_.erase(key.getKeyCode());
+}
+
 }  // namespace testing
 }  // namespace kaleidoscope

--- a/tests/issues/941/test/testcase.cpp
+++ b/tests/issues/941/test/testcase.cpp
@@ -26,99 +26,68 @@ constexpr KeyAddr key_addr_A{2, 1};
 constexpr KeyAddr key_addr_S{2, 2};
 constexpr KeyAddr key_addr_D{2, 3};
 
-using ::testing::IsEmpty;
-
 class Issue941 : public VirtualDeviceTest {};
 
 TEST_F(Issue941, OneKeypressPerCycle) {
 
-  std::unique_ptr<State> state{nullptr};
-  std::set<uint8_t> expected_keycodes{};
+  PressKey(Millis{10}, key_addr_A);
+  ExpectReport(Cycles{1}, AddKeycodes{Key_A}, "Report should contain only `A`");
+  PressKey(key_addr_S);
+  ExpectReport(Cycles{1}, AddKeycodes{Key_S}, "Report should contain `S`");
+  ReleaseKey(Millis{25}, key_addr_A);
+  ExpectReport(Cycles{1}, RemoveKeycodes{Key_A}, "Report should contain only `S`");
+  ReleaseKey(key_addr_S);
+  ExpectReport(Cycles{1}, RemoveKeycodes{Key_S}, "Report should be empty");
 
-  // Press `A`
-  sim_.Press(key_addr_A);
-  expected_keycodes.insert(Key_A.getKeyCode());
+  sim_.RunForMillis(10);
+  LoadState();
 
-  state = VirtualDeviceTest::RunCycle();
+  constexpr int expected_report_count = 4;
+  ASSERT_EQ(HIDReports()->Keyboard().size(), expected_report_count)
+      << "There should be " << expected_report_count << " HID reports";
 
-  // Press `S`
-  sim_.Press(key_addr_S);
-  expected_keycodes.insert(Key_S.getKeyCode());
-
-  state = VirtualDeviceTest::RunCycle();
-
-  ASSERT_EQ(state->HIDReports()->Keyboard().size(), 1);
-  EXPECT_THAT(
-    state->HIDReports()->Keyboard(0).ActiveKeycodes(),
-    ::testing::ElementsAreArray(expected_keycodes)
-  );
-
-  // Release `A`
-  sim_.Release(key_addr_A);
-  expected_keycodes.erase(Key_A.getKeyCode());
-
-  // Release `S`
-  sim_.Release(key_addr_S);
-  expected_keycodes.erase(Key_S.getKeyCode());
-
-  // Run one cycle with two keys toggled off
-  state = VirtualDeviceTest::RunCycle();
-
-  ASSERT_EQ(state->HIDReports()->Keyboard().size(), 1);
-  EXPECT_THAT(
-    state->HIDReports()->Keyboard(0).ActiveKeycodes(),
-    IsEmpty()
-  );
+  for (int i = 0; i < expected_report_count; ++i) {
+    EXPECT_THAT(HIDReports()->Keyboard(i).ActiveKeycodes(),
+                ::testing::ElementsAreArray(expected_reports_[i].Keycodes()))
+        << expected_reports_[i].Message();
+  }
 }
+
 
 TEST_F(Issue941, SimultaneousKeypresses) {
 
-  std::unique_ptr<State> state{nullptr};
-  std::set<uint8_t> expected_keycodes{};
+  // Press three keys in one scan cycle:
+  PressKey(Millis{10}, key_addr_A);
+  PressKey(key_addr_S);
+  PressKey(key_addr_D);
+  // This test is expected to fail when Kaleidoscope becomes event-driven;
+  // instead, there will be three reports here: the first will contain `D`, the
+  // second will add `S`, and the third will add `A` (I could have that wrong;
+  // it should be in keyscan order).
+  ExpectReport(Cycles{1}, AddKeycodes{Key_A, Key_S},
+               "Report should contain `A` and `S`");
+  ExpectReport(AddKeycodes{Key_D}, "Report should contain `A`, `S`, & `D`");
 
-  // Press `A`
-  sim_.Press(key_addr_A);
-  expected_keycodes.insert(Key_A.getKeyCode());
+  // Release all three in one scan cycle:
+  ReleaseKey(Millis{25}, key_addr_A);
+  ReleaseKey(key_addr_S);
+  ReleaseKey(key_addr_D);
+  ExpectReport(Cycles{1}, RemoveKeycodes{Key_A, Key_S, Key_D},
+               "Report should be empty");
 
-  // state = VirtualDeviceTest::RunCycle();
+  sim_.RunForMillis(10);
+  LoadState();
 
-  // Press `S`
-  sim_.Press(key_addr_S);
-  expected_keycodes.insert(Key_S.getKeyCode());
+  // The total number of reports could change
+  constexpr int expected_report_count = 3;
+  ASSERT_EQ(HIDReports()->Keyboard().size(), expected_report_count)
+      << "There should be " << expected_report_count << " HID reports";
 
-  // Press `D`
-  sim_.Press(key_addr_D);
-  expected_keycodes.insert(Key_D.getKeyCode());
-
-  // Run one cycle with two keys toggled on
-  state = VirtualDeviceTest::RunCycle();
-
-  EXPECT_THAT(state->HIDReports()->Keyboard().size(), ::testing::Ge(1));
-  int n = state->HIDReports()->Keyboard().size();
-  EXPECT_THAT(
-    state->HIDReports()->Keyboard(n - 1).ActiveKeycodes(),
-    ::testing::ElementsAreArray(expected_keycodes)
-  );
-
-  // Release `A`
-  sim_.Release(key_addr_A);
-  expected_keycodes.erase(Key_A.getKeyCode());
-
-  // Release `S`
-  sim_.Release(key_addr_S);
-  expected_keycodes.erase(Key_S.getKeyCode());
-
-  // Release `D`
-  sim_.Release(key_addr_D);
-  expected_keycodes.erase(Key_D.getKeyCode());
-
-  // Run one cycle with two keys toggled off
-  state = VirtualDeviceTest::RunCycle();
-
-  EXPECT_THAT(
-    state->HIDReports()->Keyboard(0).ActiveKeycodes(),
-    IsEmpty()
-  );
+  for (int i = 0; i < expected_report_count; ++i) {
+    EXPECT_THAT(HIDReports()->Keyboard(i).ActiveKeycodes(),
+                ::testing::ElementsAreArray(expected_reports_[i].Keycodes()))
+        << expected_reports_[i].Message();
+  }
 }
 
 }  // namespace

--- a/tests/simulator/timestamps/sketch.ino
+++ b/tests/simulator/timestamps/sketch.ino
@@ -1,0 +1,36 @@
+// -*- mode: c++ -*-
+// Copyright 2016 Keyboardio, inc. <jesse@keyboard.io>
+// See "LICENSE" for license details
+
+// The Kaleidoscope core
+#include "Kaleidoscope.h"
+
+// *INDENT-OFF*
+
+KEYMAPS(
+  KEYMAP_STACKED
+  (___,          Key_1, Key_2, Key_3, Key_4, Key_5, ___,
+   Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+   Key_PageUp,   Key_A, Key_S, Key_D, Key_F, Key_G,
+   Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+   Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+   ___,
+
+   ___,  Key_6, Key_7, Key_8,     Key_9,         Key_0,         ___,
+   Key_Enter,     Key_Y, Key_U, Key_I,     Key_O,         Key_P,         Key_Equals,
+                  Key_H, Key_J, Key_K,     Key_L,         Key_Semicolon, Key_Quote,
+   Key_RightAlt,  Key_N, Key_M, Key_Comma, Key_Period,    Key_Slash,     Key_Minus,
+   Key_RightShift, Key_LeftAlt, Key_Spacebar, Key_RightControl,
+   ___)
+
+) // KEYMAPS(
+
+// *INDENT-ON*
+
+void setup() {
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/simulator/timestamps/test/testcase.cpp
+++ b/tests/simulator/timestamps/test/testcase.cpp
@@ -1,0 +1,59 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Eric Paniagua (epaniagua@google.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testing/setup-googletest.h"
+#include "Kaleidoscope.h"
+
+SETUP_GOOGLETEST();
+
+namespace kaleidoscope {
+namespace testing {
+namespace {
+
+constexpr KeyAddr key_addr_A{2, 1};
+
+class ReportTimestamps : public VirtualDeviceTest {};
+
+TEST_F(ReportTimestamps, Keyboard) {
+  int delay = 10;
+  int current_time = 0;
+
+  sim_.RunForMillis(delay);
+  current_time += delay;
+
+  sim_.Press(key_addr_A);
+  auto state = RunCycle();
+  current_time += sim_.CycleTime();
+
+  ASSERT_EQ(state->HIDReports()->Keyboard().size(), 1);
+  EXPECT_THAT(state->HIDReports()->Keyboard(0).Timestamp(), current_time)
+      << "The report should have a correct timestamp";
+
+  sim_.RunForMillis(delay);
+  current_time += delay;
+
+  sim_.Release(key_addr_A);
+  state = RunCycle();
+  current_time += sim_.CycleTime();
+
+  ASSERT_EQ(state->HIDReports()->Keyboard().size(), 1);
+  EXPECT_THAT(state->HIDReports()->Keyboard(0).Timestamp(), current_time)
+      << "The report should have a correct timestamp";
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace kaleidoscope


### PR DESCRIPTION
This change adds a set of functions to the `VirtualDeviceTest` class to make it possible to write simpler testcases involving timed keyswitch press and release events along with corresponding keyboard HID reports.

Other outputs (Consumer & System Control HID reports, LEDs, et cetera) are not (yet) included.

Built on top of #955
