### PR TITLE
Improve report verification in testing

### DIFF
--- a/testing/VirtualDeviceTest.cpp
+++ b/testing/VirtualDeviceTest.cpp
@@ -120,5 +120,40 @@ void VirtualDeviceTest::RemoveFromReport(Key key) {
   current_keyboard_keycodes_.erase(key.getKeyCode());
 }
 
+// =============================================================================
+void VirtualDeviceTest::CheckReports() const {
+  int observed_report_count = HIDReports()->Keyboard().size();
+  int expected_report_count = expected_reports_.size();
+
+  EXPECT_EQ(observed_report_count, expected_report_count);
+
+  int max_count = std::max(observed_report_count, expected_report_count);
+
+  for (int i = 0; i < observed_report_count; ++i) {
+    auto observed_report = HIDReports()->Keyboard(i);
+    auto observed_keycodes = observed_report.ActiveKeycodes();
+
+    if (i < expected_report_count) {
+      auto expected_report = expected_reports_[i];
+      auto expected_keycodes = expected_report.Keycodes();
+
+      EXPECT_THAT(observed_keycodes,
+                  ::testing::ElementsAreArray(expected_keycodes))
+          << expected_reports_[i].Message() << " (i=" << i << ")";
+      EXPECT_EQ(observed_report.Timestamp(), expected_report.Timestamp())
+          << "Report timestamps don't match (i=" << i << ")";
+
+    } else {
+
+      std::cerr << "Unexpected keyboard report at "
+                << observed_report.Timestamp() << "ms: { " << std::hex;
+      for (uint8_t keycode : observed_keycodes) {
+        std::cerr << int(keycode) << " ";
+      }
+      std::cerr << "}" << std::dec << std::endl;
+    }
+  }
+}
+
 }  // namespace testing
 }  // namespace kaleidoscope

--- a/testing/VirtualDeviceTest.h
+++ b/testing/VirtualDeviceTest.h
@@ -24,6 +24,7 @@
 
 // Out of order due to macro conflicts.
 #include "testing/fix-macros.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <memory>
 
@@ -119,23 +120,12 @@ class VirtualDeviceTest : public ::testing::Test {
   void AddToReport(Key key);
   void RemoveFromReport(Key key);
 
+  // ---------------------------------------------------------------------------
+  // Compare accumulated observed and expected reports, matching both timestamps
+  // and keycodes.
+  void CheckReports() const;
+
 };
 
 }  // namespace testing
 }  // namespace kaleidoscope
-
-
-// XXX  This is a horrible hack and this should be a function, but I (Jesse)
-// can't quite figure out the right way to get ASSERT_EQ and ElementsAreArray
-// into a method in VirtualDeviceTest
-#define CHECK_EXPECTED_REPORTS()  							\
-  LoadState(); 										\
-  ASSERT_EQ(HIDReports()->Keyboard().size(), expected_reports_.size());                 \
-                                                                                        \
-  for (auto i = 0; i < expected_reports_.size(); ++i) {                                 \
-    EXPECT_THAT(HIDReports()->Keyboard(i).ActiveKeycodes(),                             \
-                ::testing::ElementsAreArray(expected_reports_[i].Keycodes()))           \
-        << expected_reports_[i].Message();                                              \
-  }                                                                                     \
-
-

--- a/testing/bin/ktest-to-cxx
+++ b/testing/bin/ktest-to-cxx
@@ -328,7 +328,8 @@ sub generate_expect_report {
 
 sub generate_check_expected_reports {
     cxx("");
-    cxx("CHECK_EXPECTED_REPORTS();");
+    cxx("LoadState();");
+    cxx("CheckReports();");
 }
 
 sub generate_preface {

--- a/tests/issues/970/test.ktest
+++ b/tests/issues/970/test.ktest
@@ -8,13 +8,13 @@ RUN 10 ms
 RELEASE A
 RUN 1 cycle
 EXPECT keyboard-report Key_A # Report should contain only `A`
-RUN 1 cycle
+RUN 2 cycles
 EXPECT keyboard-report empty # Report should be empty
 
 RUN 65536 ms
 
 PRESS A
-RUN 201 ms
+RUN 202 ms
 EXPECT keyboard-report Key_LeftGui # Report should contain only `LeftGui`
 
 RUN 10 ms


### PR DESCRIPTION
This replaces the `CHECK_EXPECTED_REPORTS()` macro with a new `CheckReports()` method. The new method verifies both the content and timestamps of expected keyboard reports, and provides more output on failures (including details of any unexpected reports).
