### PR TITLE
Suppress idle keyswitch events from virtual hardware device

### DIFF
--- a/src/kaleidoscope/device/virtual/Virtual.cpp
+++ b/src/kaleidoscope/device/virtual/Virtual.cpp
@@ -260,7 +260,8 @@ void VirtualKeyScanner::actOnMatrixScan() {
       break;
     }
 
-    handleKeyswitchEvent(Key_NoKey, key_addr, key_state);
+    if (key_state != 0)
+      handleKeyswitchEvent(Key_NoKey, key_addr, key_state);
     keystates_prev_[key_addr.toInt()] = keystates_[key_addr.toInt()];
 
     if (keystates_[key_addr.toInt()] == KeyState::Tap) {

--- a/testing/bin/ktest-to-cxx
+++ b/testing/bin/ktest-to-cxx
@@ -221,9 +221,7 @@ sub generate_start_new_test {
     cxx("ClearState(); // Clear any state from previous tests");
 }
 sub generate_end_test {
-    if ($reports_expected) {
-    	generate_check_expected_reports();
-    }
+    generate_check_expected_reports();
     outdent();
     cxx("} // TEST_F");
     cxx('');

--- a/tests/issues/978/common.h
+++ b/tests/issues/978/common.h
@@ -1,0 +1,27 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/tests/issues/978/sketch.ino
+++ b/tests/issues/978/sketch.ino
@@ -1,0 +1,72 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+
+#include "./common.h"
+
+#undef min
+#undef max
+#include <iostream>
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        Key_A, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+namespace kaleidoscope {
+namespace plugin {
+
+class IdleKeyDetector : public kaleidoscope::Plugin {
+ public:
+  EventHandlerResult onKeyswitchEvent(Key &key, KeyAddr key_addr, uint8_t key_state) {
+    if (key_addr == KeyAddr{0, 0} && key_state == 0) {
+      handleKeyswitchEvent(Key_X, key_addr, IS_PRESSED | WAS_PRESSED);
+    }
+    return EventHandlerResult::OK;
+  }
+};
+
+} // namespace plugin
+} // namespace kaleidoscope
+
+kaleidoscope::plugin::IdleKeyDetector IdleKeyDetector;
+
+KALEIDOSCOPE_INIT_PLUGINS(IdleKeyDetector);
+
+void setup() {
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/issues/978/test.ktest
+++ b/tests/issues/978/test.ktest
@@ -1,0 +1,12 @@
+VERSION 1
+
+KEYSWITCH A 0 0
+
+# ==============================================================================
+# This testcase shouldn't generate any HID reports. The sketch includes a plugin
+# that produces `Key_X` if the key at (0,0) is idle, so if the virtual device is
+# calling `handleKeyswitchEvent()` when `key_state` has neither `IS_PRESSED` nor
+# `WAS_PRESSED` bits set, it will fail.
+NAME Idle key detector
+
+RUN 3 cycles


### PR DESCRIPTION
The virtual hardware device, unlike others, was calling `handleKeyswitchEvent()` for every keyswitch, every cycle. It should suppress calls corresponding to idle keyswitches, just like the other devices.

Fixes #978.