### PR TITLE
Make ktest match for "keyswitch" token non-greedy

### DIFF
--- a/testing/bin/ktest-to-cxx
+++ b/testing/bin/ktest-to-cxx
@@ -88,7 +88,7 @@ sub load_from_text {
 		},
             keyswitch => sub {
                 my $content = shift;
-                if ( $content =~ /^(.*)\s+(\d+)\s+(\d+)$/ ) {
+                if ( $content =~ /^(.*?)\s+(\d+)\s+(\d+)$/ ) {
                     my $switch = $1;
                     my $row    = $2;
                     my $col    = $3;


### PR DESCRIPTION
The greedy match was including whitespace if more than one space character separated the "keyswitch" token and the first coordinate.
