### PR TITLE
Add common utility methods for `Key` & `KeyAddr` classes

### DIFF
--- a/src/kaleidoscope/plugin/Qukeys.cpp
+++ b/src/kaleidoscope/plugin/Qukeys.cpp
@@ -418,24 +418,11 @@ bool Qukeys::isKeyAddrInQueueBeforeIndex(KeyAddr k, uint8_t index) const {
 
 // -----------------------------------------------------------------------------
 
-// This function could get lifted into Kaleidoscope proper, since it might be
-// more generally useful. It's here to provide the test for a SpaceCadet-type
-// qukey, which is any Qukey that has a modifier (including layer shifts) as its
-// primary value.
+// This function is here to provide the test for a SpaceCadet-type qukey, which
+// is any Qukey that has a modifier (including layer shifts) as its primary
+// value.
 bool isModifierKey(Key key) {
-  // If it's a plain keyboard key, return true if its base keycode is a
-  // modifier, otherwise return false:
-  if ((key.getFlags() & (SYNTHETIC | RESERVED)) == 0) {
-    return (key.getKeyCode() >= HID_KEYBOARD_FIRST_MODIFIER &&
-            key.getKeyCode() <= HID_KEYBOARD_LAST_MODIFIER);
-  }
-  // If it's a layer shift key, return true:
-  if (key.getFlags() == (SYNTHETIC | SWITCH_TO_KEYMAP) &&
-      key.getKeyCode() >= LAYER_SHIFT_OFFSET) {
-    return true;
-  }
-  // In all other cases, return false:
-  return false;
+  return (key.isKeyboardModifier() || key.isLayerShift());
 }
 
 } // namespace plugin {


### PR DESCRIPTION
### `Key` changes

In working with several plugins, I've realized that several of them need to perform the same tests, especially checks for Keyboard modifier keys. Qukeys, OneShot, TopsyTurvy, and Shapeshifter all need this same test, and it makes most sense to me to implement it as an instance method of the `Key` class, like so:
```c++
key.isKeyboardModifier();
```
It could also be implemented as an external function (`isKeyboardModifier(key)`), but I think it reads better as a method.

In addition to that, I'm including the related methods `isKeyboardKey()` & `isShiftKey()`. The former includes a check that should used in many places where it's easy to assume that a `Key` value is a Keyboard key, but might not be. (e.g. checking for modifier flags without first verifying that those bits are actually modifier flags). The latter is useful in at least a few plugins, where the status of `shift` is of particular interest. In both cases, the test I've written includes not just "plain" modifiers, but also "combo" modifiers that have other mod flags applied, such as `Key_Meh`. 

In order to write these as methods, I needed access to the `RESERVED` and `SYNTHETIC` definitions, so I moved all of the macros defining bits in the flags byte to a separate file, and included it before the definition of the `Key` class. I'd prefer it if those were defined as `constexpr` instead, but that's beyond the scope of what I'm trying to accomplish here.

### `KeyAddr` changes

I've also found myself wanting to initialize or set `KeyAddr` variables to an invalid address quite often, and having difficulty remembering how. Right now, the most "proper" way to do it is one of these:
```c++
KeyAddr my_addr1 = KeyAddr(KeyAddr::invalid_state);
KeyAddr my_addr2{KeyAddr::invalid_state};
KeyAddr my_addr3;
```
When assigning to a variable:
```c++
my_addr1 = KeyAddr(KeyAddr::invalid_state);
my_addr3 = KeyAddr();
```
The `my_addr3` versions are nice an brief, but it's not obvious when looking at the code what value they'll get. The other examples are quite verbose, and difficult to remember. So, I added one constant, and one method to the `KeyAddr` (`MatrixAddr`, really) class to help make the client code easier to read and write:

- `KeyAddr::invalid`: a `constexpr KeyAddr`, usable in place of `KeyAddr(KeyAddr::invalid_state)`
- `key_addr.clear()`: an instance method that sets the stored value to `KeyAddr::invalid`

The latter is, I think, a reasonable counterpart to the `key_addr.isValid()` method, and the former is nice for explicit initialization when a `KeyAddr` should begin with an invalid value.