### PR TITLE
Add some basic plugin testcases

### DIFF
--- a/tests/plugins/Escape-OneShot/basic/common.h
+++ b/tests/plugins/Escape-OneShot/basic/common.h
@@ -1,0 +1,27 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/tests/plugins/Escape-OneShot/basic/sketch.ino
+++ b/tests/plugins/Escape-OneShot/basic/sketch.ino
@@ -1,0 +1,55 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-OneShot.h>
+#include <Kaleidoscope-Escape-OneShot.h>
+
+#include "./common.h"
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        OSM(LeftShift), OSM(LeftAlt), ___, ___, ___, ___, ___,
+        Key_Escape, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+KALEIDOSCOPE_INIT_PLUGINS(OneShot, EscapeOneShot);
+
+void setup() {
+  Kaleidoscope.setup();
+  OneShot.time_out = 50;
+  OneShot.hold_time_out = 20;
+  OneShot.double_tap_time_out = 20;
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/plugins/Escape-OneShot/basic/test.ktest
+++ b/tests/plugins/Escape-OneShot/basic/test.ktest
@@ -1,0 +1,48 @@
+VERSION 1
+
+KEYSWITCH OSM_0  0 0  # left shift
+KEYSWITCH OSM_1  0 1  # left alt
+KEYSWITCH ESC    1 0
+
+# ==============================================================================
+NAME EscapeOneShot cancel temporary
+
+RUN 5 ms
+PRESS OSM_0
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+RUN 5 ms
+RELEASE OSM_0
+RUN 10 ms
+PRESS ESC
+RUN 2 cycles
+EXPECT keyboard-report empty # Report should be empty
+RUN 5 ms
+RELEASE ESC
+RUN 1 cycle
+
+# ==============================================================================
+# The testcases below are commented out because they are currently failing.
+
+# # ==============================================================================
+# NAME EscapeOneShot cancel sticky
+
+# RUN 5 ms
+# PRESS OSM_0
+# RUN 1 cycle
+# EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+# RUN 5 ms
+# RELEASE OSM_0
+
+# RUN 5 ms
+# PRESS OSM_0
+# RUN 5 ms
+# RELEASE OSM_0
+
+# RUN 50 ms
+# PRESS ESC
+# RUN 2 cycles
+# EXPECT keyboard-report empty # Report should be empty
+# RUN 5 ms
+# RELEASE ESC
+# RUN 1 cycle

--- a/tests/plugins/MagicCombo/basic/common.h
+++ b/tests/plugins/MagicCombo/basic/common.h
@@ -1,0 +1,27 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/tests/plugins/MagicCombo/basic/sketch.ino
+++ b/tests/plugins/MagicCombo/basic/sketch.ino
@@ -1,0 +1,66 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-MagicCombo.h>
+
+#include "./common.h"
+
+#undef min
+#undef max
+#include <iostream>
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+void tapKeyA(uint8_t magic_combo_index) {
+  std::cerr << "tapKeyA" << std::endl;
+  handleKeyswitchEvent(Key_A, KeyAddr{1, 0}, IS_PRESSED | INJECTED);
+  Kaleidoscope.hid().keyboard().sendReport();
+  handleKeyswitchEvent(Key_NoKey, KeyAddr{1, 0}, WAS_PRESSED | INJECTED);
+  Kaleidoscope.hid().keyboard().sendReport();
+}
+
+USE_MAGIC_COMBOS({.action = tapKeyA, .keys = {R0C0, R0C1, R0C2}});
+
+KALEIDOSCOPE_INIT_PLUGINS(MagicCombo);
+
+void setup() {
+  Kaleidoscope.setup();
+  MagicCombo.min_interval = 20;
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/plugins/MagicCombo/basic/test.ktest
+++ b/tests/plugins/MagicCombo/basic/test.ktest
@@ -1,0 +1,30 @@
+VERSION 1
+
+KEYSWITCH MC0  0 0
+KEYSWITCH MC1  0 1
+KEYSWITCH MC2  0 2
+
+# ==============================================================================
+NAME MagicCombo key A
+
+RUN 5 ms
+PRESS MC2
+PRESS MC1
+RUN 5 ms
+PRESS MC0
+RUN 10 ms
+# With MagicCombo.min_interval set to 20(ms), we need to wait that long before
+# it will trigger, plus one.
+RUN 1 ms
+EXPECT keyboard-report Key_A # The report should contain only `A`
+EXPECT keyboard-report empty # Report should be empty
+RUN 5 ms
+RELEASE MC0
+RUN 1 cycle
+RELEASE MC2
+RUN 1 cycle
+RELEASE MC1
+RUN 1 cycle
+
+# Run a bit longer to make sure no extra reports were generated.
+RUN 5 ms

--- a/tests/plugins/OneShot/basic/common.h
+++ b/tests/plugins/OneShot/basic/common.h
@@ -1,0 +1,27 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/tests/plugins/OneShot/basic/sketch.ino
+++ b/tests/plugins/OneShot/basic/sketch.ino
@@ -1,0 +1,54 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-OneShot.h>
+
+#include "./common.h"
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        OSM(LeftShift), ___, ___, ___, ___, ___, ___,
+        Key_A, Key_B, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+KALEIDOSCOPE_INIT_PLUGINS(OneShot);
+
+void setup() {
+  Kaleidoscope.setup();
+  OneShot.time_out = 50;
+  OneShot.hold_time_out = 20;
+  OneShot.double_tap_time_out = 20;
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/plugins/OneShot/basic/test.ktest
+++ b/tests/plugins/OneShot/basic/test.ktest
@@ -1,0 +1,145 @@
+VERSION 1
+
+KEYSWITCH OS_shift  0 0
+KEYSWITCH A         1 0
+KEYSWITCH B         1 1
+
+# ==============================================================================
+NAME OneShot timeout
+
+RUN 5 ms
+
+PRESS OS_shift
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+RUN 5 ms
+RELEASE OS_shift
+RUN 45 ms
+RUN 2 cycles
+EXPECT keyboard-report empty # Report should be empty
+
+# ==============================================================================
+NAME OneShot next key
+
+RUN 5 ms
+
+PRESS OS_shift
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+RUN 5 ms
+RELEASE OS_shift
+RUN 10 ms
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift Key_A # There should be `shift`+`A`
+RUN 1 cycle
+EXPECT keyboard-report Key_A # There should be only `A`
+RUN 5 ms
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+
+# ==============================================================================
+NAME OneShot double tap
+
+RUN 5 ms
+PRESS OS_shift
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+RUN 5 ms
+RELEASE OS_shift
+
+RUN 5 ms
+PRESS OS_shift
+RUN 5 ms
+RELEASE OS_shift
+
+RUN 50 ms
+
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift Key_A # There should be `shift`+`A`
+RUN 5 ms
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+
+RUN 10 ms
+
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift Key_A # There should be `shift`+`A`
+RUN 5 ms
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+
+RUN 5 ms
+PRESS OS_shift
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+RUN 5 ms
+RELEASE OS_shift
+RUN 1 cycle
+
+# ==============================================================================
+NAME OneShot double tap timeout
+
+RUN 5 ms
+PRESS OS_shift
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+RUN 5 ms
+RELEASE OS_shift
+
+RUN 20 ms
+PRESS OS_shift
+RUN 5 ms
+RELEASE OS_shift
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+
+RUN 50 ms
+
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # There should be only `A`
+RUN 5 ms
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+
+RUN 10 ms
+
+# ==============================================================================
+NAME OneShot hold timeout
+
+RUN 5 ms
+
+PRESS OS_shift
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+RUN 30 ms
+RELEASE OS_shift
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+
+# ==============================================================================
+NAME OneShot rollover
+
+RUN 5 ms
+PRESS OS_shift
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+RUN 5 ms
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift Key_A # There should be `shift`+`A`
+RUN 5 ms
+RELEASE OS_shift
+RUN 2 cycles # 2 cycles?
+EXPECT keyboard-report Key_A # There should be only `A`
+RUN 5 ms
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty

--- a/tests/plugins/ShapeShifter/basic/common.h
+++ b/tests/plugins/ShapeShifter/basic/common.h
@@ -1,0 +1,27 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/tests/plugins/ShapeShifter/basic/sketch.ino
+++ b/tests/plugins/ShapeShifter/basic/sketch.ino
@@ -1,0 +1,59 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-ShapeShifter.h>
+
+#include "./common.h"
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        Key_1, Key_2, Key_3, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        Key_LeftShift, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+static const kaleidoscope::plugin::ShapeShifter::dictionary_t shape_shifter_dictionary[] PROGMEM = {
+  {Key_1, Key_2},
+  {Key_2, Key_1},
+  {Key_3, Key_4},
+  {Key_NoKey, Key_NoKey},
+};
+
+KALEIDOSCOPE_INIT_PLUGINS(ShapeShifter);
+
+void setup() {
+  Kaleidoscope.setup();
+  ShapeShifter.dictionary = shape_shifter_dictionary;
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/plugins/ShapeShifter/basic/test.ktest
+++ b/tests/plugins/ShapeShifter/basic/test.ktest
@@ -1,0 +1,38 @@
+VERSION 1
+
+KEYSWITCH K1       0 0
+KEYSWITCH K2       0 1
+KEYSWITCH K3       0 2
+KEYSWITCH LSHIFT   2 0
+
+# ==============================================================================
+NAME ShapeShifter without shift
+
+RUN 5 ms
+PRESS K1
+RUN 1 cycle
+EXPECT keyboard-report Key_1 # The report should contain only `1`
+RUN 5 ms
+RELEASE K1
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+
+# ==============================================================================
+NAME ShapeShifter full overlap
+
+RUN 5 ms
+PRESS LSHIFT
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+RUN 5 ms
+PRESS K1
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift Key_2 # The report should contain `shift` + `2`
+RUN 5 ms
+RELEASE K1
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+RUN 5 ms
+RELEASE LSHIFT
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty

--- a/tests/plugins/TapDance/basic/common.h
+++ b/tests/plugins/TapDance/basic/common.h
@@ -1,0 +1,27 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/tests/plugins/TapDance/basic/sketch.ino
+++ b/tests/plugins/TapDance/basic/sketch.ino
@@ -1,0 +1,65 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-TapDance.h>
+
+#include "./common.h"
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        Key_X, ___, ___, ___, ___, ___, ___,
+        TD(0), ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+void tapDanceAction(uint8_t tap_dance_index,
+                    KeyAddr key_addr,
+                    uint8_t tap_count,
+                    kaleidoscope::plugin::TapDance::ActionType tap_dance_action) {
+  switch (tap_dance_index) {
+  case 0:
+    return tapDanceActionKeys(tap_count, tap_dance_action,
+                              Key_A, Key_B, Key_C);
+  default:
+    break;
+  }
+}
+
+KALEIDOSCOPE_INIT_PLUGINS(TapDance);
+
+void setup() {
+  Kaleidoscope.setup();
+  TapDance.time_out = 25;
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/plugins/TapDance/basic/test.ktest
+++ b/tests/plugins/TapDance/basic/test.ktest
@@ -1,0 +1,105 @@
+VERSION 1
+
+KEYSWITCH X     0 0
+KEYSWITCH TD_0  1 0
+
+# ==============================================================================
+NAME Tapdance interrupt
+
+RUN 5 ms
+PRESS TD_0
+RUN 5 ms
+RELEASE TD_0
+
+RUN 10 ms
+PRESS TD_0
+RUN 5 ms
+RELEASE TD_0
+
+RUN 5 ms
+PRESS X
+RUN 1 cycle
+EXPECT keyboard-report Key_B # The report should contain `B`
+EXPECT keyboard-report empty # Report should be empty
+RUN 1 cycle
+EXPECT keyboard-report Key_X # Report should contain `X`
+
+RUN 5 ms
+RELEASE X
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+
+# ==============================================================================
+NAME Tapdance timeout
+
+RUN 50 ms
+
+PRESS TD_0
+RUN 5 ms
+RELEASE TD_0
+RUN 10 ms
+
+PRESS TD_0
+RUN 1 cycle
+RUN 5 ms
+RELEASE TD_0
+RUN 20 ms # Timeout = 25ms
+
+RUN 2 ms # Extra 2 cycles for some reason
+EXPECT keyboard-report Key_B # The report should contain `B`
+EXPECT keyboard-report empty # Report should be empty
+
+# ==============================================================================
+# The testcases below are commented out because they are currently failing.
+
+# # ==============================================================================
+# NAME Tapdance interrupt with rollover
+
+# RUN 5 ms
+# PRESS TD_0
+# RUN 5 ms
+# RELEASE TD_0
+
+# RUN 10 ms
+# PRESS TD_0
+
+# RUN 5 ms
+# PRESS X
+# RUN 1 cycle
+# EXPECT keyboard-report Key_B # The report should contain `B`
+# RUN 1 cycle
+# EXPECT keyboard-report Key_B Key_X # Report should contain `B` & `X`
+
+# RUN 5 ms
+# RELEASE TD_0
+# RUN 1 cycle
+# EXPECT keyboard-report Key_X # Report should contain `X`
+
+
+# RUN 5 ms
+# RELEASE X
+# RUN 1 cycle
+# EXPECT keyboard-report empty # Report should be empty
+
+# # ==============================================================================
+# NAME Tapdance timeout while held
+
+# RUN 5 ms
+
+# PRESS TD_0
+# RUN 5 ms
+# RELEASE TD_0
+# RUN 10 ms
+
+# PRESS TD_0
+# RUN 1 cycle
+# RUN 25 ms
+
+# RUN 2 cycles
+# EXPECT keyboard-report Key_B # The report should contain `B`
+
+# RUN 10 ms
+# RELEASE TD_0
+# RUN 1 cycle
+
+# EXPECT keyboard-report empty # Report should be empty

--- a/tests/plugins/TopsyTurvy/basic/common.h
+++ b/tests/plugins/TopsyTurvy/basic/common.h
@@ -1,0 +1,27 @@
+// -*- mode: c++ -*-
+
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace kaleidoscope {
+namespace testing {
+
+}  // namespace testing
+}  // namespace kaleidoscope

--- a/tests/plugins/TopsyTurvy/basic/sketch.ino
+++ b/tests/plugins/TopsyTurvy/basic/sketch.ino
@@ -1,0 +1,51 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2020  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-TopsyTurvy.h>
+
+#include "./common.h"
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        TOPSY(1), TOPSY(2), ___, ___, ___, ___, ___,
+        Key_A, Key_B, ___, ___, ___, ___, ___,
+        Key_LeftShift, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+KALEIDOSCOPE_INIT_PLUGINS(TopsyTurvy);
+
+void setup() {
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/plugins/TopsyTurvy/basic/test.ktest
+++ b/tests/plugins/TopsyTurvy/basic/test.ktest
@@ -1,0 +1,47 @@
+VERSION 1
+
+KEYSWITCH TOPSY_1  0 0
+KEYSWITCH TOPSY_2  0 1
+KEYSWITCH A        1 0
+KEYSWITCH B        1 1
+KEYSWITCH LSHIFT   2 0
+
+# ==============================================================================
+NAME TopsyTurvy without shift
+
+RUN 5 ms
+PRESS TOPSY_1
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+EXPECT keyboard-report Key_LeftShift Key_1 # The report should contain `shift` + `1`
+RUN 5 ms
+RELEASE TOPSY_1
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+EXPECT keyboard-report empty # Report should be empty
+
+# ==============================================================================
+NAME TopsyTurvy with shift
+
+RUN 5 ms
+PRESS LSHIFT
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+RUN 5 ms
+PRESS TOPSY_1
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty
+EXPECT keyboard-report Key_1 # The report should contain only `1`
+RUN 5 ms
+RELEASE TOPSY_1
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift Key_1 # The report should contain `shift` + `1`
+# Really the report above should be empty, but it seems to work okay in master
+# like this, and it will get fixed if and when Kaleidoscope becomes
+# event-driven.
+# EXPECT keyboard-report empty # Report should be empty
+EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
+RUN 5 ms
+RELEASE LSHIFT
+RUN 1 cycle
+EXPECT keyboard-report empty # Report should be empty


### PR DESCRIPTION
I've written some trivial testcases for a few plugins:

- OneShot
- Escape-OneShot
- MagicCombo
- TopsyTurvy
- ShapeShifter
- TapDance

I originally wrote these for verifying #904 & #905, which contain a few bugfixes for issues that still exist on master, so I commented out testcases that currently fail on master (in TapDance & Escape-OneShot). I'll update them accordingly in those PRs.