### PR TITLE
update AppSwitcher example to indicate that one must manually set the OS

### DIFF
--- a/examples/Features/AppSwitcher/AppSwitcher.ino
+++ b/examples/Features/AppSwitcher/AppSwitcher.ino
@@ -61,6 +61,9 @@ KALEIDOSCOPE_INIT_PLUGINS(EEPROMSettings,
 
 void setup() {
   Kaleidoscope.setup();
+  // Uncomment to manually set the OS, as Kaleidoscope will not autodetect it.
+  // (Possible values are in HostOS.h.)
+  // HostOS.os(kaleidoscope::hostos::LINUX);
 }
 
 void loop() {


### PR DESCRIPTION
Host auto-detection was removed in 985e31b4, but the examples were never
updated accordingly.

While 3 examples include the HostOS header, AppSwitcher is the only example to
actually use the HostOS value for any purpose other than printing it. I got
stumped trying to debug why auto-detection was failing until I searched the
code history and saw it was removed. I think we should be more explicit by
updating the example to clearly indicate to any user reading it that the OS
must be manually set.