### PR TITLE
Integrate KeyboardioScanner as a driver

### DIFF
--- a/LICENSE.MIT
+++ b/LICENSE.MIT
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright © 2015 Jesse Vincent <jesse@fsck.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/kaleidoscope/device/dygma/Raise.cpp
+++ b/src/kaleidoscope/device/dygma/Raise.cpp
@@ -43,8 +43,8 @@ namespace dygma {
 /********* RaiseHands *********/
 
 struct RaiseHands {
-  static raise::Hand leftHand;
-  static raise::Hand rightHand;
+  static raise::RaiseSide leftHand;
+  static raise::RaiseSide rightHand;
 
   static void setup();
   static void initializeSides();
@@ -68,8 +68,8 @@ struct RaiseHands {
   static constexpr uint8_t iso_only_led_ = 19;
 };
 
-raise::Hand RaiseHands::leftHand(0);
-raise::Hand RaiseHands::rightHand(1);
+raise::RaiseSide RaiseHands::leftHand(0);
+raise::RaiseSide RaiseHands::rightHand(1);
 uint8_t RaiseHands::layout;
 bool RaiseHands::side_power_;
 uint16_t RaiseHands::settings_base_;

--- a/src/kaleidoscope/device/dygma/Raise.h
+++ b/src/kaleidoscope/device/dygma/Raise.h
@@ -21,7 +21,7 @@
 #ifdef ARDUINO_SAMD_RAISE
 #include <Arduino.h>
 
-#include "kaleidoscope/device/dygma/raise/Hand.h"
+#include "kaleidoscope/device/dygma/raise/RaiseSide.h"
 
 #define CRGB(r,g,b) (cRGB){b, g, r}
 

--- a/src/kaleidoscope/device/dygma/raise/RaiseSide.cpp
+++ b/src/kaleidoscope/device/dygma/raise/RaiseSide.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * kaleidoscope::device::dygma::Raise -- Kaleidoscope device plugin for Dygma Raise
- * Copyright (C) 2017-2019  Keyboard.io, Inc
+ * Copyright (C) 2017-2020  Keyboard.io, Inc
  * Copyright (C) 2017-2020  Dygma Lab S.L.
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -19,7 +19,7 @@
 #ifdef ARDUINO_SAMD_RAISE
 
 #include <Arduino.h>
-#include "Hand.h"
+#include "RaiseSide.h"
 
 #include "kaleidoscope/driver/color/GammaCorrection.h"
 
@@ -66,7 +66,7 @@ namespace raise {
 #define ELEMENTS(arr)  (sizeof(arr) / sizeof((arr)[0]))
 
 // Returns the relative controller addresss. The expected range is 0-3
-uint8_t Hand::controllerAddress() {
+uint8_t RaiseSide::controllerAddress() {
   return ad01_;
 }
 
@@ -87,42 +87,42 @@ uint8_t Hand::controllerAddress() {
 //
 // returns the Wire.endTransmission code (0 = success)
 // https://www.arduino.cc/en/Reference/WireEndTransmission
-byte Hand::setKeyscanInterval(byte delay) {
+byte RaiseSide::setKeyscanInterval(byte delay) {
   uint8_t data[] = {TWI_CMD_KEYSCAN_INTERVAL, delay};
   return twi_.writeTo(data, ELEMENTS(data));
 }
 
 // returns -1 on error, otherwise returns the scanner version integer
-int Hand::readVersion() {
+int RaiseSide::readVersion() {
   return readRegister(TWI_CMD_VERSION);
 }
 
 // returns -1 on error, otherwise returns the sled version integer
-int Hand::readSLEDVersion() {
+int RaiseSide::readSLEDVersion() {
   return readRegister(TWI_CMD_SLED_STATUS);
 }
 // returns -1 on error, otherwise returns the sled current settings
-int Hand::readSLEDCurrent() {
+int RaiseSide::readSLEDCurrent() {
   return readRegister(TWI_CMD_SLED_CURRENT);
 }
 
-byte Hand::setSLEDCurrent(byte current) {
+byte RaiseSide::setSLEDCurrent(byte current) {
   uint8_t data[] = {TWI_CMD_SLED_CURRENT, current};
   return twi_.writeTo(data, ELEMENTS(data));
 }
 
 // returns -1 on error, otherwise returns the scanner keyscan interval
-int Hand::readKeyscanInterval() {
+int RaiseSide::readKeyscanInterval() {
   return readRegister(TWI_CMD_KEYSCAN_INTERVAL);
 }
 
 // returns -1 on error, otherwise returns the layout (ANSI/ISO) setting
-int Hand::readLayout() {
+int RaiseSide::readLayout() {
   return readRegister(TWI_CMD_LAYOUT);
 }
 
 // returns -1 on error, otherwise returns the LED SPI Frequncy
-int Hand::readLEDSPIFrequency() {
+int RaiseSide::readLEDSPIFrequency() {
   return readRegister(TWI_CMD_LED_SPI_FREQUENCY);
 }
 
@@ -131,13 +131,13 @@ int Hand::readLEDSPIFrequency() {
 //
 // returns the Wire.endTransmission code (0 = success)
 // https://www.arduino.cc/en/Reference/WireEndTransmission
-byte Hand::setLEDSPIFrequency(byte frequency) {
+byte RaiseSide::setLEDSPIFrequency(byte frequency) {
   uint8_t data[] = {TWI_CMD_LED_SPI_FREQUENCY, frequency};
   return twi_.writeTo(data, ELEMENTS(data));
 }
 
 // returns -1 on error, otherwise returns the value of the hall sensor integer
-int Hand::readJoint() {
+int RaiseSide::readJoint() {
   byte return_value = 0;
 
   uint8_t data[] = {TWI_CMD_JOINED};
@@ -159,7 +159,7 @@ int Hand::readJoint() {
   }
 }
 
-int Hand::readRegister(uint8_t cmd) {
+int RaiseSide::readRegister(uint8_t cmd) {
   byte return_value = 0;
 
   uint8_t data[] = {cmd};
@@ -182,13 +182,13 @@ int Hand::readRegister(uint8_t cmd) {
 }
 
 // gives information on the key that was just pressed or released.
-bool Hand::readKeys() {
+bool RaiseSide::readKeys() {
   uint8_t rxBuffer[6] = {0, 0, 0, 0, 0, 0};
 
   // perform blocking read into buffer
   uint8_t result = twi_.readFrom(rxBuffer, ELEMENTS(rxBuffer));
   // if result isn't 6? this can happens if slave nacks while trying to read
-  Hand::online = (result == 6) ? true : false;
+  RaiseSide::online = (result == 6) ? true : false;
 
   if (result != 6)
     // could also try reset pressed keys here
@@ -206,11 +206,11 @@ bool Hand::readKeys() {
   }
 }
 
-keydata_t Hand::getKeyData() {
+keydata_t RaiseSide::getKeyData() {
   return key_data_;
 }
 
-void Hand::sendLEDData() {
+void RaiseSide::sendLEDData() {
   sendLEDBank(next_led_bank_++);
   if (next_led_bank_ == LED_BANKS) {
     next_led_bank_ = 0;
@@ -219,7 +219,7 @@ void Hand::sendLEDData() {
 
 auto constexpr gamma8 = kaleidoscope::driver::color::gamma_correction;
 
-void Hand::sendLEDBank(uint8_t bank) {
+void RaiseSide::sendLEDBank(uint8_t bank) {
   uint8_t data[LED_BYTES_PER_BANK + 1]; // + 1 for the update LED command itself
   data[0]  = TWI_CMD_LED_BASE + bank;
   for (uint8_t i = 0 ; i < LED_BYTES_PER_BANK; i++) {

--- a/src/kaleidoscope/device/dygma/raise/RaiseSide.h
+++ b/src/kaleidoscope/device/dygma/raise/RaiseSide.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * kaleidoscope::device::dygma::Raise -- Kaleidoscope device plugin for Dygma Raise
- * Copyright (C) 2017-2019  Keyboard.io, Inc
+ * Copyright (C) 2017-2020  Keyboard.io, Inc
  * Copyright (C) 2017-2019  Dygma Lab S.L.
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -54,9 +54,9 @@ typedef union {
   uint64_t all;
 } keydata_t;
 
-class Hand {
+class RaiseSide {
  public:
-  explicit Hand(byte ad01) : ad01_(ad01), twi_(i2c_addr_base_ | ad01) {}
+  explicit RaiseSide(byte ad01) : ad01_(ad01), twi_(i2c_addr_base_ | ad01) {}
 
   int readVersion();
   int readSLEDVersion();

--- a/src/kaleidoscope/device/keyboardio/Model01.cpp
+++ b/src/kaleidoscope/device/keyboardio/Model01.cpp
@@ -38,14 +38,14 @@ constexpr uint8_t Model01LEDDriverProps::key_led_map[] PROGMEM;
 /********* Model01Hands *********/
 
 struct Model01Hands {
-  static KeyboardioScanner leftHand;
-  static KeyboardioScanner rightHand;
+  static driver::keyboardio::Model01Side leftHand;
+  static driver::keyboardio::Model01Side rightHand;
 
   static void setup();
 };
 
-KeyboardioScanner Model01Hands::leftHand(0);
-KeyboardioScanner Model01Hands::rightHand(3);
+driver::keyboardio::Model01Side Model01Hands::leftHand(0);
+driver::keyboardio::Model01Side Model01Hands::rightHand(3);
 
 void Model01Hands::setup(void) {
   // This lets the keyboard pull up to 1.6 amps from the host.
@@ -135,12 +135,12 @@ boolean Model01LEDDriver::ledPowerFault() {
 
 /********* Key scanner *********/
 
-keydata_t Model01KeyScanner::leftHandState;
-keydata_t Model01KeyScanner::rightHandState;
-keydata_t Model01KeyScanner::previousLeftHandState;
-keydata_t Model01KeyScanner::previousRightHandState;
-keydata_t Model01KeyScanner::leftHandMask;
-keydata_t Model01KeyScanner::rightHandMask;
+driver::keyboardio::keydata_t Model01KeyScanner::leftHandState;
+driver::keyboardio::keydata_t Model01KeyScanner::rightHandState;
+driver::keyboardio::keydata_t Model01KeyScanner::previousLeftHandState;
+driver::keyboardio::keydata_t Model01KeyScanner::previousRightHandState;
+driver::keyboardio::keydata_t Model01KeyScanner::leftHandMask;
+driver::keyboardio::keydata_t Model01KeyScanner::rightHandMask;
 
 void Model01KeyScanner::enableScannerPower(void) {
   // Turn on power to the LED net

--- a/src/kaleidoscope/device/keyboardio/Model01.h
+++ b/src/kaleidoscope/device/keyboardio/Model01.h
@@ -32,12 +32,9 @@ struct cRGB {
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
 
 #include "kaleidoscope/driver/keyscanner/Base.h"
+#include "kaleidoscope/driver/keyboardio/Model01Side.h"
 #include "kaleidoscope/driver/led/Base.h"
 #include "kaleidoscope/driver/bootloader/avr/Caterina.h"
-
-#ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-#include "KeyboardioScanner.h"
-#endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
 namespace kaleidoscope {
 namespace device {
@@ -102,13 +99,13 @@ class Model01KeyScanner : public kaleidoscope::driver::keyscanner::Base<Model01K
   static void setKeyscanInterval(uint8_t interval);
 
  protected:
-  static keydata_t leftHandState;
-  static keydata_t rightHandState;
-  static keydata_t previousLeftHandState;
-  static keydata_t previousRightHandState;
+  static driver::keyboardio::keydata_t leftHandState;
+  static driver::keyboardio::keydata_t rightHandState;
+  static driver::keyboardio::keydata_t previousLeftHandState;
+  static driver::keyboardio::keydata_t previousRightHandState;
 
-  static keydata_t leftHandMask;
-  static keydata_t rightHandMask;
+  static driver::keyboardio::keydata_t leftHandMask;
+  static driver::keyboardio::keydata_t rightHandMask;
 
   static void actOnHalfRow(byte row, byte colState, byte colPrevState, byte startPos);
   static void enableScannerPower();

--- a/src/kaleidoscope/driver/keyboardio/Model01Side.cpp
+++ b/src/kaleidoscope/driver/keyboardio/Model01Side.cpp
@@ -1,0 +1,214 @@
+/* kaleidoscope::driver::keyboardio::Model01Side
+ * Copyright (C) 2015-2020  Keyboard.io, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+
+#include <Arduino.h>
+#include "Model01Side.h"
+
+extern "C" {
+#include "kaleidoscope/device/keyboardio/twi.h"
+}
+
+#include "kaleidoscope/driver/color/GammaCorrection.h"
+
+namespace kaleidoscope {
+namespace driver {
+namespace keyboardio {
+
+#define SCANNER_I2C_ADDR_BASE 0x58
+#define ELEMENTS(arr)  (sizeof(arr) / sizeof((arr)[0]))
+
+uint8_t twi_uninitialized = 1;
+
+Model01Side::Model01Side(byte setAd01) {
+  ad01 = setAd01;
+  addr = SCANNER_I2C_ADDR_BASE | ad01;
+  if (twi_uninitialized--) {
+    twi_init();
+  }
+}
+
+// Returns the relative controller addresss. The expected range is 0-3
+uint8_t Model01Side::controllerAddress() {
+  return ad01;
+}
+
+// Sets the keyscan interval. We currently do three reads.
+// before declaring a key event debounced.
+//
+// Takes an integer value representing a counter.
+//
+// 0 - 0.1-0.25ms
+// 1 - 0.125ms
+// 10 - 0.35ms
+// 25 - 0.8ms
+// 50 - 1.6ms
+// 100 - 3.15ms
+//
+// You should think of this as the _minimum_ keyscan interval.
+// LED updates can cause a bit of jitter.
+//
+// returns the Wire.endTransmission code (0 = success)
+// https://www.arduino.cc/en/Reference/WireEndTransmission
+byte Model01Side::setKeyscanInterval(byte delay) {
+  uint8_t data[] = {TWI_CMD_KEYSCAN_INTERVAL, delay};
+  uint8_t result = twi_writeTo(addr, data, ELEMENTS(data), 1, 0);
+
+  return result;
+}
+
+
+
+
+// returns -1 on error, otherwise returns the scanner version integer
+int Model01Side::readVersion() {
+  return readRegister(TWI_CMD_VERSION);
+}
+
+// returns -1 on error, otherwise returns the scanner keyscan interval
+int Model01Side::readKeyscanInterval() {
+  return readRegister(TWI_CMD_KEYSCAN_INTERVAL);
+}
+
+
+// returns -1 on error, otherwise returns the LED SPI Frequncy
+int Model01Side::readLEDSPIFrequency() {
+  return readRegister(TWI_CMD_LED_SPI_FREQUENCY);
+}
+
+// Set the LED SPI Frequency. See wire-protocol-constants.h for
+// values.
+//
+// returns the Wire.endTransmission code (0 = success)
+// https://www.arduino.cc/en/Reference/WireEndTransmission
+byte Model01Side::setLEDSPIFrequency(byte frequency) {
+  uint8_t data[] = {TWI_CMD_LED_SPI_FREQUENCY, frequency};
+  uint8_t result = twi_writeTo(addr, data, ELEMENTS(data), 1, 0);
+
+  return result;
+}
+
+
+
+int Model01Side::readRegister(uint8_t cmd) {
+
+  byte return_value = 0;
+
+  uint8_t data[] = {cmd};
+  uint8_t result = twi_writeTo(addr, data, ELEMENTS(data), 1, 0);
+
+
+
+  delayMicroseconds(15); // We may be able to drop this in the future
+  // but will need to verify with correctly
+  // sized pull-ups on both the left and right
+  // hands' i2c SDA and SCL lines
+
+  uint8_t rxBuffer[1];
+
+  // perform blocking read into buffer
+  uint8_t read = twi_readFrom(addr, rxBuffer, ELEMENTS(rxBuffer), true);
+  if (read > 0) {
+    return rxBuffer[0];
+  } else {
+    return -1;
+  }
+
+}
+
+
+// gives information on the key that was just pressed or released.
+bool Model01Side::readKeys() {
+
+  uint8_t rxBuffer[5];
+
+  // perform blocking read into buffer
+  uint8_t read = twi_readFrom(addr, rxBuffer, ELEMENTS(rxBuffer), true);
+  if (rxBuffer[0] == TWI_REPLY_KEYDATA) {
+    keyData.rows[0] = rxBuffer[1];
+    keyData.rows[1] = rxBuffer[2];
+    keyData.rows[2] = rxBuffer[3];
+    keyData.rows[3] = rxBuffer[4];
+    return true;
+  } else {
+    return false;
+  }
+}
+
+keydata_t Model01Side::getKeyData() {
+  return keyData;
+}
+
+void Model01Side::sendLEDData() {
+  sendLEDBank(nextLEDBank++);
+  if (nextLEDBank == LED_BANKS) {
+    nextLEDBank = 0;
+  }
+}
+
+auto constexpr gamma8 = kaleidoscope::driver::color::gamma_correction;
+
+void Model01Side::sendLEDBank(byte bank) {
+  uint8_t data[LED_BYTES_PER_BANK + 1];
+  data[0]  = TWI_CMD_LED_BASE + bank;
+  for (uint8_t i = 0 ; i < LED_BYTES_PER_BANK; i++) {
+    /* While the ATTiny controller does have a global brightness command, it is
+     * limited to 32 levels, and those aren't nicely spread out either. For this
+     * reason, we're doing our own brightness adjustment on this side, because
+     * that results in a considerably smoother curve. */
+    uint8_t c = ledData.bytes[bank][i];
+    if (c > brightness_adjustment_)
+      c -= brightness_adjustment_;
+    else
+      c = 0;
+
+    data[i + 1] = pgm_read_byte(&gamma8[c]);
+  }
+  uint8_t result = twi_writeTo(addr, data, ELEMENTS(data), 1, 0);
+}
+
+void Model01Side::setAllLEDsTo(cRGB color) {
+  uint8_t data[] = {TWI_CMD_LED_SET_ALL_TO,
+                    pgm_read_byte(&gamma8[color.b]),
+                    pgm_read_byte(&gamma8[color.g]),
+                    pgm_read_byte(&gamma8[color.r])
+                   };
+  uint8_t result = twi_writeTo(addr, data, ELEMENTS(data), 1, 0);
+}
+
+void Model01Side::setOneLEDTo(byte led, cRGB color) {
+  uint8_t data[] = {TWI_CMD_LED_SET_ONE_TO,
+                    led,
+                    pgm_read_byte(&gamma8[color.b]),
+                    pgm_read_byte(&gamma8[color.g]),
+                    pgm_read_byte(&gamma8[color.r])
+                   };
+  uint8_t result = twi_writeTo(addr, data, ELEMENTS(data), 1, 0);
+
+}
+
+} // namespace keyboardio
+} // namespace driver
+} // namespace kaleidoscope
+
+#endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/src/kaleidoscope/driver/keyboardio/Model01Side.h
+++ b/src/kaleidoscope/driver/keyboardio/Model01Side.h
@@ -1,0 +1,106 @@
+// -*- mode: c++ -*-
+/* kaleidoscope::driver::keyboardio::Model01Side
+ * Copyright (C) 2015-2020  Keyboard.io, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+namespace kaleidoscope {
+namespace driver {
+namespace keyboardio {
+
+#include <Arduino.h>
+#include "wire-protocol-constants.h"
+
+// We allow cRGB/CRGB to be defined already when this is included.
+//
+#ifndef CRGB
+struct cRGB {
+  uint8_t b;
+  uint8_t g;
+  uint8_t r;
+};
+#define CRGB(r,g,b) (cRGB){b, g, r}
+#endif
+
+#define LED_BANKS 4
+
+#define LEDS_PER_HAND 32
+#define LED_BYTES_PER_BANK sizeof(cRGB)  * LEDS_PER_HAND/LED_BANKS
+
+typedef union {
+  cRGB leds[LEDS_PER_HAND];
+  byte bytes[LED_BANKS][LED_BYTES_PER_BANK];
+} LEDData_t;
+
+typedef union {
+  uint8_t rows[4];
+  uint32_t all;
+} keydata_t;
+
+// config options
+
+#ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+// used to configure interrupts, configuration for a particular controller
+class Model01Side {
+ public:
+  explicit Model01Side(byte setAd01);
+  ~Model01Side() {}
+
+  int readVersion();
+
+  byte setKeyscanInterval(byte delay);
+  int readKeyscanInterval();
+
+  byte setLEDSPIFrequency(byte frequency);
+  int readLEDSPIFrequency();
+
+  void sendLEDData();
+  void setOneLEDTo(byte led, cRGB color);
+  void setAllLEDsTo(cRGB color);
+  keydata_t getKeyData();
+  bool readKeys();
+  LEDData_t ledData;
+  uint8_t controllerAddress();
+
+  void setBrightness(uint8_t brightness) {
+    brightness_adjustment_ = 255 - brightness;
+  }
+  uint8_t getBrightness() {
+    return 255 - brightness_adjustment_;
+  }
+
+ private:
+  uint8_t brightness_adjustment_ = 0;
+  int addr;
+  int ad01;
+  keydata_t keyData;
+  byte nextLEDBank = 0;
+  void sendLEDBank(byte bank);
+  int readRegister(uint8_t cmd);
+};
+#else // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+class Model01Side;
+#endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+
+} // namespace keyboardio
+} // namespace driver
+} // namespace kaleidoscope

--- a/src/kaleidoscope/driver/keyboardio/wire-protocol-constants.h
+++ b/src/kaleidoscope/driver/keyboardio/wire-protocol-constants.h
@@ -1,0 +1,51 @@
+/* KeyboardioScanner
+ * Copyright (C) 2015-2018  Keyboard.io, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#define TWI_CMD_NONE 0x00
+#define TWI_CMD_VERSION 0x01
+#define TWI_CMD_KEYSCAN_INTERVAL 0x02
+#define TWI_CMD_LED_SET_ALL_TO 0x03
+#define TWI_CMD_LED_SET_ONE_TO 0x04
+#define TWI_CMD_COLS_USE_PULLUPS 0x05
+#define TWI_CMD_LED_SPI_FREQUENCY 0x06
+
+#define LED_SPI_FREQUENCY_4MHZ      0x07
+#define LED_SPI_FREQUENCY_2MHZ      0x06
+#define LED_SPI_FREQUENCY_1MHZ      0x05
+#define LED_SPI_FREQUENCY_512KHZ    0x04
+#define LED_SPI_FREQUENCY_256KHZ    0x03
+#define LED_SPI_FREQUENCY_128KHZ    0x02
+#define LED_SPI_FREQUENCY_64KHZ     0x01
+#define LED_SPI_OFF                 0x00
+
+
+// 512KHZ seems to be the sweet spot in early testing
+// so make it the default
+#define LED_SPI_FREQUENCY_DEFAULT LED_SPI_FREQUENCY_512KHZ
+
+
+#define TWI_CMD_LED_BASE 0x80
+
+#define TWI_REPLY_NONE 0x00
+#define TWI_REPLY_KEYDATA 0x01


### PR DESCRIPTION
In the process of moving towards a single repository for everything Kaleidoscope, integrate KeyboardioScanner as a driver. This is a direct copy of KeyboardioScanner as of keyboardio/KeyboardioScanner@2090cd426cae25b07c0ce3a6b7365b95c21dd87b, renamed and namespaced to fit into Kaleidoscope.

I opted to not take the full history of KeyboardioScanner, but copy it instead.

There are some differences in PROGMEM & RAM size: compared to master, we're at -42 PROGMEM, at the cost of +160 RAM. I'm not entirely sure yet what the extra RAM is for, but while a lot, it doesn't seem to be _too_ much.