### PR TITLE
kaleidoscope/hooks.cpp: Update a comment to reflect reality

### DIFF
--- a/src/kaleidoscope/hooks.cpp
+++ b/src/kaleidoscope/hooks.cpp
@@ -21,15 +21,14 @@
 
 namespace kaleidoscope {
 
-// The following weak symbols are overwritten by
-// using the KALEIDOSCOPE_INIT_PLUGINS(...) macro
-// in the the firmware sketch. Their only purpose is
-// to provide backwards compatibility during the transition
-// from the old implementation of the hooking/plugin system
-// to the new one. The weak symbols ensure that there
-// are no undefined symbols if KALEIDOSCOPE_INIT_PLUGINS(...)
-// is not used. This allows legacy sketches to be used
-// during the transition phase.
+// The following weak symbols are overwritten by using the
+// KALEIDOSCOPE_INIT_PLUGINS(...) macro in the firmware sketch. Their only
+// purpose is to ensure that there are no undefined symbols if
+// KALEIDOSCOPE_INIT_PLUGINS(...) is not used. Sketches that use no plugins do
+// not use the macro, because due to technical reasons, we do not support an
+// empty KALEIDOSCOPE_INIT_PLUGINS() invocation. These symbols therefore ensure
+// that we can compile sketches that use no plugins, without them having to use
+// KALEIDOSCOPE_INIT_PLUGINS() with a dummy plugin.
 
 #define INSTANTIATE_WEAK_HOOK_FUNCTION(                                        \
     HOOK_NAME, HOOK_VERSION, DEPRECATION_TAG,                                  \


### PR DESCRIPTION
The `INSTANTIATE_WEAK_HOOK_FUNCTION` claimed that it's there for v1 API compatibility alone - it is not. It allows us to have sketches that use no plugins too, without them having to use `KALEIDOSCOPE_INIT_PLUGINS()` with a dummy plugin.

We'd need a dummy plugin because `KALEIDOSCOPE_INIT_PLUGINS()` does not support being invoked with an empty plugin list, due to technical reasons. From an end-user point of view, not using the macro is much preferable to using it with a dummy plugin. We can't automatically inject a dummy plugin either, again, due to technical reasons.

Fixes #1005, see the same issue for the details what those technical reasons are.