### PR TITLE
Rejigger the makefile and dockerfile to do arduino setup when building the Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DEFAULT_GOAL: smoke-sketches
 PLUGIN_TEST_SUPPORT_DIR ?= $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/build-tools/
 PLUGIN_TEST_BIN_DIR ?= $(PLUGIN_TEST_SUPPORT_DIR)/../toolchain/$(shell gcc --print-multiarch)/bin
 
-setup: $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/boards.txt $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/virtual/boards.txt $(ARDUINO_CLI_PATH) configure-arduino-cli install-arduino-core-avr
+setup: $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/boards.txt $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/virtual/boards.txt $(ARDUINO_CLI_PATH) $(ARDUINO_DIRECTORIES_DATA)/arduino-cli.yaml  install-arduino-core-avr
 	@:
 
 
@@ -33,7 +33,7 @@ $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/boards.txt:
 	rm -d $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/libraries/Kaleidoscope
 	ln -s $(KALEIDOSCOPE_DIR) $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/libraries/Kaleidoscope
 
-simulator-tests: setup
+simulator-tests:
 	$(MAKE) -C tests all
 
 docker-simulator-tests:

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -10,8 +10,12 @@ RUN ccache --set-config=cache_dir=/kaleidoscope-persist/ccache/cache
 
 RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | \
   sh
-RUN ARDUINO_DIRECTORIES_DATA=/arduino-cli/data /bin/arduino-cli config init
+
+RUN ARDUINO_DIRECTORIES_DATA=/arduino-cli/data \
+    ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS=https://raw.githubusercontent.com/keyboardio/boardsmanager/master/package_keyboardio_index.json \
+    /bin/arduino-cli config init
 RUN ARDUINO_DIRECTORIES_DATA=/arduino-cli/data /bin/arduino-cli update
+RUN ARDUINO_DIRECTORIES_DATA=/arduino-cli/data /bin/arduino-cli core update-index
 RUN ARDUINO_DIRECTORIES_DATA=/arduino-cli/data /bin/arduino-cli core install arduino:avr
 
 


### PR DESCRIPTION
Rejigger the makefile and dockerfile to do arduino setup when building the Dockerfile, rather than at simulator-test runtime. Should be a bit faster and re-enable sim tests while offline

@gedankenexperimenter does this fix your offline build issue?