### PR TITLE
New hook: onNameQuery()

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -101,6 +101,7 @@ In practice, this boils down to implementing one or more of the following hook p
 - `beforeEachCycle()`: Called once, at the beginning of each cycle of the main loop. This is similar to the old "loop hook" with its `post_clear` argument set to false. Takes no arguments, must return `kaleidoscope::EventHandlerResult::OK`.
 - `onKeyswitchEvent`: Called for every non-idle key event. This replaces the old "event handler hook". It takes a key reference, a key address, and a key state. The key reference can be updated to change the key being processed, so that any plugin that processes it further, will see the updated key. Can return `kaleidoscope::EventHandlerResult::OK` to let other plugins process the event further, or `kaleidoscope::EventHandlerResult::EVENT_CONSUMED` to stop processing.
 - `onFocusEvent`: Used to implement [bi-directional communication](#bidirectional-communication-for-plugins). This is called whenever the firmware receives a command from the host. The only argument is the command name. Can return `kaleidoscope::EventHandlerResult::OK` to let other plugins process the event further, or `kaleidoscope::EventHandlerResult::EVENT_CONSUMED` to stop processing.
+- `onNameQuery`: Used by the [Focus](#bidirecional-communication-for-plugins) plugin, when replying to a `plugins` command. Should either send the plugin name, or not be implemented at all, if the host knowing about the plugin isn't important.
 - `beforeReportingState`: Called without arguments, just before sending the keyboard and mouse reports to the host. Must return `kaleidoscope::EventHandlerResult::OK`.
 - `afterEachCycle`: Called without arguments at the very end of each cycle. This is the replacement for the "loop hook" with its `post_clear` argument set.
 
@@ -159,6 +160,10 @@ namespace kaleidoscope {
 class FocusExampleCommand : public Plugin {
  public:
   FocusExampleCommand() {}
+
+  EventHandlerResult onNameQuery() {
+    return ::Focus.sendName(F("FocusExampleCommand"));
+  }
 
   EventHandlerResult onFocusEvent(const char *command) {
     if (strcmp_P(command, PSTR("example")) != 0)
@@ -326,7 +331,7 @@ As a developer, one can continue using `millis()`, but migrating to `Kaleidoscop
 
 ### Repository rearchitecture
 
-To improve build times and to better highlight Kaleidoscope's many plugins, plugins have been move into directories inside the Kaleidoscope directory. 
+To improve build times and to better highlight Kaleidoscope's many plugins, plugins have been move into directories inside the Kaleidoscope directory.
 
 The "breaking change" part of this is that git checkouts of Kaleidoscope are no longer directly compatible with the Arduino IDE, since plugins aren't in a directory the IDE looks in. They are, of course, visible to tools using our commandline build infrastructure / Makefiles.
 

--- a/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/Colormap.cpp
+++ b/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/Colormap.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Colormap -- Per-layer colormap effect
- * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2016, 2017, 2018, 2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -34,6 +34,10 @@ void ColormapEffect::max_layers(uint8_t max_) {
 
   max_layers_ = max_;
   map_base_ = ::LEDPaletteTheme.reserveThemes(max_layers_);
+}
+
+EventHandlerResult ColormapEffect::onNameQuery() {
+  return ::Focus.sendName(F("ColormapEffect"));
 }
 
 void ColormapEffect::TransientLEDMode::onActivate(void) {

--- a/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/Colormap.h
+++ b/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/Colormap.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Colormap -- Per-layer colormap effect
- * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2016, 2017, 2018, 2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -31,6 +31,7 @@ class ColormapEffect : public Plugin,
   void max_layers(uint8_t max_);
 
   EventHandlerResult onLayerChange();
+  EventHandlerResult onNameQuery();
   EventHandlerResult onFocusEvent(const char *command);
 
   // This class' instance has dynamic lifetime

--- a/plugins/Kaleidoscope-Cycle/src/kaleidoscope/plugin/Cycle.cpp
+++ b/plugins/Kaleidoscope-Cycle/src/kaleidoscope/plugin/Cycle.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Cycle -- Key sequence cycling dead key for Kaleidoscope.
- * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2016, 2017, 2018, 2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,6 +17,7 @@
 
 #include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Cycle.h>
+#include <Kaleidoscope-FocusSerial.h>
 #include "kaleidoscope/keyswitch_state.h"
 #include "kaleidoscope/key_events.h"
 
@@ -51,6 +52,10 @@ void Cycle::replace(uint8_t cycle_size, const Key cycle_steps[]) {
 }
 
 // --- hooks ---
+
+EventHandlerResult Cycle::onNameQuery() {
+  return ::Focus.sendName(F("Cycle"));
+}
 
 EventHandlerResult Cycle::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
   if (key_state & INJECTED)

--- a/plugins/Kaleidoscope-Cycle/src/kaleidoscope/plugin/Cycle.h
+++ b/plugins/Kaleidoscope-Cycle/src/kaleidoscope/plugin/Cycle.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Cycle -- Key sequence cycling dead key for Kaleidoscope.
- * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2016, 2017, 2018, 2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -36,6 +36,7 @@ class Cycle : public kaleidoscope::Plugin {
   static void replace(Key key);
   static void replace(uint8_t cycle_size, const Key cycle_steps[]);
 
+  EventHandlerResult onNameQuery();
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 
  private:

--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -1,5 +1,5 @@
 /* DynamicMacros - Dynamic macro support for Kaleidoscope.
- * Copyright (C) 2019  Keyboard.io, Inc.
+ * Copyright (C) 2019, 2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -206,6 +206,10 @@ EventHandlerResult DynamicMacros::onKeyswitchEvent(Key &mappedKey, KeyAddr key_a
   }
 
   return EventHandlerResult::EVENT_CONSUMED;
+}
+
+EventHandlerResult DynamicMacros::onNameQuery() {
+  return ::Focus.sendName(F("DynamicMacros"));
 }
 
 EventHandlerResult DynamicMacros::onFocusEvent(const char *command) {

--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.h
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.h
@@ -1,5 +1,5 @@
 /* DynamicMacros - Dynamic macro support for Kaleidoscope.
- * Copyright (C) 2019  Keyboard.io, Inc.
+ * Copyright (C) 2019, 2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -32,6 +32,7 @@ class DynamicMacros : public kaleidoscope::Plugin {
   DynamicMacros(void) {}
 
   EventHandlerResult onKeyswitchEvent(Key &mappedKey, KeyAddr key_addr, uint8_t keyState);
+  EventHandlerResult onNameQuery();
   EventHandlerResult onFocusEvent(const char *command);
 
   static void reserve_storage(uint16_t size);

--- a/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
+++ b/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
@@ -1,5 +1,5 @@
 /* DynamicTapDance -- Dynamic TapDance support for Kaleidoscope
- * Copyright (C) 2019  Keyboard.io, Inc
+ * Copyright (C) 2019, 2021  Keyboard.io, Inc
  * Copyright (C) 2019  Dygma Lab S.L.
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -84,6 +84,10 @@ bool DynamicTapDance::dance(uint8_t tap_dance_index, KeyAddr key_addr,
   }
 
   return true;
+}
+
+EventHandlerResult DynamicTapDance::onNameQuery() {
+  return ::Focus.sendName(F("DynamicTapDance"));
 }
 
 EventHandlerResult DynamicTapDance::onFocusEvent(const char *command) {

--- a/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.h
+++ b/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.h
@@ -1,5 +1,5 @@
 /* DynamicTapDance -- Dynamic TapDance support for Kaleidoscope
- * Copyright (C) 2019  Keyboard.io, Inc
+ * Copyright (C) 2019, 2021  Keyboard.io, Inc
  * Copyright (C) 2019  Dygma Lab S.L.
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -27,6 +27,7 @@ class DynamicTapDance: public kaleidoscope::Plugin {
  public:
   DynamicTapDance() {}
 
+  EventHandlerResult onNameQuery();
   EventHandlerResult onFocusEvent(const char *command);
 
   static void setup(uint8_t dynamic_offset, uint16_t size);

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-EEPROM-Keymap -- EEPROM-based keymap support.
- * Copyright (C) 2017, 2018, 2019  Keyboard.io, Inc
+ * Copyright (C) 2017, 2018, 2019, 2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -30,6 +30,10 @@ EventHandlerResult EEPROMKeymap::onSetup() {
   ::EEPROMSettings.onSetup();
   progmem_layers_ = layer_count;
   return EventHandlerResult::OK;
+}
+
+EventHandlerResult EEPROMKeymap::onNameQuery() {
+  return ::Focus.sendName(F("EEPROMKeymap"));
 }
 
 void EEPROMKeymap::setup(uint8_t max) {

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.h
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-EEPROM-Keymap -- EEPROM-based keymap support.
- * Copyright (C) 2017, 2018, 2019  Keyboard.io, Inc
+ * Copyright (C) 2017, 2018, 2019, 2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -32,6 +32,7 @@ class EEPROMKeymap : public kaleidoscope::Plugin {
   EEPROMKeymap(void) {}
 
   EventHandlerResult onSetup();
+  EventHandlerResult onNameQuery();
   EventHandlerResult onFocusEvent(const char *command);
 
   static void setup(uint8_t max);

--- a/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
+++ b/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-FingerPainter -- On-the-fly keyboard painting.
- * Copyright (C) 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2017-2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -28,6 +28,10 @@ namespace plugin {
 
 uint16_t FingerPainter::color_base_;
 bool FingerPainter::edit_mode_;
+
+EventHandlerResult FingerPainter::onNameQuery() {
+  return ::Focus.sendName(F("FingerPainter"));
+}
 
 EventHandlerResult FingerPainter::onSetup() {
   color_base_ = ::LEDPaletteTheme.reserveThemes(1);

--- a/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.h
+++ b/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-FingerPainter -- On-the-fly keyboard painting.
- * Copyright (C) 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2017-2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -35,6 +35,7 @@ class FingerPainter : public LEDMode {
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
   EventHandlerResult onFocusEvent(const char *command);
   EventHandlerResult onSetup();
+  EventHandlerResult onNameQuery();
 
  protected:
   void update(void) final;

--- a/plugins/Kaleidoscope-FocusSerial/README.md
+++ b/plugins/Kaleidoscope-FocusSerial/README.md
@@ -22,6 +22,10 @@ class FocusTestCommand : public Plugin {
  public:
   FocusTestCommand() {}
 
+  EventHandlerResult onNameQuery() {
+    return ::Focus.sendName(F("FocusTestCommand"));
+  }
+
   EventHandlerResult onFocusEvent(const char *command) {
     if (strcmp_P(command, PSTR("test")) != 0)
       return EventHandlerResult::OK;
@@ -51,6 +55,13 @@ The plugin provides the `Focus` object, with a couple of helper methods aimed at
 Sends a list of variables over the wire. The difference between `.send()` and `.sendRaw()` is that the former puts a space between each variable, the latter does not. If one just wants to send a list of things, use the former. If one needs more control over the formatting, use the latter. In most cases, `.send()` is the recommended method to use.
 
 Both of them take a variable number of arguments, of almost any type: all built-in types can be sent, `cRGB`, `Key` and `bool` too in addition. For colors, `.send()` will write them as an `R G B` sequence; `Key` objects will be sent as the raw 16-bit keycode; and `bool` will be sent as either the string `true`, or `false`.
+
+### `.sendName(F("..."))`
+
+To be used with the `onNameQuery()` hook, this sends the plugin name given,
+followed by a newline, and returns `EventHandlerResult::OK`, so that
+`onNameQuery()` hooks can be implemented in a single line with the help of this
+function.
 
 ### `.read(variable)`
 

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-FocusSerial -- Bidirectional communication plugin
- * Copyright (C) 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2017, 2018, 2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -70,7 +70,14 @@ bool FocusSerial::handleHelp(const char *command,
 }
 
 EventHandlerResult FocusSerial::onFocusEvent(const char *command) {
-  handleHelp(command, PSTR("help"));
+  if (handleHelp(command, PSTR("help\nplugins")))
+    return EventHandlerResult::OK;
+
+  if (strcmp_P(command, PSTR("plugins")) == 0) {
+    kaleidoscope::Hooks::onNameQuery();
+    return EventHandlerResult::EVENT_CONSUMED;
+  }
+
   return EventHandlerResult::OK;
 }
 

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-FocusSerial -- Bidirectional communication plugin
- * Copyright (C) 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2017, 2018, 2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -27,6 +27,12 @@ class FocusSerial : public kaleidoscope::Plugin {
 
   bool handleHelp(const char *command,
                   const char *help_message);
+
+  EventHandlerResult sendName(const __FlashStringHelper *name) {
+    Runtime.serialPort().print(name);
+    Runtime.serialPort().print(NEWLINE);
+    return EventHandlerResult::OK;
+  }
 
   void send() {}
   void send(const cRGB color) {

--- a/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Idle-LEDs -- Turn off the LEDs when the keyboard's idle
- * Copyright (C) 2018, 2019, 2020  Keyboard.io, Inc
+ * Copyright (C) 2018, 2019, 2020, 2021  Keyboard.io, Inc
  * Copyright (C) 2019  Dygma, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -62,6 +62,10 @@ EventHandlerResult IdleLEDs::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr,
 }
 
 uint16_t PersistentIdleLEDs::settings_base_;
+
+EventHandlerResult PersistentIdleLEDs::onNameQuery() {
+  return ::Focus.sendName(F("PersistentIdleLEDs"));
+}
 
 EventHandlerResult PersistentIdleLEDs::onSetup() {
   settings_base_ = ::EEPROMSettings.requestSlice(sizeof(uint16_t));

--- a/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.h
+++ b/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Idle-LEDs -- Turn off the LEDs when the keyboard's idle
- * Copyright (C) 2018, 2019  Keyboard.io, Inc
+ * Copyright (C) 2018, 2019, 2021  Keyboard.io, Inc
  * Copyright (C) 2019  Dygma, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -43,6 +43,7 @@ class IdleLEDs: public kaleidoscope::Plugin {
 class PersistentIdleLEDs : public IdleLEDs {
  public:
   EventHandlerResult onSetup();
+  EventHandlerResult onNameQuery();
   EventHandlerResult onFocusEvent(const char *command);
 
   static void setIdleTimeoutSeconds(uint32_t new_limit);

--- a/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
+++ b/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-LayerFocus -- Focus commands to work with layers
- * Copyright (C) 2020  Keyboard.io, Inc
+ * Copyright (C) 2020, 2021  Keyboard.io, Inc
  * Copyright (C) 2020  DygmaLab, SE.
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -23,6 +23,10 @@
 
 namespace kaleidoscope {
 namespace plugin {
+
+EventHandlerResult LayerFocus::onNameQuery() {
+  return ::Focus.sendName(F("LayerFocus"));
+}
 
 EventHandlerResult LayerFocus::onFocusEvent(const char *command) {
   if (::Focus.handleHelp(command, PSTR("layer.activate\nlayer.deactivate\nlayer.isActive"

--- a/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.h
+++ b/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-LayerFocus -- Focus commands to work with layers
- * Copyright (C) 2020  Keyboard.io, Inc
+ * Copyright (C) 2020, 2021  Keyboard.io, Inc
  * Copyright (C) 2020  DygmaLab, SE.
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -27,6 +27,7 @@ class LayerFocus: public kaleidoscope::Plugin {
  public:
   LayerFocus() {}
 
+  EventHandlerResult onNameQuery();
   EventHandlerResult onFocusEvent(const char *command);
 };
 

--- a/plugins/Kaleidoscope-Leader/src/kaleidoscope/plugin/Leader.cpp
+++ b/plugins/Kaleidoscope-Leader/src/kaleidoscope/plugin/Leader.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Leader -- VIM-style leader keys
- * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2016, 2017, 2018, 2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope-Leader.h>
+#include <Kaleidoscope-FocusSerial.h>
 #include "kaleidoscope/keyswitch_state.h"
 #include "kaleidoscope/keyswitch_state.h"
 #include "kaleidoscope/key_events.h"
@@ -85,6 +86,10 @@ void Leader::inject(Key key, uint8_t key_state) {
 }
 
 // --- hooks ---
+EventHandlerResult Leader::onNameQuery() {
+  return ::Focus.sendName(F("Leader"));
+}
+
 EventHandlerResult Leader::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
   if (keyState & INJECTED)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-Leader/src/kaleidoscope/plugin/Leader.h
+++ b/plugins/Kaleidoscope-Leader/src/kaleidoscope/plugin/Leader.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Leader -- VIM-style leader keys
- * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2016, 2017, 2018, 2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -46,6 +46,7 @@ class Leader : public kaleidoscope::Plugin {
 
   void inject(Key key, uint8_t key_state);
 
+  EventHandlerResult onNameQuery();
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);
   EventHandlerResult afterEachCycle();
 

--- a/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros.cpp
+++ b/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros.cpp
@@ -1,5 +1,5 @@
 /* Kaleidoscope-Macros - Macro keys for Kaleidoscope.
- * Copyright (C) 2017-2019  Keyboard.io, Inc.
+ * Copyright (C) 2017-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -15,6 +15,7 @@
  */
 
 #include "Kaleidoscope-Macros.h"
+#include "Kaleidoscope-FocusSerial.h"
 #include "kaleidoscope/keyswitch_state.h"
 #include "kaleidoscope/key_events.h"
 
@@ -247,6 +248,10 @@ bool Macros_::isMacroKey(Key key) {
   if (key >= ranges::MACRO_FIRST && key <= ranges::MACRO_LAST)
     return true;
   return false;
+}
+
+EventHandlerResult Macros_::onNameQuery() {
+  return ::Focus.sendName(F("Macros"));
 }
 
 EventHandlerResult Macros_::onKeyswitchEvent(Key &mappedKey, KeyAddr key_addr, uint8_t keyState) {

--- a/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros.h
+++ b/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros.h
@@ -1,5 +1,5 @@
 /* Kaleidoscope-Macros - Macro keys for Kaleidoscope.
- * Copyright (C) 2017-2018  Keyboard.io, Inc.
+ * Copyright (C) 2017-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -55,6 +55,7 @@ class Macros_ : public kaleidoscope::Plugin {
     ++active_macro_count;
   }
 
+  EventHandlerResult onNameQuery();
   EventHandlerResult onKeyswitchEvent(Key &mappedKey, KeyAddr key_addr, uint8_t keyState);
   EventHandlerResult beforeReportingState();
   EventHandlerResult afterEachCycle();

--- a/plugins/Kaleidoscope-MagicCombo/src/kaleidoscope/plugin/MagicCombo.cpp
+++ b/plugins/Kaleidoscope-MagicCombo/src/kaleidoscope/plugin/MagicCombo.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-MagicCombo -- Magic combo framework
- * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2016-2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -16,12 +16,17 @@
  */
 
 #include <Kaleidoscope-MagicCombo.h>
+#include <Kaleidoscope-FocusSerial.h>
 
 namespace kaleidoscope {
 namespace plugin {
 
 uint16_t MagicCombo::min_interval = 500;
 uint16_t MagicCombo::start_time_ = 0;
+
+EventHandlerResult MagicCombo::onNameQuery() {
+  return ::Focus.sendName(F("MagicCombo"));
+}
 
 EventHandlerResult MagicCombo::beforeReportingState() {
   for (byte i = 0; i < magiccombo::combos_length; i++) {

--- a/plugins/Kaleidoscope-MagicCombo/src/kaleidoscope/plugin/MagicCombo.h
+++ b/plugins/Kaleidoscope-MagicCombo/src/kaleidoscope/plugin/MagicCombo.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-MagicCombo -- Magic combo framework
- * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2016-2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -48,6 +48,7 @@ class MagicCombo : public kaleidoscope::Plugin {
 
   static uint16_t min_interval;
 
+  EventHandlerResult onNameQuery();
   EventHandlerResult beforeReportingState();
 
  private:

--- a/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.cpp
+++ b/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.cpp
@@ -1,5 +1,5 @@
 /* Kaleidoscope-MouseKeys - Mouse keys for Kaleidoscope.
- * Copyright (C) 2017-2018  Keyboard.io, Inc.
+ * Copyright (C) 2017-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -18,6 +18,7 @@
 
 #include "kaleidoscope/Runtime.h"
 #include "Kaleidoscope-MouseKeys.h"
+#include "Kaleidoscope-FocusSerial.h"
 #include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
@@ -60,6 +61,10 @@ void MouseKeys_::scrollWheel(uint8_t keyCode) {
     kaleidoscope::Runtime.hid().mouse().move(0, 0, 0, -wheelSpeed);
   else if (keyCode & KEY_MOUSE_RIGHT)
     kaleidoscope::Runtime.hid().mouse().move(0, 0, 0, wheelSpeed);
+}
+
+EventHandlerResult MouseKeys_::onNameQuery() {
+  return ::Focus.sendName(F("MouseKeys"));
 }
 
 EventHandlerResult MouseKeys_::afterEachCycle() {

--- a/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.h
+++ b/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.h
@@ -1,5 +1,5 @@
 /* Kaleidoscope-MouseKeys - Mouse keys for Kaleidoscope.
- * Copyright (C) 2017-2018  Keyboard.io, Inc.
+ * Copyright (C) 2017-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -38,6 +38,7 @@ class MouseKeys_ : public kaleidoscope::Plugin {
   static void setSpeedLimit(uint8_t speed_limit);
 
   EventHandlerResult onSetup();
+  EventHandlerResult onNameQuery();
   EventHandlerResult beforeReportingState();
   EventHandlerResult afterEachCycle();
   EventHandlerResult onKeyswitchEvent(Key &mappedKey, KeyAddr key_addr, uint8_t keyState);

--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.cpp
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-OneShot -- One-shot modifiers and layers
- * Copyright (C) 2016-2019  Keyboard.io, Inc.
+ * Copyright (C) 2016-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope-OneShot.h>
+#include <Kaleidoscope-FocusSerial.h>
 #include "kaleidoscope/keyswitch_state.h"
 #include "kaleidoscope/key_events.h"
 
@@ -75,6 +76,10 @@ void OneShot::activateOneShot(uint8_t idx) {
 void OneShot::cancelOneShot(uint8_t idx) {
   state_[idx].active = false;
   injectNormalKey(idx, WAS_PRESSED);
+}
+
+EventHandlerResult OneShot::onNameQuery() {
+  return ::Focus.sendName(F("OneShot"));
 }
 
 EventHandlerResult OneShot::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {

--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.h
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-OneShot -- One-shot modifiers and layers
- * Copyright (C) 2016-2019  Keyboard.io, Inc.
+ * Copyright (C) 2016-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -72,6 +72,7 @@ class OneShot : public kaleidoscope::Plugin {
 
   static bool isModifierActive(Key key);
 
+  EventHandlerResult onNameQuery();
   EventHandlerResult beforeReportingState();
   EventHandlerResult afterEachCycle();
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);

--- a/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.cpp
+++ b/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.cpp
@@ -20,12 +20,17 @@
 
 #include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-Ranges.h>
+#include <Kaleidoscope-FocusSerial.h>
 #include "kaleidoscope/progmem_helpers.h"
 #include "kaleidoscope/layers.h"
 
 
 namespace kaleidoscope {
 namespace plugin {
+
+EventHandlerResult Qukeys::onNameQuery() {
+  return ::Focus.sendName(F("Qukeys"));
+}
 
 // This is the event handler. It ignores certain events, but mostly just adds
 // them to the Qukeys event queue.

--- a/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.h
+++ b/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.h
@@ -127,6 +127,7 @@ class Qukeys : public kaleidoscope::Plugin {
   static constexpr int8_t layer_wildcard{-1};
 
   // Kaleidoscope hook functions.
+  EventHandlerResult onNameQuery();
   EventHandlerResult onKeyswitchEvent(Key &mapped_key,
                                       KeyAddr key_addr,
                                       uint8_t key_state);

--- a/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.cpp
+++ b/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Redial -- Redial support for Kaleidoscope
- * Copyright (C) 2018, 2019  Keyboard.io, Inc.
+ * Copyright (C) 2018-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope-Redial.h>
+#include <Kaleidoscope-FocusSerial.h>
 #include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
@@ -24,6 +25,10 @@ namespace plugin {
 Key Redial::key_to_redial_;
 Key Redial::last_key_;
 bool Redial::redial_held_ = false;
+
+EventHandlerResult Redial::onNameQuery() {
+  return ::Focus.sendName(F("Redial"));
+}
 
 EventHandlerResult Redial::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {
   if (mapped_key == Key_Redial) {

--- a/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.h
+++ b/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Redial -- Redial support for Kaleidoscope
- * Copyright (C) 2018, 2019  Keyboard.io, Inc.
+ * Copyright (C) 2018-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -31,6 +31,7 @@ class Redial : public kaleidoscope::Plugin {
 
   static bool shouldRemember(Key mappedKey);
 
+  EventHandlerResult onNameQuery();
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 
  private:

--- a/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadet.cpp
+++ b/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadet.cpp
@@ -1,6 +1,7 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-SpaceCadet -- Space Cadet Shift Extended
  * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc, Ben Gemperline
+ * Copyright (C) 2019-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -16,6 +17,7 @@
  */
 
 #include <Kaleidoscope-SpaceCadet.h>
+#include <Kaleidoscope-FocusSerial.h>
 #include "kaleidoscope/keyswitch_state.h"
 #include "kaleidoscope/key_events.h"
 
@@ -69,6 +71,10 @@ void SpaceCadet::disable() {
 //Function to determine whether SpaceCadet is active (useful for Macros and other plugins)
 bool SpaceCadet::active() {
   return !disabled;
+}
+
+EventHandlerResult SpaceCadet::onNameQuery() {
+  return ::Focus.sendName(F("SpaceCadet"));
 }
 
 EventHandlerResult SpaceCadet::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state) {

--- a/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadet.h
+++ b/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadet.h
@@ -1,7 +1,7 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-SpaceCadet -- Space Cadet Shift Extended
  * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc, Ben Gemperline
- * Copyright (C) 2019  Keyboard.io, Inc
+ * Copyright (C) 2019-2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -66,6 +66,7 @@ class SpaceCadet : public kaleidoscope::Plugin {
   static uint16_t time_out;  //  The global timeout in milliseconds
   static SpaceCadet::KeyBinding * map;  // The map of key bindings
 
+  EventHandlerResult onNameQuery();
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
 
  private:

--- a/plugins/Kaleidoscope-Steno/src/kaleidoscope/plugin/GeminiPR.cpp
+++ b/plugins/Kaleidoscope-Steno/src/kaleidoscope/plugin/GeminiPR.cpp
@@ -1,6 +1,6 @@
 /* Kaleidoscope-Steno -- Steno protocols for Kaleidoscope
  * Copyright (C) 2017  Joseph Wasson
- * Copyright (C) 2017, 2018  Keyboard.io, Inc.
+ * Copyright (C) 2017-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope-Steno.h>
+#include <Kaleidoscope-FocusSerial.h>
 #include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
@@ -24,6 +25,10 @@ namespace steno {
 
 uint8_t GeminiPR::keys_held_;
 uint8_t GeminiPR::state_[6];
+
+EventHandlerResult GeminiPR::onNameQuery() {
+  return ::Focus.sendName(F("GeminiPR"));
+}
 
 EventHandlerResult GeminiPR::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
   if (mapped_key < geminipr::START ||

--- a/plugins/Kaleidoscope-Steno/src/kaleidoscope/plugin/GeminiPR.h
+++ b/plugins/Kaleidoscope-Steno/src/kaleidoscope/plugin/GeminiPR.h
@@ -1,6 +1,6 @@
 /* Kaleidoscope-Steno -- Steno protocols for Kaleidoscope
  * Copyright (C) 2017  Joseph Wasson
- * Copyright (C) 2017, 2018  Keyboard.io, Inc.
+ * Copyright (C) 2017-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -29,6 +29,7 @@ class GeminiPR : public kaleidoscope::Plugin {
  public:
   GeminiPR(void) {}
 
+  EventHandlerResult onNameQuery();
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);
  private:
   static uint8_t keys_held_;

--- a/plugins/Kaleidoscope-Syster/src/kaleidoscope/plugin/Syster.cpp
+++ b/plugins/Kaleidoscope-Syster/src/kaleidoscope/plugin/Syster.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Syster -- Symbolic input system
- * Copyright (C) 2017, 2018, 2019  Keyboard.io, Inc
+ * Copyright (C) 2017-2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope-Syster.h>
+#include <Kaleidoscope-FocusSerial.h>
 #include "kaleidoscope/keyswitch_state.h"
 #include "kaleidoscope/key_events.h"
 
@@ -44,6 +45,10 @@ bool Syster::is_active(void) {
 }
 
 // --- hooks ---
+EventHandlerResult Syster::onNameQuery() {
+  return ::Focus.sendName(F("Syster"));
+}
+
 EventHandlerResult Syster::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
   if (!is_active_) {
     if (!isSyster(mapped_key))

--- a/plugins/Kaleidoscope-Syster/src/kaleidoscope/plugin/Syster.h
+++ b/plugins/Kaleidoscope-Syster/src/kaleidoscope/plugin/Syster.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Syster -- Symbolic input system
- * Copyright (C) 2017, 2018, 2019  Keyboard.io, Inc
+ * Copyright (C) 2017-2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -41,6 +41,7 @@ class Syster : public kaleidoscope::Plugin {
 
   bool is_active(void);
 
+  EventHandlerResult onNameQuery();
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);
 
  private:

--- a/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.cpp
+++ b/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-TapDance -- Tap-dance keys
- * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2016-2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope-TapDance.h>
+#include <Kaleidoscope-FocusSerial.h>
 #include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
@@ -104,6 +105,10 @@ void TapDance::actionKeys(uint8_t tap_count, ActionType tap_dance_action, uint8_
 }
 
 // --- hooks ---
+
+EventHandlerResult TapDance::onNameQuery() {
+  return ::Focus.sendName(F("TapDance"));
+}
 
 EventHandlerResult TapDance::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState) {
   if (keyState & INJECTED)

--- a/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.h
+++ b/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-TapDance -- Tap-dance keys
- * Copyright (C) 2016, 2017, 2018, 2019  Keyboard.io, Inc
+ * Copyright (C) 2016-2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -46,6 +46,7 @@ class TapDance : public kaleidoscope::Plugin {
 
   void actionKeys(uint8_t tap_count, ActionType tap_dance_action, uint8_t max_keys, const Key tap_keys[]);
 
+  EventHandlerResult onNameQuery();
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t keyState);
   EventHandlerResult afterEachCycle();
 

--- a/plugins/Kaleidoscope-Turbo/src/kaleidoscope/plugin/Turbo.cpp
+++ b/plugins/Kaleidoscope-Turbo/src/kaleidoscope/plugin/Turbo.cpp
@@ -17,6 +17,7 @@
 
 #include <Kaleidoscope-Turbo.h>
 #include <Kaleidoscope-LEDControl.h>
+#include <Kaleidoscope-FocusSerial.h>
 #include "kaleidoscope/layers.h"
 #include "kaleidoscope/keyswitch_state.h"
 
@@ -83,6 +84,10 @@ void Turbo::findKeyPositions() {
 EventHandlerResult Turbo::onSetup() {
   Turbo::findKeyPositions();
   return EventHandlerResult::OK;
+}
+
+EventHandlerResult Turbo::onNameQuery() {
+  return ::Focus.sendName(F("Turbo"));
 }
 
 EventHandlerResult Turbo::onLayerChange() {

--- a/plugins/Kaleidoscope-Turbo/src/kaleidoscope/plugin/Turbo.h
+++ b/plugins/Kaleidoscope-Turbo/src/kaleidoscope/plugin/Turbo.h
@@ -45,6 +45,7 @@ class Turbo : public kaleidoscope::Plugin {
   void activeColor(cRGB newVal);
 
   EventHandlerResult onSetup();
+  EventHandlerResult onNameQuery();
   EventHandlerResult onLayerChange();
   EventHandlerResult onKeyswitchEvent(Key &key, KeyAddr key_addr, uint8_t key_state);
   EventHandlerResult afterEachCycle();

--- a/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
+++ b/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-TypingBreaks -- Enforced typing breaks
- * Copyright (C) 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2017-2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -100,6 +100,10 @@ EventHandlerResult TypingBreaks::onKeyswitchEvent(Key &mapped_key, KeyAddr key_a
   }
 
   return EventHandlerResult::OK;
+}
+
+EventHandlerResult TypingBreaks::onNameQuery() {
+  return ::Focus.sendName(F("TypingBreaks"));
 }
 
 EventHandlerResult TypingBreaks::onSetup() {

--- a/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.h
+++ b/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-TypingBreaks -- Enforced typing breaks
- * Copyright (C) 2017, 2018, 2019  Keyboard.io, Inc
+ * Copyright (C) 2017-2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -36,6 +36,7 @@ class TypingBreaks : public kaleidoscope::Plugin {
 
   static settings_t settings;
 
+  EventHandlerResult onNameQuery();
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr, uint8_t key_state);
   EventHandlerResult onFocusEvent(const char *command);
   EventHandlerResult onSetup();

--- a/src/kaleidoscope/event_handlers.h
+++ b/src/kaleidoscope/event_handlers.h
@@ -1,5 +1,5 @@
 /* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2018  Keyboard.io, Inc.
+ * Copyright (C) 2013-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -112,6 +112,16 @@ class SignatureCheckDummy {};
 } // namespace kaleidoscope
 
 #define _FOR_EACH_EVENT_HANDLER(OPERATION, ...)                           __NL__ \
+                                                                          __NL__ \
+   /* Called by Focus, when handling the `plugins` command. */            __NL__ \
+   /* Should send the plugin name if that makes sense, */                 __NL__ \
+   /* but can be no-op. */                                                __NL__ \
+   OPERATION(onNameQuery,                                                 __NL__ \
+             1,                                                           __NL__ \
+             _CURRENT_IMPLEMENTATION,                                     __NL__ \
+             _NOT_ABORTABLE,                                              __NL__ \
+             (), (), (),                                                  __NL__ \
+             (), (), ##__VA_ARGS__)                                       __NL__ \
                                                                           __NL__ \
    OPERATION(onSetup,                                                     __NL__ \
              1,                                                           __NL__ \
@@ -232,6 +242,10 @@ class SignatureCheckDummy {};
    START(onSetup, 1)                                                    __NL__ \
       OP(onSetup, 1)                                                    __NL__ \
    END(onSetup, 1)                                                      __NL__ \
+                                                                        __NL__ \
+   START(onNameQuery, 1)                                                __NL__ \
+      OP(onNameQuery, 1)                                                __NL__ \
+   END(onNameQuery, 1)                                                  __NL__ \
                                                                         __NL__ \
    START(beforeEachCycle, 1)                                            __NL__ \
       OP(beforeEachCycle, 1)                                            __NL__ \

--- a/src/kaleidoscope/hooks.h
+++ b/src/kaleidoscope/hooks.h
@@ -1,5 +1,5 @@
 /* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2018  Keyboard.io, Inc.
+ * Copyright (C) 2013-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -35,6 +35,7 @@ namespace kaleidoscope {
 namespace plugin {
 // Forward declaration to enable friend declarations.
 class LEDControl;
+class FocusSerial;
 }
 
 // Forward declaration to enable friend declarations.
@@ -61,6 +62,7 @@ class Hooks {
   // Runtime_ calls Hooks::onSetup, Hooks::beforeReportingState
   // and Hooks::afterEachCycle.
   friend class Runtime_;
+  friend class ::kaleidoscope::plugin::FocusSerial;
   friend class ::kaleidoscope::Layer_;
   friend class ::kaleidoscope::plugin::LEDControl;
   friend void ::kaleidoscope::sketch_exploration::pluginsExploreSketch();


### PR DESCRIPTION
This implements a new `FocusSerial` command: `plugins`. The `plugins` command will reply back with a list of plugins enabled in the firmware. The list is not exhaustive, only plugins that opt-in to this mechanism will be listed. It is opt-in, because for a lot of plugins, having them listed isn't useful in a practical sense.

The goal with this feature is to allow Chrysalis to detect plugins that would affect what keys it offers, or which additional settings it displays, and do so in a consistent way. This is why IdleLEDs has an `onNameQuery` handler too, even though it can be detected otherwise: for consistency.
