### PR TITLE
Remove (mostly) useless `MouseWrapper.diagonalize()` function

### DIFF
--- a/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys/MouseWrapper.cpp
+++ b/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys/MouseWrapper.cpp
@@ -110,30 +110,12 @@ uint8_t MouseWrapper_::acceleration(uint8_t cycles) {
   }
 }
 
-// Get the diagonalized version of a value, i.e. value * sqrt(2) / 2. If the
-// value ends up being zero, return the original value instead.
-static int16_t diagonalize(int16_t value) {
-  // 99 / 140 closely approximates sqrt(2) / 2. Since integer division
-  // truncates towards zero we do not need to worry about truncation errors.
-  int16_t diagonalValue = value * 99 / 140;
-  return (diagonalValue == 0 ? value : diagonalValue);
-}
-
 void MouseWrapper_::move(int8_t x, int8_t y) {
   int16_t moveX = 0;
   int16_t moveY = 0;
   static int8_t remainderX = 0;
   static int8_t remainderY = 0;
   int16_t effectiveSpeedLimit = speedLimit;
-
-  if (x != 0 && y != 0) {
-    // For diagonal movements, we apply a diagonalized speed limit. The
-    // effective speed limit is set based on whether we are moving diagonally.
-    effectiveSpeedLimit = diagonalize(effectiveSpeedLimit);
-
-    x = diagonalize(x);
-    y = diagonalize(y);
-  }
 
   if (x != 0) {
     moveX = remainderX + (x * acceleration(accelStep));

--- a/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys/MouseWrapper.cpp
+++ b/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys/MouseWrapper.cpp
@@ -131,7 +131,7 @@ void MouseWrapper_::move(int8_t x, int8_t y) {
 
   end_warping();
   // move by whole pixels, not subpixels
-  Kaleidoscope.hid().mouse().move(moveX / subpixelsPerPixel, moveY / subpixelsPerPixel, 0);
+  Kaleidoscope.hid().mouse().move(moveX / subpixelsPerPixel, moveY / subpixelsPerPixel);
   // save leftover subpixel movements for later
   remainderX = moveX - moveX / subpixelsPerPixel * subpixelsPerPixel;
   remainderY = moveY - moveY / subpixelsPerPixel * subpixelsPerPixel;


### PR DESCRIPTION
Because the mouse speed values are so low, `diagonalize()` was never actually used (integer division caused the result to be zero, which triggered a fallback to the original input value (`1`), which meant that the curbing speed on diagonal motion never actually happened. Since it's not clear that slowing down diagonal motion is better, and it saves 108 bytes of PROGMEM to remove the function, let's just do without it.

Closes #633

