### PR TITLE
Fix timeout checker

### DIFF
--- a/src/kaleidoscope/Runtime.h
+++ b/src/kaleidoscope/Runtime.h
@@ -124,7 +124,7 @@ class Runtime_ {
   static bool hasTimeExpired(_Timestamp start_time, _Timeout ttl) {
     _Timestamp current_time = millis_at_cycle_start_;
     _Timestamp elapsed_time = current_time - start_time;
-    return (elapsed_time > ttl);
+    return (elapsed_time >= ttl);
   }
 
   EventHandlerResult onFocusEvent(const char *command) {

--- a/tests/issues/806/test.ktest
+++ b/tests/issues/806/test.ktest
@@ -11,9 +11,8 @@ RUN 5 ms
 
 PRESS TD_0
 RUN 1 cycle
-RUN 25 ms # timeout is 25 ms
 
-RUN 1 cycle
+RUN 25 ms # timeout is 25 ms
 EXPECT keyboard-report Key_A # The report should contain only `A`
 
 RUN 20 ms

--- a/tests/issues/922/test.ktest
+++ b/tests/issues/922/test.ktest
@@ -16,12 +16,12 @@ RUN 4 ms
 RELEASE TD_0
 RUN 5 ms
 RELEASE TD_1
-RUN 16 ms  # timeout = 25ms
+RUN 15 ms  # timeout = 25ms
 RUN 1 cycle
 EXPECT keyboard-report Key_A, Key_B # TD_1 should time out, yielding `B`
 EXPECT keyboard-report Key_B # TD_0 should be released
 EXPECT keyboard-report empty # Empty report after TD_1 timeout
-RUN 13 ms  # t = 50ms
+RUN 14 ms  # t = 50ms
 
 RUN 5 ms
 PRESS TD_0
@@ -33,12 +33,12 @@ RUN 4 ms
 RELEASE TD_0
 RUN 5 ms
 RELEASE TD_1
-RUN 16 ms  # timeout = 25ms
+RUN 15 ms  # timeout = 25ms
 RUN 1 cycle
 EXPECT keyboard-report Key_A, Key_B # TD_1 should time out, yielding `B`
 EXPECT keyboard-report Key_B # TD_0 should be released
 EXPECT keyboard-report empty # Empty report after TD_1 timeout
-RUN 13 ms  # t = 100ms
+RUN 14 ms  # t = 100ms
 
 # ==============================================================================
 NAME TapDance to TapDance rollover right to left
@@ -53,12 +53,12 @@ RUN 4 ms
 RELEASE TD_1
 RUN 5 ms
 RELEASE TD_0
-RUN 16 ms  # timeout = 25ms
+RUN 15 ms  # timeout = 25ms
 RUN 1 cycle
 EXPECT keyboard-report Key_B, Key_A # TD_0 should time out, yielding `A`
 EXPECT keyboard-report Key_A # TD_1 should be released
 EXPECT keyboard-report empty # Empty report after TD_1 timeout
-RUN 13 ms  # t = 150ms
+RUN 14 ms  # t = 150ms
 
 RUN 5 ms
 PRESS TD_1
@@ -70,12 +70,12 @@ RUN 4 ms
 RELEASE TD_1
 RUN 5 ms
 RELEASE TD_0
-RUN 16 ms  # timeout = 25ms
+RUN 15 ms  # timeout = 25ms
 RUN 1 cycle
 EXPECT keyboard-report Key_B, Key_A # TD_0 should time out, yielding `A`
 EXPECT keyboard-report Key_A # TD_1 should be released
 EXPECT keyboard-report empty # Empty report after TD_1 timeout
-RUN 13 ms  # t = 200ms
+RUN 14 ms  # t = 200ms
 
 # ==============================================================================
 NAME TapDance to TapDance rollover back and forth
@@ -90,12 +90,12 @@ RUN 4 ms
 RELEASE TD_0
 RUN 5 ms
 RELEASE TD_1
-RUN 16 ms  # timeout = 25ms
+RUN 15 ms  # timeout = 25ms
 RUN 1 cycle
 EXPECT keyboard-report Key_A, Key_B # TD_1 should time out, yielding `B`
 EXPECT keyboard-report Key_B # TD_0 should be released
 EXPECT keyboard-report empty # Empty report after TD_1 timeout
-RUN 13 ms  # t = 250ms
+RUN 14 ms  # t = 250ms
 
 RUN 5 ms
 PRESS TD_1
@@ -107,9 +107,9 @@ RUN 4 ms
 RELEASE TD_1
 RUN 5 ms
 RELEASE TD_0
-RUN 16 ms  # timeout = 25ms
+RUN 15 ms  # timeout = 25ms
 RUN 1 cycle
 EXPECT keyboard-report Key_B, Key_A # TD_0 should time out, yielding `A`
 EXPECT keyboard-report Key_A # TD_1 should be released
 EXPECT keyboard-report empty # Empty report after TD_1 timeout
-RUN 13 ms  # t = 300ms
+RUN 14 ms  # t = 300ms

--- a/tests/issues/970/test.ktest
+++ b/tests/issues/970/test.ktest
@@ -18,7 +18,6 @@ RUN 65536 ms
 PRESS A
 RUN 1 cycle
 RUN 200 ms  # hold timeout is 200 ms
-RUN 1 ms
 EXPECT keyboard-report Key_LeftGui # Report should contain only `LeftGui`
 
 RUN 10 ms

--- a/tests/plugins/MagicCombo/basic/test.ktest
+++ b/tests/plugins/MagicCombo/basic/test.ktest
@@ -14,8 +14,7 @@ RUN 5 ms
 PRESS MC0
 RUN 10 ms
 # With MagicCombo.min_interval set to 20(ms), we need to wait that long before
-# it will trigger, plus one.
-RUN 1 ms
+# it will trigger.
 EXPECT keyboard-report Key_A # The report should contain only `A`
 EXPECT keyboard-report empty # Report should be empty
 RUN 5 ms

--- a/tests/plugins/OneShot/basic/test.ktest
+++ b/tests/plugins/OneShot/basic/test.ktest
@@ -15,7 +15,6 @@ EXPECT keyboard-report Key_LeftShift # The report should contain `shift`
 RUN 5 ms
 RELEASE OS_shift
 RUN 45 ms
-RUN 1 cycle
 EXPECT keyboard-report empty # Report should be empty
 
 # ==============================================================================

--- a/tests/plugins/Qukeys/TapRepeat/test.ktest
+++ b/tests/plugins/Qukeys/TapRepeat/test.ktest
@@ -26,7 +26,7 @@ RUN 1 cycle
 EXPECT keyboard-report empty # Report should be empty
 EXPECT keyboard-report Key_A # Report should contain only A
 
-RUN 16 ms
+RUN 15 ms
 EXPECT keyboard-report empty # Report should be empty
 
 RUN 100 ms
@@ -68,7 +68,7 @@ RUN 1 cycle
 EXPECT keyboard-report empty # Report should be empty
 EXPECT keyboard-report Key_J # Report should contain only J
 
-RUN 16 ms
+RUN 15 ms
 EXPECT keyboard-report empty # Report should be empty
 
 RUN 100 ms
@@ -110,7 +110,7 @@ RUN 1 cycle
 EXPECT keyboard-report empty # Report should be empty
 EXPECT keyboard-report Key_B # Report should contain only B
 
-RUN 16 ms
+RUN 15 ms
 EXPECT keyboard-report empty # Report should be empty
 
 RUN 100 ms

--- a/tests/plugins/SpaceCadet/basic/test.ktest
+++ b/tests/plugins/SpaceCadet/basic/test.ktest
@@ -27,7 +27,6 @@ PRESS LSHIFT
 RUN 1 cycle
 
 RUN 10 ms
-RUN 1 cycle
 EXPECT keyboard-report Key_LeftShift # Report should contain `shift` (0xE1)
 
 RUN 5 ms
@@ -44,7 +43,6 @@ PRESS RSHIFT
 RUN 1 cycle
 
 RUN 20 ms
-RUN 1 cycle
 EXPECT keyboard-report Key_RightShift # Report should contain `shift` (0xE5)
 
 RUN 5 ms
@@ -111,7 +109,6 @@ RUN 1 cycle
 EXPECT keyboard-report Key_LeftShift # Report should contain `shift` (0xE1)
 
 RUN 20 ms
-RUN 1 cycle
 EXPECT keyboard-report Key_LeftShift Key_RightShift # Report should contain both `shift` keycodes (0xE1, 0xE5)
 
 RUN 5 ms

--- a/tests/plugins/TapDance/basic/test.ktest
+++ b/tests/plugins/TapDance/basic/test.ktest
@@ -46,8 +46,6 @@ RUN 5 ms
 RELEASE TD_0
 
 RUN 20 ms # Timeout = 25ms
-
-RUN 1 cycle
 EXPECT keyboard-report Key_B # The report should contain `B`
 EXPECT keyboard-report empty # Report should be empty
 
@@ -91,8 +89,6 @@ RUN 10 ms
 PRESS TD_0
 RUN 1 cycle
 RUN 25 ms
-
-RUN 1 cycle
 EXPECT keyboard-report Key_B # The report should contain `B`
 
 RUN 10 ms

--- a/tests/plugins/Turbo/basic/test.ktest
+++ b/tests/plugins/Turbo/basic/test.ktest
@@ -35,28 +35,22 @@ EXPECT keyboard-report Key_A # report should contain `A` (0x04)
 RUN 4 ms
 PRESS TURBO
 RUN 1 cycle
-
-RUN 1 ms
 EXPECT keyboard-report empty # report should be empty
 EXPECT keyboard-report Key_A # report should contain `A` (0x04)
 
 RUN 10 ms
-RUN 1 ms
 EXPECT keyboard-report empty # report should be empty
 EXPECT keyboard-report Key_A # report should contain `A` (0x04)
 
 RUN 10 ms
-RUN 1 ms
 EXPECT keyboard-report empty # report should be empty
 EXPECT keyboard-report Key_A # report should contain `A` (0x04)
 
 RUN 10 ms
-RUN 1 ms
 EXPECT keyboard-report empty # report should be empty
 EXPECT keyboard-report Key_A # report should contain `A` (0x04)
 
 RUN 10 ms
-RUN 1 ms
 EXPECT keyboard-report empty # report should be empty
 EXPECT keyboard-report Key_A # report should contain `A` (0x04)
 
@@ -88,13 +82,11 @@ PRESS A
 RUN 1 cycle
 EXPECT keyboard-report Key_A # report should contain `A` (0x04)
 
-RUN 7 ms
-RUN 1 ms
+RUN 5 ms
 EXPECT keyboard-report empty # report should be empty
 EXPECT keyboard-report Key_A # report should contain `A` (0x04)
 
 RUN 10 ms
-RUN 1 ms
 EXPECT keyboard-report empty # report should be empty
 EXPECT keyboard-report Key_A # report should contain `A` (0x04)
 


### PR DESCRIPTION
`Runtime.hasTimeExpired()` had a minor flaw. Because it was comparing two values using `>` instead of `>=`, it meant that a timeout set at 20ms wouldn't actually time out until 21ms elapsed.

I will add updates to all the affected testcases later; I'd like to wait until #1024 is settled first, so I'm leaving this in draft status for now.