### PR TITLE
Fix Syster translation of `Key_0` to ASCII

### DIFF
--- a/plugins/Kaleidoscope-Syster/src/kaleidoscope/plugin/Syster.cpp
+++ b/plugins/Kaleidoscope-Syster/src/kaleidoscope/plugin/Syster.cpp
@@ -169,8 +169,10 @@ __attribute__((weak)) const char keyToChar(Key key) {
   switch (key.getKeyCode()) {
   case Key_A.getKeyCode() ... Key_Z.getKeyCode():
     return 'a' + (key.getKeyCode() - Key_A.getKeyCode());
-  case Key_1.getKeyCode() ... Key_0.getKeyCode():
+  case Key_1.getKeyCode() ... Key_9.getKeyCode():
     return '1' + (key.getKeyCode() - Key_1.getKeyCode());
+  case Key_0.getKeyCode():
+    return '0';
   }
 
   return 0;

--- a/tests/issues/1032/1032.ino
+++ b/tests/issues/1032/1032.ino
@@ -1,0 +1,69 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2021  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+
+#include <Kaleidoscope-Syster.h>
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        SYSTER, ___, ___, ___, ___, ___, ___,
+        Key_A, Key_B, Key_C, ___, ___, ___, ___,
+        Key_0, Key_1, ___, ___, ___, ___,
+        Key_Spacebar, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+void systerAction(kaleidoscope::plugin::Syster::action_t action, const char *symbol) {
+  switch (action) {
+  case kaleidoscope::plugin::Syster::StartAction:
+    break;
+  case kaleidoscope::plugin::Syster::EndAction:
+    break;
+  case kaleidoscope::plugin::Syster::SymbolAction:
+    if (strcmp(symbol, "abc") == 0) {
+      Kaleidoscope.handleKeyEvent(KeyEvent(KeyAddr::none(), INJECTED | IS_PRESSED, Key_X));
+      Kaleidoscope.handleKeyEvent(KeyEvent(KeyAddr::none(), INJECTED | WAS_PRESSED, Key_X));
+    }
+    if (strcmp(symbol, "a0") == 0) {
+      Kaleidoscope.handleKeyEvent(KeyEvent(KeyAddr::none(), INJECTED | IS_PRESSED, Key_Y));
+      Kaleidoscope.handleKeyEvent(KeyEvent(KeyAddr::none(), INJECTED | WAS_PRESSED, Key_Y));
+    }
+    break;
+  }
+}
+
+KALEIDOSCOPE_INIT_PLUGINS(Syster);
+
+void setup() {
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/issues/1032/sketch.json
+++ b/tests/issues/1032/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:virtual:model01",
+    "port": ""
+  }
+}

--- a/tests/issues/1032/test.ktest
+++ b/tests/issues/1032/test.ktest
@@ -1,0 +1,115 @@
+VERSION 1
+
+KEYSWITCH SYSTER  0 0
+KEYSWITCH A       1 0
+KEYSWITCH B       1 1
+KEYSWITCH C       1 2
+KEYSWITCH ZERO    2 0
+KEYSWITCH ONE     2 1
+KEYSWITCH SPACE   3 0
+
+# ==============================================================================
+NAME Syster sequence without zero
+
+RUN 4 ms
+PRESS SYSTER
+RUN 1 cycle
+
+RUN 4 ms
+RELEASE SYSTER
+RUN 1 cycle
+
+RUN 4 ms
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # The report should contain only `A`
+
+RUN 4 ms
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # The report should be empty
+
+RUN 4 ms
+PRESS B
+RUN 1 cycle
+EXPECT keyboard-report Key_B # The report should contain only `B`
+
+RUN 4 ms
+RELEASE B
+RUN 1 cycle
+EXPECT keyboard-report empty # The report should be empty
+
+RUN 4 ms
+PRESS C
+RUN 1 cycle
+EXPECT keyboard-report Key_C # The report should contain only `C`
+
+RUN 4 ms
+RELEASE C
+RUN 1 cycle
+EXPECT keyboard-report empty # The report should be empty
+
+RUN 4 ms
+PRESS SPACE
+RUN 1 cycle
+EXPECT keyboard-report Key_Backspace # The report should contain `backspace`
+EXPECT keyboard-report empty # The report should be empty
+EXPECT keyboard-report Key_Backspace # The report should contain `backspace`
+EXPECT keyboard-report empty # The report should be empty
+EXPECT keyboard-report Key_Backspace # The report should contain `backspace`
+EXPECT keyboard-report empty # The report should be empty
+EXPECT keyboard-report Key_X # The report should contain `X`
+EXPECT keyboard-report empty # The report should be empty
+
+RUN 4 ms
+RELEASE SPACE
+RUN 1 cycle
+
+RUN 10 ms
+
+# ==============================================================================
+NAME Syster sequence with zero
+
+RUN 4 ms
+PRESS SYSTER
+RUN 1 cycle
+
+RUN 4 ms
+RELEASE SYSTER
+RUN 1 cycle
+
+RUN 4 ms
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # The report should contain only `A`
+
+RUN 4 ms
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # The report should be empty
+
+RUN 4 ms
+PRESS ZERO
+RUN 1 cycle
+EXPECT keyboard-report Key_0 # The report should contain only `0`
+
+RUN 4 ms
+RELEASE ZERO
+RUN 1 cycle
+EXPECT keyboard-report empty # The report should be empty
+
+RUN 4 ms
+PRESS SPACE
+RUN 1 cycle
+EXPECT keyboard-report Key_Backspace # The report should contain `backspace`
+EXPECT keyboard-report empty # The report should be empty
+EXPECT keyboard-report Key_Backspace # The report should contain `backspace`
+EXPECT keyboard-report empty # The report should be empty
+EXPECT keyboard-report Key_Y # The report should contain `Y`
+EXPECT keyboard-report empty # The report should be empty
+
+RUN 4 ms
+RELEASE SPACE
+RUN 1 cycle
+
+RUN 10 ms


### PR DESCRIPTION
Fixes #1032.

This fix will be the same, but the testcase changes after #1024 is merged. I have that version saved as well. If this gets merged first, I'll update #1024. If that one gets merged first, I'll rewrite this one.