### PR TITLE
Suppress warnings when expecting no report without comment

### DIFF
--- a/testing/bin/ktest-to-cxx
+++ b/testing/bin/ktest-to-cxx
@@ -375,7 +375,9 @@ sub generate_expect_report {
     $reports_expected++;
 
     if ( $report->{data}->{count} == 0 ) {
-        cxx_comment( $report->{comment} );
+        if ( $report->{comment} ) {
+            cxx_comment( $report->{comment} );
+        }
         cxx_comment(
 "We don't expect any report here, and have told the tests to check that"
         );


### PR DESCRIPTION
This allows the use of the following line in a ktest script without getting an error from Perl in ktest-to-cxx:
```
EXPECT no keyboard-report
```
If there's no trailing comment, which I think is unnecessary, as it's self-explanatory.