### PR TITLE
Clear masked keys in `Runtime.handleKeyswitchEvent()`

### DIFF
--- a/src/kaleidoscope/Runtime.cpp
+++ b/src/kaleidoscope/Runtime.cpp
@@ -102,6 +102,11 @@ Runtime_::handleKeyswitchEvent(KeyEvent event) {
     // When a key toggles off, set the event's key value to whatever the key's
     // current value is in the live keys state array.
     event.key = live_keys[event.addr];
+    // If that key was masked, unmask it and return.
+    if (event.key == Key_Masked) {
+      live_keys.clear(event.addr);
+      return;
+    }
   } else if (event.key == Key_NoKey) {
     // When a key toggles on, unless the event already has a key value (i.e. we
     // were called by a plugin rather than `actOnMatrixScan()`), we look up the

--- a/tests/issues/1042/1042.ino
+++ b/tests/issues/1042/1042.ino
@@ -1,0 +1,147 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-Leader -- VIM-style leader keys
+ * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-Leader.h>
+#include <Kaleidoscope-Macros.h>
+
+#include <Kaleidoscope-Ranges.h>
+#include "kaleidoscope/KeyEventTracker.h"
+#include "kaleidoscope/LiveKeys.h"
+#include "kaleidoscope/plugin.h"
+
+#include <Kaleidoscope-Devel-ArduinoTrace.h>
+
+// *INDENT-OFF*
+KEYMAPS(
+  [0] = KEYMAP_STACKED
+  (LEAD(0),      Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
+   Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+   Key_PageUp,   Key_A, Key_S, Key_D, Key_F, Key_G,
+   Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+
+   Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+   LEAD(0),
+
+   Key_skip,  Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
+   Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
+              Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
+   Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
+
+   Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
+   LEAD(0)),
+)
+// *INDENT-ON*
+
+namespace kaleidoscope {
+namespace plugin {
+
+class LeaderPrefix : public Plugin {
+ public:
+  EventHandlerResult onKeyswitchEvent(KeyEvent &event) {
+    // DUMP(int(event.id()));
+    // DUMP(int(event.key.getRaw()));
+    if (event_tracker_.shouldIgnore(event))
+      return EventHandlerResult::OK;
+
+    if (!active_) {
+      if (keyToggledOn(event.state) && isLeaderKey(event.key)) {
+        active_ = true;
+        leader_arg_ = 0;
+      }
+      return EventHandlerResult::OK;
+    }
+
+    if (keyToggledOn(event.state)) {
+      for (uint8_t i{0}; i < 10; ++i) {
+        if (digit_keys_[i] == event.key) {
+          leader_arg_ *= 10;
+          leader_arg_ += i;
+          live_keys.mask(event.addr);
+          return EventHandlerResult::ABORT;
+        }
+      }
+      // DUMP(active_);
+      active_ = false;
+    }
+    if (keyToggledOff(event.state) && event.key == Key_Masked)
+      return EventHandlerResult::ABORT;
+    return EventHandlerResult::OK;
+  }
+
+  EventHandlerResult afterEachCycle() {
+    // int timestamp = Runtime.millisAtCycleStart();
+    // DUMP(timestamp);
+    return EventHandlerResult::OK;
+  }
+
+  uint16_t arg() const {
+    return leader_arg_;
+  }
+
+ private:
+  Key digit_keys_[10] = {
+    Key_P, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Y, Key_U, Key_I, Key_O,
+  };
+
+  KeyEventTracker event_tracker_;
+  bool active_{false};
+  uint16_t leader_arg_{0};
+  bool isLeaderKey(Key key) {
+    return (key >= ranges::LEAD_FIRST && key <= ranges::LEAD_LAST);
+  }
+};
+
+} // namespace plugin
+} // namespace kaleidoscope
+
+kaleidoscope::plugin::LeaderPrefix LeaderPrefix;
+
+auto &serial_port = Kaleidoscope.serialPort();
+
+static void leaderTestX(uint8_t seq_index) {
+  Macros.tap(Key_A);
+}
+
+static void leaderTestXX(uint8_t seq_index) {
+  Macros.tap(Key_B);
+}
+
+void leaderTestPrefix(uint8_t seq_index) {
+  uint8_t prefix_arg = LeaderPrefix.arg();
+  // DUMP(prefix_arg);
+  Macros.tap(Key_Y);
+  while (prefix_arg-- > 0)
+    Macros.tap(Key_X);
+}
+
+static const kaleidoscope::plugin::Leader::dictionary_t leader_dictionary[] PROGMEM =
+LEADER_DICT({LEADER_SEQ(LEAD(0), Key_X), leaderTestX},
+{LEADER_SEQ(LEAD(0), Key_X, Key_X), leaderTestXX},
+{LEADER_SEQ(LEAD(0), Key_Z), leaderTestPrefix});
+
+KALEIDOSCOPE_INIT_PLUGINS(LeaderPrefix, Leader);
+
+void setup() {
+  Kaleidoscope.setup();
+
+  Leader.dictionary = leader_dictionary;
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/issues/1042/sketch.json
+++ b/tests/issues/1042/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:model01",
+    "port": ""
+  }
+}

--- a/tests/issues/1042/test.ktest
+++ b/tests/issues/1042/test.ktest
@@ -1,0 +1,82 @@
+VERSION 1
+
+KEYSWITCH LEAD   0 0
+KEYSWITCH Q      1 1
+KEYSWITCH W      1 2
+KEYSWITCH E      1 3
+KEYSWITCH R      1 4
+KEYSWITCH T      1 5
+KEYSWITCH Z      3 1
+
+# ==============================================================================
+NAME Leader prefix sequence
+
+RUN 4 ms
+PRESS LEAD
+RUN 1 cycle
+
+RUN 4 ms
+RELEASE LEAD
+RUN 1 cycle
+
+RUN 4 ms
+PRESS Q
+RUN 1 cycle
+
+RUN 4 ms
+RELEASE Q
+RUN 1 cycle
+
+RUN 4 ms
+PRESS W
+RUN 1 cycle
+
+RUN 4 ms
+RELEASE W
+RUN 1 cycle
+
+RUN 4 ms
+PRESS Z
+RUN 1 cycle
+EXPECT keyboard-report Key_Y
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+EXPECT keyboard-report empty
+
+RUN 4 ms
+RELEASE Z
+RUN 1 cycle
+
+RUN 4 ms
+PRESS W
+RUN 1 cycle
+EXPECT keyboard-report Key_W
+
+RUN 4 ms
+RELEASE W
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+RUN 5 ms


### PR DESCRIPTION
This change guarantees that masked keys will become unmasked on release.

Fixes #1042