### PR TITLE
Remove expired deprecated implementation inside OneShot

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -628,10 +628,9 @@ Older versions of the plugin were based on `Key` values; OneShot is now based on
 `KeyAddr` coordinates instead, in order to improve reliability and
 functionality.
 
-The following deprecated functions and variables will be removed after
-**2021-04-31**.
+The following deprecated functions and variables were removed on **2021-06-04**.
 
-#### Deprecated functions
+#### Removed functions
 
 - `OneShot.inject(key, key_state)`: This `Key`-based function still works, but
   because OneShot keys are now required to have a valid `KeyAddr`, it will now
@@ -654,7 +653,7 @@ The following deprecated functions and variables will be removed after
   perfectly reliable, because it now returns positive results for keys other
   than OneShot modifiers. It should not be used.
 
-#### Deprecated variables
+#### Removed variables
 
 - `OneShot.time_out`: Use `OneShot.setTimeout()` instead.
 - `OneShot.hold_time_out`: Use `OneShot.setHoldTimeout()` instead.

--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.cpp
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.cpp
@@ -31,13 +31,6 @@ uint16_t OneShot::timeout_ = 2500;
 uint16_t OneShot::hold_timeout_ = 250;
 int16_t OneShot::double_tap_timeout_ = -1;
 
-// Deprecated
-#ifndef NDEPRECATED
-uint16_t OneShot::time_out = 2500;
-uint16_t OneShot::hold_time_out = 250;
-int16_t OneShot::double_tap_time_out = -1;
-#endif
-
 // ----------------------------------------------------------------------------
 // State variables
 
@@ -354,16 +347,6 @@ EventHandlerResult OneShot::afterEachCycle() {
     start_time_ = Runtime.millisAtCycleStart();
   }
 
-  // Temporary fix for deprecated variables
-#ifndef NDEPRECATED
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  timeout_ = time_out;
-  hold_timeout_ = hold_time_out;
-  double_tap_timeout_ = double_tap_time_out;
-#pragma GCC diagnostic pop
-#endif
-
   return EventHandlerResult::OK;
 }
 
@@ -444,66 +427,6 @@ void OneShot::releaseKey(KeyAddr key_addr) {
 }
 
 // ------------------------------------------------------------------------------
-// Deprecated functions
-#ifndef NDEPRECATED
-void OneShot::inject(Key key, uint8_t key_state) {
-  if (isOneShotKey(key)) {
-    key = decodeOneShotKey(key);
-  }
-  // Find an idle keyswitch to use for the injected OneShot key and activate
-  // it. This is an ugly hack, but it will work. It does mean that whatever key
-  // is used will be unavailable for its normal function until the injected
-  // OneShot key is deactivated, so use of `inject()` is strongly discouraged.
-  for (KeyAddr key_addr : KeyAddr::all()) {
-    if (live_keys[key_addr] == Key_Transparent) {
-      pressKey(key_addr, key);
-      glue_addrs_.set(key_addr);
-      break;
-    }
-  }
-}
-
-bool OneShot::isModifierActive(Key key) {
-  // This actually works for any `Key` value, not just modifiers. Because we're
-  // just searching the keymap cache, it's also possible to return a false
-  // positive (a plugin might have altered the cache for an idle `KeyAddr`), or
-  // a false negative (a plugin might be inserting a modifier without a valid
-  // `KeyAddr`), but as this is a deprecated function, I think this is good
-  // enough.
-  for (KeyAddr key_addr : KeyAddr::all()) {
-    if (live_keys[key_addr] == key) {
-      return true;
-    }
-  }
-  return false;
-}
-
-bool OneShot::isActive(Key key) {
-  if (isOneShotKey(key)) {
-    key = decodeOneShotKey(key);
-  }
-  for (KeyAddr key_addr : glue_addrs_) {
-    if (live_keys[key_addr] == key) {
-      return true;
-    }
-  }
-  return false;
-}
-
-bool OneShot::isSticky(Key key) {
-  if (isOneShotKey(key)) {
-    key = decodeOneShotKey(key);
-  }
-  for (KeyAddr key_addr : glue_addrs_) {
-    if (live_keys[key_addr] == key &&
-        !temp_addrs_.read(key_addr)) {
-      return true;
-    }
-  }
-  return false;
-}
-#endif
-
 
 } // namespace plugin
 } // namespace kaleidoscope

--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.h
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.h
@@ -22,37 +22,6 @@
 #include "kaleidoscope/key_events.h"
 #include "kaleidoscope/KeyAddrBitfield.h"
 
-// ----------------------------------------------------------------------------
-// Deprecation warning messages
-#define _DEPRECATED_MESSAGE_ONESHOT_TIMEOUT                                     \
-  "The `OneShot.time_out` variable is deprecated. Please use the\n"             \
-  "`OneShot.setTimeout()` function instead."
-
-#define _DEPRECATED_MESSAGE_ONESHOT_HOLD_TIMEOUT                                \
-  "The `OneShot.hold_time_out` variable is deprecated. Please use the\n"        \
-  "`OneShot.setHoldTimeout()` function instead."
-
-#define _DEPRECATED_MESSAGE_ONESHOT_DOUBLE_TAP_TIMEOUT                          \
-  "The `OneShot.double_tap_time_out` variable is deprecated. Please use the\n"  \
-  "`OneShot.setDoubleTapTimeout()` function instead."
-
-#define _DEPRECATED_MESSAGE_ONESHOT_INJECT                                      \
-  "The `OneShot.inject(key, key_state)` function has been deprecated."
-
-#define _DEPRECATED_MESSAGE_ONESHOT_ISACTIVE_KEY                                \
-  "The `OneShot.isActive(key)` function is deprecated. Please use\n"            \
-  "`OneShot.isActive(key_addr)` instead, if possible."
-
-#define _DEPRECATED_MESSAGE_ONESHOT_ISSTICKY_KEY                                \
-  "The `OneShot.isSticky(key)` function is deprecated. Please use\n"            \
-  "`OneShot.isSticky(key_addr)` instead, if possible."
-
-#define _DEPRECATED_MESSAGE_ONESHOT_ISPRESSED                                   \
-  "The `OneShot.isPressed()` function is deprecated. This function now\n"       \
-  "always returns false."
-
-#define _DEPRECATED_MESSAGE_ONESHOT_ISMODIFIERACTIVE                            \
-  "The `OneShot.isModifierActive()` function is deprecated."
 
 // ----------------------------------------------------------------------------
 // Keymap macros
@@ -156,66 +125,19 @@ class OneShot : public kaleidoscope::Plugin {
   static void cancel(bool with_stickies = false);
 
   // --------------------------------------------------------------------------
-  // Deprecated functions
-#ifndef NDEPRECATED
-  DEPRECATED(ONESHOT_INJECT)
-  void inject(Key key, uint8_t key_state);
-
-  DEPRECATED(ONESHOT_ISMODIFIERACTIVE)
-  static bool isModifierActive(Key key);
-
-  DEPRECATED(ONESHOT_ISACTIVE_KEY)
-  static bool isActive(Key oneshot_key);
-
-  DEPRECATED(ONESHOT_ISSTICKY_KEY)
-  static bool isSticky(Key oneshot_key);
-
-  DEPRECATED(ONESHOT_ISPRESSED)
-  static bool isPressed() {
-    return false;
-  }
-#endif
-
-  // --------------------------------------------------------------------------
   // Timeout onfiguration functions
   static void setTimeout(uint16_t ttl) {
     timeout_ = ttl;
-#ifndef NDEPRECATED
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    time_out = ttl;
-#pragma GCC diagnostic pop
-#endif
   }
   static void setHoldTimeout(uint16_t ttl) {
     hold_timeout_ = ttl;
-#ifndef NDEPRECATED
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    hold_time_out = ttl;
-#pragma GCC diagnostic pop
-#endif
   }
   static void setDoubleTapTimeout(int16_t ttl) {
     double_tap_timeout_ = ttl;
-#ifndef NDEPRECATED
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    double_tap_time_out = ttl;
-#pragma GCC diagnostic pop
-#endif
   }
 
   // --------------------------------------------------------------------------
   // Configuration variables (should probably be private)
-#ifndef NDEPRECATED
-  DEPRECATED(ONESHOT_TIMEOUT)
-  static uint16_t time_out;
-  DEPRECATED(ONESHOT_HOLD_TIMEOUT)
-  static uint16_t hold_time_out;
-  DEPRECATED(ONESHOT_DOUBLE_TAP_TIMEOUT)
-  static int16_t double_tap_time_out;
-#endif
 
   // --------------------------------------------------------------------------
   // Plugin hook functions


### PR DESCRIPTION
The deprecations on this stuff were expired. @gedankenexperimenter - does this look right to you?