### PR TITLE
[draft] Pointer sensor support

### DIFF
--- a/plugins/Kaleidoscope-Pointer/README.md
+++ b/plugins/Kaleidoscope-Pointer/README.md
@@ -1,0 +1,1 @@
+# Pointer

--- a/plugins/Kaleidoscope-Pointer/library.properties
+++ b/plugins/Kaleidoscope-Pointer/library.properties
@@ -1,0 +1,7 @@
+name=Kaleidoscope-Pointer
+version=0.0.0
+sentence=Pointing device support for Kaleidoscope
+maintainer=Kaleidoscope's Developers <jesse@keyboard.io>
+url=https://github.com/keyboardio/Kaleidoscope
+author=Keyboardio
+paragraph=

--- a/plugins/Kaleidoscope-Pointer/src/Kaleidoscope-Pointer.h
+++ b/plugins/Kaleidoscope-Pointer/src/Kaleidoscope-Pointer.h
@@ -1,0 +1,19 @@
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2021  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "kaleidoscope/plugin/Pointer.h"

--- a/plugins/Kaleidoscope-Pointer/src/kaleidoscope/plugin/Pointer.cpp
+++ b/plugins/Kaleidoscope-Pointer/src/kaleidoscope/plugin/Pointer.cpp
@@ -1,0 +1,64 @@
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2021  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Arduino.h>
+
+#include "kaleidoscope/Runtime.h"
+#include "Kaleidoscope-FocusSerial.h"
+
+namespace kaleidoscope {
+namespace plugin {
+
+// =============================================================================
+// Event Handlers
+
+// -----------------------------------------------------------------------------
+EventHandlerResult Pointer::onNameQuery() {
+  return ::Focus.sendName(F("Pointer"));
+}
+
+// -----------------------------------------------------------------------------
+EventHandlerResult Pointer::onSetup(void) {
+  kaleidoscope::Runtime.hid().mouse().setup();
+
+  return EventHandlerResult::OK;
+}
+
+// -----------------------------------------------------------------------------
+EventHandlerResult Pointer::afterEachCycle() {
+  Runtime.hid().mouse().sendReport();
+
+  return EventHandlerResult::OK;
+}
+
+// -----------------------------------------------------------------------------
+EventHandlerResult Pointer::onPointerSensorEvent(PointerEvent &event) {
+  if (event.key != POINTER_MOTION && event.key != POINTER_SCROLL)
+    return EventHandlerResult::OK;
+
+  if (event.key == POINTER_MOTION) {
+    Runtime.hid().mouse().move(event.x, event.y, 0, 0);
+  } else if (event.key == POINTER_SCROLL) {
+    Runtime.hid().mouse().move(0, 0, event.v, event.h);
+  }
+
+  return EventHandlerResult::EVENT_CONSUMED;
+}
+
+} // namespace plugin
+} // namespace kaleidoscope
+
+kaleidoscope::plugin::Pointer Pointer;

--- a/plugins/Kaleidoscope-Pointer/src/kaleidoscope/plugin/Pointer.h
+++ b/plugins/Kaleidoscope-Pointer/src/kaleidoscope/plugin/Pointer.h
@@ -1,0 +1,37 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2021  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "kaleidoscope/Runtime.h"
+
+namespace kaleidoscope {
+namespace plugin {
+
+class Pointer: public kaleidoscope::Plugin {
+ public:
+  Pointer() {}
+
+  EventHandlerResult onSetup();
+  EventHandlerResult onNameQuery();
+  EventHandlerResult onPointerSensorEvent(PointerEvent &event);
+};
+
+}
+}
+
+extern kaleidoscope::plugin::Pointer Pointer;

--- a/plugins/Kaleidoscope-Ranges/src/Kaleidoscope-Ranges.h
+++ b/plugins/Kaleidoscope-Ranges/src/Kaleidoscope-Ranges.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Ranges -- Common ranges, used by a number of Kaleidoscope plugins.
- * Copyright (C) 2016, 2017, 2019  Keyboard.io, Inc
+ * Copyright (C) 2016-2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -83,6 +83,8 @@ enum : uint16_t {
   OS_META_STICKY,
   OS_ACTIVE_STICKY,
   OS_CANCEL,
+  POINTER_MOTION,
+  POINTER_SCROLL,
 
   SAFE_START,
   KALEIDOSCOPE_SAFE_START = SAFE_START

--- a/src/kaleidoscope/PointerEvent.cpp
+++ b/src/kaleidoscope/PointerEvent.cpp
@@ -1,0 +1,23 @@
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2021  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "kaleidoscope/PointerEvent.h"
+
+namespace kaleidoscope {
+
+PointerEventId PointerEvent::last_id_ = 0;
+
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/PointerEvent.h
+++ b/src/kaleidoscope/PointerEvent.h
@@ -33,7 +33,7 @@ struct PointerEvent {
                Key key = Key_NoKey, PointerEventId id = last_id_)
     : addr(addr), x(x), y(y), h(h), v(v), key(key), id_(id) {}
 
-  PointerEventEvent() : id_(last_id_) {}
+  PointerEvent() : id_(last_id_) {}
 
   // For use by sensor creating a new event from a physical sensor event.
   static PointerEvent next(KeyAddr addr, int8_t x, int8_t y, int8_t h, int8_t v) {

--- a/src/kaleidoscope/PointerEvent.h
+++ b/src/kaleidoscope/PointerEvent.h
@@ -1,0 +1,68 @@
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2021  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>                 // for uint8_t, int8_t
+
+#include "kaleidoscope/key_defs.h"  // for Key, Key_NoKey
+#include "kaleidoscope/KeyAddr.h"   // for KeyAddr
+
+namespace kaleidoscope {
+
+typedef int8_t PointerEventId;
+
+struct PointerEvent {
+
+ public:
+  // Constructor for plugin use when regenerating an event with specific ID:
+  PointerEvent(KeyAddr addr, int8_t x, int8_t y, int8_t h, int8_t v,
+               Key key = Key_NoKey, PointerEventId id = last_id_)
+    : addr(addr), x(x), y(y), h(h), v(v), key(key), id_(id) {}
+
+  PointerEventEvent() : id_(last_id_) {}
+
+  // For use by sensor creating a new event from a physical sensor event.
+  static PointerEvent next(KeyAddr addr, int8_t x, int8_t y, int8_t h, int8_t v) {
+    return PointerEvent(addr, x, y, h, v, Key_NoKey, ++last_id_);
+  }
+
+  PointerEventId id() const {
+    return id_;
+  }
+  void swapId(PointerEvent &other) {
+    PointerEventId tmp_id = id_;
+    id_ = other.id_;
+    other.id_ = tmp_id;
+  }
+
+  KeyAddr addr = KeyAddr::none();
+  int8_t x = 0;
+  int8_t y = 0;
+  int8_t h = 0;
+  int8_t v = 0;
+  Key key = Key_NoKey;
+
+ private:
+  // serial number of the event:
+  static PointerEventId last_id_;
+  PointerEventId id_;
+};
+
+}  // namespace kaleidoscope
+
+typedef kaleidoscope::PointerEventId PointerEventId;
+typedef kaleidoscope::PointerEvent PointerEvent;

--- a/src/kaleidoscope/Runtime.h
+++ b/src/kaleidoscope/Runtime.h
@@ -1,5 +1,5 @@
 /* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2018  Keyboard.io, Inc.
+ * Copyright (C) 2013-2021  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -20,6 +20,7 @@
 #include "kaleidoscope/event_handler_result.h"
 #include "kaleidoscope/hooks.h"
 #include "kaleidoscope/KeyEvent.h"
+#include "kaleidoscope/PointerEvent.h"
 #include "kaleidoscope/LiveKeys.h"
 #include "kaleidoscope/layers.h"
 

--- a/src/kaleidoscope/event_handlers.h
+++ b/src/kaleidoscope/event_handlers.h
@@ -186,7 +186,7 @@ class SignatureCheckDummy {};
             _ABORTABLE,                                                   __NL__ \
             (), (), (), /* non template */                                __NL__ \
             (PointerEvent &event),                                        __NL__ \
-            (event), ##_VA_ARGS__)                                        __NL__ \
+            (event), ##__VA_ARGS__)                                       __NL__ \
                                                                           __NL__ \
    /* Function called for every logical key event, including ones that */ __NL__ \
    /* originate from a physical keyswitch and ones that are injected   */ __NL__ \

--- a/src/kaleidoscope/event_handlers.h
+++ b/src/kaleidoscope/event_handlers.h
@@ -173,6 +173,21 @@ class SignatureCheckDummy {};
              (KeyEvent &event),                                           __NL__ \
              (event), ##__VA_ARGS__)                                      __NL__ \
                                                                           __NL__ \
+  /* Function called for every physical pointer sensor event (motion   */ __NL__ \
+  /* and/or scrolling). The `event` parameter is passed by reference   */ __NL__ \
+  /* so all of its properties (key, motion, scrolling) can be changed. */ __NL__ \
+  /* If it returns EventHandlerResult::OK, the next handler will be    */ __NL__ \
+  /* passed the event; otherwise Kaleidoscope will stop processing it. */ __NL__ \
+  /* Plugins that implement this handler must not process the same     */ __NL__ \
+  /* event twice in order to prevent handler loops.                    */ __NL__ \
+  OPERATION(onPointerSensorEvent,                                         __NL__ \
+            2,                                                            __NL__ \
+            _CURRENT_IMPLEMENTATION,                                      __NL__ \
+            _ABORTABLE,                                                   __NL__ \
+            (), (), (), /* non template */                                __NL__ \
+            (PointerEvent &event),                                        __NL__ \
+            (event), ##_VA_ARGS__)                                        __NL__ \
+                                                                          __NL__ \
    /* Function called for every logical key event, including ones that */ __NL__ \
    /* originate from a physical keyswitch and ones that are injected   */ __NL__ \
    /* by plugins. The `event` parameter is passed by reference so its  */ __NL__ \

--- a/src/kaleidoscope/hooks.h
+++ b/src/kaleidoscope/hooks.h
@@ -24,6 +24,7 @@ class Key;
 
 #include "kaleidoscope/KeyAddr.h"
 #include "kaleidoscope/KeyEvent.h"
+#include "kaleidoscope/PointerEvent.h"
 #include "kaleidoscope/plugin.h"
 #include "kaleidoscope/event_handlers.h"
 


### PR DESCRIPTION
This is a _very_ early and rough draft of an idea I've been entertaining lately: how to support devices with a pointer sensor (trackballs, mice, that kind of stuff).

The core idea is that we'll add these to the keymap aswell, as `Pointer_Motion` or `Pointer_Scroll` "keys". The device implementation itself will poll the hardware and emit `onPointerSensorEvent(PointerEvent &event)`, which is very similar to `onKeyswitchEvent()`, except our event has `x, y, h, v` properties rather than `state`, corresponding to horizontal / vertical movement and scrolling.

Plugins that wish to influence pointer behaviour will be able to implement `onPointerEvent` (similar in spirit to `onKeyEvent`, but currently unimplemented).

The downside of having these keys on the keymap is that they're... not really keys, and any code that loops over the keymap might be surprised to see the new pointer keys there. However, I feel it's more userfriendly to have them on the keymap, rather than having to define them separately. A device may have multiple such directional sensors: a trackball, a scroll wheel, volume knobs - they could all plug in nicely to this scheme.

The next step will be to rework MouseKeys to emit `onPointerEvent` rather than working directly with `hid().mouse()`.