### PR TITLE
Add removal dates for various functions & variables

### DIFF
--- a/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.h
+++ b/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.h
@@ -22,7 +22,8 @@
 #define _DEPRECATED_MESSAGE_ENABLEWAKEUP                                    \
   "The HostPowerManagement.enableWakeup() call is not necessary anymore,\n" \
   "the firmware supports wakeup by default now. The line can be safely\n"   \
-  "removed."
+  "removed.\n"                                                          \
+  "This function will be removed after 2021-08-01."
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LED-ActiveModColor/src/kaleidoscope/plugin/LED-ActiveModColor.h
+++ b/plugins/Kaleidoscope-LED-ActiveModColor/src/kaleidoscope/plugin/LED-ActiveModColor.h
@@ -29,7 +29,8 @@
   "Please use the following methods instead:                               \n" \
   " - for `highlight_color` => `setHighlightColor(color)`                  \n" \
   " - for `oneshot_color` => `setOneShotColor(color)`                      \n" \
-  " - for `sticky_color` => `setStickyColor(color)`"
+  " - for `sticky_color` => `setStickyColor(color)`                        \n" \
+  "These variables will be removed after 2021-08-01."
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.h
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.h
@@ -26,33 +26,41 @@
 // Deprecation warning messages
 #define _DEPRECATED_MESSAGE_ONESHOT_TIMEOUT                                     \
   "The `OneShot.time_out` variable is deprecated. Please use the\n"             \
-  "`OneShot.setTimeout()` function instead."
+  "`OneShot.setTimeout()` function instead.\n"                                  \
+  "This variable will be removed after 2021-08-01."
 
 #define _DEPRECATED_MESSAGE_ONESHOT_HOLD_TIMEOUT                                \
   "The `OneShot.hold_time_out` variable is deprecated. Please use the\n"        \
-  "`OneShot.setHoldTimeout()` function instead."
+  "`OneShot.setHoldTimeout()` function instead.\n"                              \
+  "This variable will be removed after 2021-08-01."
 
 #define _DEPRECATED_MESSAGE_ONESHOT_DOUBLE_TAP_TIMEOUT                          \
   "The `OneShot.double_tap_time_out` variable is deprecated. Please use the\n"  \
-  "`OneShot.setDoubleTapTimeout()` function instead."
+  "`OneShot.setDoubleTapTimeout()` function instead.\n"                         \
+  "This variable will be removed after 2021-08-01."
 
 #define _DEPRECATED_MESSAGE_ONESHOT_INJECT                                      \
-  "The `OneShot.inject(key, key_state)` function has been deprecated."
+  "The `OneShot.inject(key, key_state)` function has been deprecated.\n"        \
+  "This function will be removed after 2021-08-01."
 
 #define _DEPRECATED_MESSAGE_ONESHOT_ISACTIVE_KEY                                \
   "The `OneShot.isActive(key)` function is deprecated. Please use\n"            \
-  "`OneShot.isActive(key_addr)` instead, if possible."
+  "`OneShot.isActive(key_addr)` instead, if possible.\n"                        \
+  "This function will be removed after 2021-08-01."
 
 #define _DEPRECATED_MESSAGE_ONESHOT_ISSTICKY_KEY                                \
   "The `OneShot.isSticky(key)` function is deprecated. Please use\n"            \
-  "`OneShot.isSticky(key_addr)` instead, if possible."
+  "`OneShot.isSticky(key_addr)` instead, if possible.\n"                        \
+  "This function will be removed after 2021-08-01."
 
 #define _DEPRECATED_MESSAGE_ONESHOT_ISPRESSED                                   \
   "The `OneShot.isPressed()` function is deprecated. This function now\n"       \
-  "always returns false."
+  "always returns false.\n"                                                     \
+  "This function will be removed after 2021-08-01."
 
 #define _DEPRECATED_MESSAGE_ONESHOT_ISMODIFIERACTIVE                            \
-  "The `OneShot.isModifierActive()` function is deprecated."
+  "The `OneShot.isModifierActive()` function is deprecated.\n"                  \
+  "This function will be removed after 2021-08-01."
 
 // ----------------------------------------------------------------------------
 // Keymap macros

--- a/src/kaleidoscope_internal/deprecations.h
+++ b/src/kaleidoscope_internal/deprecations.h
@@ -27,39 +27,45 @@
 
 /* Messages */
 
-#define _DEPRECATED_MESSAGE_LAYER_UPDATELIVECOMPOSITEKEYMAP             __NL__ \
-  "`Layer.updateLiveCompositeKeymap()` is deprecated.\n"                __NL__ \
-  "The 'live composite keymap' cache has been replaced with the\n"      __NL__ \
-  "'active keys' cache, which now represents the state of the active\n" __NL__ \
-  "keys at any given time. It is probably not necessary to directly\n"  __NL__ \
-  "update that cache from a plugin, but if you need to, please use\n"   __NL__ \
-  "the `live_keys.activate(key_addr, key)` function instead."
+#define _DEPRECATED_MESSAGE_LAYER_UPDATELIVECOMPOSITEKEYMAP                   __NL__ \
+  "`Layer.updateLiveCompositeKeymap()` is deprecated.\n"                      __NL__ \
+  "The 'live composite keymap' cache has been replaced with the\n"            __NL__ \
+  "'active keys' cache, which now represents the state of the active\n"       __NL__ \
+  "keys at any given time. It is probably not necessary to directly\n"        __NL__ \
+  "update that cache from a plugin, but if you need to, please use\n"         __NL__ \
+  "the `live_keys.activate(key_addr, key)` function instead.\n"               __NL__ \
+  "This function will be removed after 2021-08-01."
 
-#define _DEPRECATED_MESSAGE_LAYER_EVENTHANDLER               __NL__ \
-  "`Layer.eventHandler()` is deprecated.\n"                  __NL__ \
-  "Please use `Layer.handleKeymapKeyswitchEvent()` instead."
+#define _DEPRECATED_MESSAGE_LAYER_EVENTHANDLER                                __NL__ \
+  "`Layer.eventHandler()` is deprecated.\n"                                   __NL__ \
+  "Please use `Layer.handleKeymapKeyswitchEvent()` instead.\n"                __NL__ \
+  "This function will be removed after 2021-08-01."
 
-#define _DEPRECATED_MESSAGE_LAYER_HANDLE_KEYMAP_KEYSWITCH_EVENT  __NL__ \
-  "`Layer.handleKeymapKeyswitchEvent()` is deprecated.\n"        __NL__ \
-  "Please use `Layer.handleLayerKeyEvent()` instead."
+#define _DEPRECATED_MESSAGE_LAYER_HANDLE_KEYMAP_KEYSWITCH_EVENT               __NL__ \
+  "`Layer.handleKeymapKeyswitchEvent()` is deprecated.\n"                     __NL__ \
+  "Please use `Layer.handleLayerKeyEvent()` instead.\n"                       __NL__ \
+  "This function will be removed after 2021-08-01."
 
 #define _DEPRECATED_MESSAGE_LAYER_LOOKUP                                      __NL__ \
   "`Layer.lookup(key_addr)` is deprecated.\n"                                 __NL__ \
   "Please use `Runtime.lookupKey(key_addr)` instead. Alternatively, if you\n" __NL__ \
   "need to look up the current keymap entry without regard to current live\n" __NL__ \
   "key state(s) (i.e. the `live_keys` array, which normally overrides the\n"  __NL__ \
-  "keymap), you can use `Layer.lookupOnActiveLayer(key_addr)`."
+  "keymap), you can use `Layer.lookupOnActiveLayer(key_addr)`.\n"             __NL__ \
+  "This function will be removed after 2021-08-01."
 
-#define _DEPRECATED_MESSAGE_HANDLE_KEYSWITCH_EVENT   __NL__ \
-  "`handleKeyswitchEvent()` has been deprecated.\n"  __NL__ \
-  "Please use `Runtime.handleKeyEvent()` instead."
+#define _DEPRECATED_MESSAGE_HANDLE_KEYSWITCH_EVENT                            __NL__ \
+  "`handleKeyswitchEvent()` has been deprecated.\n"                           __NL__ \
+  "Please use `Runtime.handleKeyEvent()` instead.\n"                          __NL__ \
+  "This function will be removed after 2021-08-01."
 
 #define _DEPRECATED_MESSAGE_ON_KEYSWITCH_EVENT_V1                             __NL__ \
   "The `onKeyswitchEvent()` event handler is deprecated.\n"                   __NL__ \
   "Please replace it with an `onKeyEvent()` handler. See the documentation\n" __NL__ \
   "in UPGRADING.md and docs/api-reference/event-handler-hooks.md for more\n"  __NL__ \
   "information on what changes are needed to adapt old plugins to the new\n"  __NL__ \
-  "event handler API."
+  "event handler API.\n"                                                      __NL__ \
+  "This function will be removed after 2021-08-01."
 
 #define _DEPRECATED_MESSAGE_BEFORE_REPORTING_STATE_V1                          __NL__ \
   "This `beforeReportingState()` event handler version is deprecated.\n"       __NL__ \
@@ -68,11 +74,13 @@
   "report is sent. However, the new handler does not run every cycle, but\n"   __NL__ \
   "only in response to key events. If you have code that is intended to run\n" __NL__ \
   "every scan cycle, it should be moved to the `afterEachCycle()` event\n"     __NL__ \
-  "handler instead."
+  "handler instead.\n"                                                         __NL__ \
+  "This function will be removed after 2021-08-01."
 
 #define _DEPRECATED_MESSAGE_HID_KEYBOARD_PRESSKEY_TOGGLEDON                    __NL__ \
   "The `Keyboard::pressKey(key, toggled_on)` function is deprecated.\n"        __NL__ \
   "Please use `Keyboard::pressKey(key)` without the second argument\n"         __NL__ \
   "instead. The version with two arguments handled rollover events, and\n"     __NL__ \
   "this is now handled more completely by the event handling functions in\n"   __NL__ \
-  "`Runtime`."
+  "`Runtime`.\n"                                                               __NL__ \
+  "This function will be removed after 2021-08-01."


### PR DESCRIPTION
There were many deprecated functions that had uncertain dates, so they were omitted.  I'm proposing August 1 as the earliest date for removal.  I separated the plugin deprecations from the core ones to make it easier to update them independently.