### PR TITLE
driver::hid::base: Add isKeyPressed() to the NoKeyboard classes

### DIFF
--- a/src/kaleidoscope/driver/hid/base/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/base/Keyboard.h
@@ -54,6 +54,9 @@ class NoBootKeyboard {
   bool wasAnyModifierActive() {
     return false;
   }
+  bool isKeyPressed(uint8_t code) {
+    return false;
+  }
 
   uint8_t getLeds() {
     return 0;
@@ -81,6 +84,9 @@ class NoNKROKeyboard {
     return false;
   }
   bool wasAnyModifierActive() {
+    return false;
+  }
+  bool isKeyPressed(uint8_t code) {
     return false;
   }
 


### PR DESCRIPTION
Other parts of Kaleidoscope require the NKRO and Boot keyboard classes  to have an `isKeyPressed()` method, which our base classes did not provide - until now.

We need these in the base class so we can create devices that do not use any HID drivers - mostly for testing purposes.