### PR TITLE
internal/deprecations: Include macro_helpers.h for __NL__

### DIFF
--- a/src/kaleidoscope_internal/deprecations.h
+++ b/src/kaleidoscope_internal/deprecations.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "kaleidoscope/macro_helpers.h"
+
 #define DEPRECATED(tag)                                                 \
   __attribute__((deprecated(_DEPRECATE(_DEPRECATED_MESSAGE_ ## tag))))
 


### PR DESCRIPTION
Without including `macro_helpers.h`, compilation fails if we actually end up compiling parts that include `kaleidoscope_internal/deprecations.h`, like the following little plugin:

```c++
#include "kaleidoscope/driver/keyscanner/None.h"
#include "kaleidoscope/device/Base.h"

namespace kaleidoscope {
namespace device {
namespace adafruit {

struct M4FeatherProps : kaleidoscope::device::BaseProps {
  typedef kaleidoscope::driver::keyscanner::None KeyScanner;
  static constexpr const char *short_name = "m4-feather";
};

class M4Feather: public kaleidoscope::device::Base<M4FeatherProps> {
 public:
  auto serialPort() -> decltype(Serial) & {
    return Serial;
  }
};

}
}

typedef kaleidoscope::device::adafruit::M4Feather Device;

}
```

Without the macro helpers, this fails to compile with:

```
In file included from .../Kaleidoscope/src/kaleidoscope/key_defs/keymaps.h:21:0,                                      
                 from .../Kaleidoscope/src/kaleidoscope/key_defs.h:27,                                                
                 from .../Kaleidoscope/src/kaleidoscope/driver/keyscanner/Base.h:22,                                  
                 from .../Kaleidoscope/src/kaleidoscope/driver/keyscanner/None.h:22,                                  
                 from .../Kaleidoscope/plugins/Kaleidoscope-Hardware-Adafrui
t-M4/src/kaleidoscope/device/adafruit/M4.h:23,                                                                                                     
                 from .../Kaleidoscope/plugins/Kaleidoscope-Hardware-Adafrui
t-M4/src/Kaleidoscope-Hardware-Adafruit-M4.h:21,                                                                                                   
                 from .../Kaleidoscope/src/kaleidoscope/device/device.h:22,                                           
                 from .../Kaleidoscope/src/Kaleidoscope.h:40,                                                         
                 from .../Kaleidoscope/examples/Devices/Adafruit/FeatherM4/F
eatherM4.ino:18:                                                                                                                                   
.../Kaleidoscope/src/kaleidoscope_internal/deprecations.h:80:80: error: expected ')' before '__NL__'                  
 #define _DEPRECATED_MESSAGE_HID_KEYBOARD_PRESSKEY_TOGGLEDON                    __NL__ \                                                           
                                                                                ^                                                                  
.../Kaleidoscope/src/kaleidoscope_internal/deprecations.h:24:3: note: in definition of macro '_DEPRECATE'             
   message                                                                      \                                                                  
   ^~~~~~~                                                                                                                                         
.../Kaleidoscope/src/kaleidoscope_internal/deprecations.h:20:40: note: in expansion of macro '_DEPRECATED_MESSAGE_HID_
KEYBOARD_PRESSKEY_TOGGLEDON'                                                                                                                       
   __attribute__((deprecated(_DEPRECATE(_DEPRECATED_MESSAGE_ ## tag))))                                                                            
                                        ^~~~~~~~~~~~~~~~~~~~                                                                                       
.../Kaleidoscope/src/kaleidoscope/driver/hid/base/Keyboard.h:177:3: note: in expansion of macro 'DEPRECATED'          
   DEPRECATED(HID_KEYBOARD_PRESSKEY_TOGGLEDON)                                                                                                     
   ^~~~~~~~~~               
```

With the include, the `__NL__` macro gets defined, and users of the message can be compiled.

Alternatively, we could drop the use of `__NL__` from there, because it doesn't really serve a good purpose. I opted not to do that, because using `__NL__` feels like a good habit.