### PR TITLE
Change default value of `KeyEvent::key` from `Key_NoKey` to `Key_Undefined`

### DIFF
--- a/src/kaleidoscope/KeyAddrEventQueue.h
+++ b/src/kaleidoscope/KeyAddrEventQueue.h
@@ -147,7 +147,7 @@ class KeyAddrEventQueue {
 
   KeyEvent event(uint8_t i) const {
     uint8_t state = isRelease(i) ? WAS_PRESSED : IS_PRESSED;
-    return KeyEvent{addr(i), state, Key_NoKey, id(i)};
+    return KeyEvent{addr(i), state, Key_Undefined, id(i)};
   }
 
   // Only call this after `EventTracker::shouldIgnore()` returns `true`.

--- a/src/kaleidoscope/KeyEvent.h
+++ b/src/kaleidoscope/KeyEvent.h
@@ -32,7 +32,7 @@ struct KeyEvent {
  public:
   // Constructor for plugin use when regenerating an event with specific ID:
   KeyEvent(KeyAddr addr, uint8_t state,
-           Key key = Key_NoKey, KeyEventId id = last_id_)
+           Key key = Key_Undefined, KeyEventId id = last_id_)
     : addr(addr), state(state), key(key), id_(id) {}
 
   KeyEvent() : id_(last_id_) {}
@@ -40,7 +40,7 @@ struct KeyEvent {
   // For use by keyscanner creating a new event from a physical keyswitch toggle
   // on or off.
   static KeyEvent next(KeyAddr addr, uint8_t state) {
-    return KeyEvent(addr, state, Key_NoKey, ++last_id_);
+    return KeyEvent(addr, state, Key_Undefined, ++last_id_);
   }
 
   KeyEventId id() const {
@@ -54,7 +54,7 @@ struct KeyEvent {
 
   KeyAddr addr = KeyAddr::none();
   uint8_t state = 0;
-  Key key = Key_NoKey;
+  Key key = Key_Undefined;
 
  private:
   // serial number of the event:

--- a/src/kaleidoscope/key_defs.h
+++ b/src/kaleidoscope/key_defs.h
@@ -293,6 +293,10 @@ typedef kaleidoscope::Key Key_;
 #define Key_Inactive Key_Transparent
 #define Key_Masked Key_NoKey
 
+// The default value for new events.  Used to signal that a keymap lookup should
+// be done.
+#define Key_Undefined Key_Transparent
+
 #define KEY_BACKLIGHT_DOWN 0xf1
 #define KEY_BACKLIGHT_UP 0xf2
 #define Key_BacklightDown Key(KEY_BACKLIGHT_DOWN, KEY_FLAGS)


### PR DESCRIPTION
This lets us remove some awkward code from `handleKeyswitchEvent()`, because as long as the default value (which triggers a keymap lookup) was the same as `Key_Masked`, it wasn't sufficient for an `onKeyswitchEvent()` handler to change `event.key` to `Key_Masked`, because that would be interpreted by `handleKeyEvent()` as a signal to do a keymap lookup.

This also makes it more consistent with other parts of the code.  The values `Key_Undefined`, `Key_Inactive`, and `Key_Transparent` are all the same, and with this change they are each interpreted the same way by code that encounters them.  In a keymap lookup, if an active layer has a `Key_Transparent` value, we continue searching for a different value on another layer.  In the live keys array, if we find a `Key_Inactive` entry, we look for a value from the keymap. And with this change, when processing a key event, if it has a `Key_Undefined` value, we look for a value from `active_keys` (and then from the keymap layers, if nothing is found there).
