### PR TITLE
Assorted portability fixes

### DIFF
--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/Raise.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/Raise.h
@@ -26,6 +26,7 @@
 #define CRGB(r,g,b) (cRGB){b, g, r}
 
 #include "kaleidoscope/driver/keyscanner/Base.h"
+#include "kaleidoscope/driver/hid/Keyboardio.h"
 #include "kaleidoscope/driver/led/Base.h"
 #include "kaleidoscope/driver/bootloader/samd/Bossac.h"
 #include "kaleidoscope/driver/storage/Flash.h"
@@ -156,6 +157,8 @@ struct RaiseStorageProps : public kaleidoscope::driver::storage::FlashProps {
 struct RaiseSideFlasherProps : public kaleidoscope::util::flasher::BaseProps {};
 
 struct RaiseProps : kaleidoscope::device::BaseProps {
+  typedef kaleidoscope::driver::hid::KeyboardioProps HIDProps;
+  typedef kaleidoscope::driver::hid::Keyboardio<HIDProps> HID;
   typedef RaiseLEDDriverProps  LEDDriverProps;
   typedef RaiseLEDDriver LEDDriver;
   typedef RaiseKeyScannerProps KeyScannerProps;

--- a/src/kaleidoscope/device/ATmega32U4Keyboard.h
+++ b/src/kaleidoscope/device/ATmega32U4Keyboard.h
@@ -23,6 +23,7 @@
 #include "kaleidoscope/device/Base.h"
 
 #include "kaleidoscope/driver/mcu/ATmega32U4.h"
+#include "kaleidoscope/driver/hid/Keyboardio.h"
 #include "kaleidoscope/driver/keyscanner/ATmega.h"
 #include "kaleidoscope/driver/storage/ATmega32U4EEPROMProps.h"
 #include "kaleidoscope/driver/storage/AVREEPROM.h"
@@ -31,6 +32,8 @@ namespace kaleidoscope {
 namespace device {
 
 struct ATmega32U4KeyboardProps : kaleidoscope::device::BaseProps {
+  typedef kaleidoscope::driver::hid::KeyboardioProps HIDProps;
+  typedef kaleidoscope::driver::hid::Keyboardio<HIDProps> HID;
   typedef kaleidoscope::driver::mcu::ATmega32U4Props MCUProps;
   typedef kaleidoscope::driver::mcu::ATmega32U4<MCUProps> MCU;
   typedef kaleidoscope::driver::storage::ATmega32U4EEPROMProps StorageProps;

--- a/src/kaleidoscope/device/Base.h
+++ b/src/kaleidoscope/device/Base.h
@@ -25,7 +25,7 @@
 #include "kaleidoscope_internal/deprecations.h"
 #include "kaleidoscope/macro_helpers.h"
 
-#include "kaleidoscope/driver/hid/Keyboardio.h"
+#include "kaleidoscope/driver/hid/Base.h"
 #include "kaleidoscope/driver/keyscanner/None.h"
 #include "kaleidoscope/driver/led/None.h"
 #include "kaleidoscope/driver/mcu/None.h"
@@ -53,8 +53,8 @@ namespace kaleidoscope {
 namespace device {
 
 struct BaseProps {
-  typedef kaleidoscope::driver::hid::KeyboardioProps HIDProps;
-  typedef kaleidoscope::driver::hid::Keyboardio<HIDProps> HID;
+  typedef kaleidoscope::driver::hid::BaseProps HIDProps;
+  typedef kaleidoscope::driver::hid::Base<HIDProps> HID;
   typedef kaleidoscope::driver::keyscanner::BaseProps KeyScannerProps;
   typedef kaleidoscope::driver::keyscanner::None KeyScanner;
   typedef kaleidoscope::driver::led::BaseProps LEDDriverProps;

--- a/src/kaleidoscope/device/virtual/Virtual.h
+++ b/src/kaleidoscope/device/virtual/Virtual.h
@@ -22,6 +22,7 @@
 #include KALEIDOSCOPE_HARDWARE_H
 
 #include "kaleidoscope/driver/bootloader/None.h"
+#include "kaleidoscope/driver/hid/Keyboardio.h"
 #include "kaleidoscope/driver/led/Base.h"
 
 namespace kaleidoscope {
@@ -110,6 +111,8 @@ class VirtualLEDDriver
 // the physical keyboard.
 //
 struct VirtualProps : public kaleidoscope::DeviceProps {
+  typedef kaleidoscope::driver::hid::KeyboardioProps HIDProps;
+  typedef kaleidoscope::driver::hid::Keyboardio<HIDProps> HID;
   typedef typename kaleidoscope::DeviceProps::KeyScannerProps
   KeyScannerProps;
   typedef VirtualKeyScanner

--- a/src/kaleidoscope/driver/hid/base/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/base/Keyboard.h
@@ -20,6 +20,10 @@
 
 #include "kaleidoscope/key_defs.h"
 
+#ifndef HID_BOOT_PROTOCOL
+#define HID_BOOT_PROTOCOL 0
+#endif
+
 namespace kaleidoscope {
 namespace driver {
 namespace hid {

--- a/src/kaleidoscope/driver/hid/base/Mouse.h
+++ b/src/kaleidoscope/driver/hid/base/Mouse.h
@@ -35,10 +35,6 @@ class NoMouse {
   void press(uint8_t buttons) {}
   void release(uint8_t buttons) {}
   void click(uint8_t buttons) {}
-  HID_MouseReport_Data_t getReport() {
-    static HID_MouseReport_Data_t report;
-    return report;
-  }
 };
 
 struct MouseProps {

--- a/src/kaleidoscope/driver/hid/base/Mouse.h
+++ b/src/kaleidoscope/driver/hid/base/Mouse.h
@@ -30,6 +30,7 @@ class NoMouse {
   void begin() {}
   void sendReport() {}
   void move(int8_t x, int8_t y, int8_t vWheel, int8_t hWheel) {}
+  void stop(bool x, bool y, bool vWheel, bool hWheel) {}
   void releaseAll() {}
   void press(uint8_t buttons) {}
   void release(uint8_t buttons) {}
@@ -63,17 +64,7 @@ class Mouse {
     mouse_.move(x, y, vWheel, hWheel);
   }
   void stop(bool x, bool y, bool vWheel = false, bool hWheel = false) {
-    HID_MouseReport_Data_t report = mouse_.getReport();
-
-    if (x)
-      report.xAxis = 0;
-    if (y)
-      report.yAxis = 0;
-    if (vWheel)
-      report.vWheel = 0;
-    if (hWheel)
-      report.hWheel = 0;
-    move(report.xAxis, report.yAxis, report.vWheel, report.hWheel);
+    mouse_.stop(x, y, vWheel, hWheel);
   }
   void releaseAllButtons() {
     mouse_.releaseAll();

--- a/src/kaleidoscope/driver/hid/keyboardio/Mouse.h
+++ b/src/kaleidoscope/driver/hid/keyboardio/Mouse.h
@@ -76,9 +76,6 @@ class MouseWrapper {
   void click(uint8_t buttons) {
     Mouse.click(buttons);
   }
-  HID_MouseReport_Data_t getReport() {
-    return Mouse.getReport();
-  }
 };
 
 struct MouseProps: public base::MouseProps {

--- a/src/kaleidoscope/driver/hid/keyboardio/Mouse.h
+++ b/src/kaleidoscope/driver/hid/keyboardio/Mouse.h
@@ -50,6 +50,20 @@ class MouseWrapper {
   void move(int8_t x, int8_t y, int8_t vWheel, int8_t hWheel) {
     Mouse.move(x, y, vWheel, hWheel);
   }
+  void stop(bool x, bool y, bool vWheel = false, bool hWheel = false) {
+    HID_MouseReport_Data_t report = Mouse.getReport();
+
+    if (x)
+      report.xAxis = 0;
+    if (y)
+      report.yAxis = 0;
+    if (vWheel)
+      report.vWheel = 0;
+    if (hWheel)
+      report.hWheel = 0;
+    move(report.xAxis, report.yAxis, report.vWheel, report.hWheel);
+  }
+
   void releaseAll() {
     Mouse.releaseAll();
   }

--- a/src/kaleidoscope_internal/LEDModeManager.h
+++ b/src/kaleidoscope_internal/LEDModeManager.h
@@ -23,7 +23,7 @@
 
 #include <stddef.h>
 
-#ifdef KALEIDOSCOPE_VIRTUAL_BUILD
+#if defined(KALEIDOSCOPE_VIRTUAL_BUILD) || defined(ARDUINO_ARCH_STM32)
 #include <new>
 #else
 


### PR DESCRIPTION
This includes a small batch of fixes aimed at making it easier to port Kaleidoscope to different Arduino Cores, perhaps even ones that do not support KeyboardioHID.

Included changes are:
- We should not redefine `new` on STM32 (used by LEDModeManager). There might be better ways to do the same thing, this was easiest.
- `driver::hid::Keyboardio` has been restricted to not compile when using a core that does not support PluggableUSB.
- `device::Base` has been switched to use `hid::Base` as default, rather than `hid::Keyboardio`, so that we can support different HID drivers. All appropriate place have been updated to explicitly set `hid::Keyboardio`.
- Moved `driver::hid::mouse::stop` from the base class to the specific implementation, to avoid a dependency on KeyboardioHID in the base class.
- `driver::hid::mouse::getReport()` has been removed for the same reason. There are no past or present users, and it shouldn't have been exposed in the first place.
- The base HID driver defines `HID_BOOT_PROTOCOL` if it is undefined, to remove a dependency on KeyboardioHID.

Basically, these changes make it not only theoretically, but practically possible to use a different HID driver, if need be. The LEDModeManager is unrelated to HID, but still a portability bug, so I lumped it in here.