### PR TITLE
Unicode: Allow setting the key used for starting Unicode input on Linux

### DIFF
--- a/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.cpp
+++ b/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.cpp
@@ -21,17 +21,18 @@ namespace kaleidoscope {
 namespace plugin {
 
 uint8_t Unicode::input_delay_;
+Key Unicode::linux_key_ = Key_U;
 
 void Unicode::start(void) {
   switch (::HostOS.os()) {
   case hostos::LINUX:
     kaleidoscope::Runtime.hid().keyboard().pressRawKey(Key_LeftControl);
     kaleidoscope::Runtime.hid().keyboard().pressRawKey(Key_LeftShift);
-    kaleidoscope::Runtime.hid().keyboard().pressRawKey(Key_U);
+    kaleidoscope::Runtime.hid().keyboard().pressRawKey(linux_key_);
     kaleidoscope::Runtime.hid().keyboard().sendReport();
     kaleidoscope::Runtime.hid().keyboard().releaseRawKey(Key_LeftControl);
     kaleidoscope::Runtime.hid().keyboard().releaseRawKey(Key_LeftShift);
-    kaleidoscope::Runtime.hid().keyboard().releaseRawKey(Key_U);
+    kaleidoscope::Runtime.hid().keyboard().releaseRawKey(linux_key_);
     kaleidoscope::Runtime.hid().keyboard().sendReport();
     break;
   case hostos::WINDOWS:

--- a/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.h
+++ b/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.h
@@ -39,7 +39,15 @@ class Unicode : public kaleidoscope::Plugin {
   static uint8_t input_delay() {
     return input_delay_;
   }
+
+  static void setLinuxKey(const Key key) {
+    linux_key_ = key;
+  }
+  static Key getLinuxKey() {
+    return linux_key_;
+  }
  private:
+  static Key linux_key_;
   static uint8_t input_delay_;
 };
 }


### PR DESCRIPTION
To account for non-qwerty host-side layouts, we want to be able to easily set the last part of the sequence used to start Unicode input on Linux. The newly introduced `Unicode.setLinuxKey(Key_S)` function does just that.

Fixes #1063.
