### PR TITLE
Unicode: Use the numpad to input digits on Linux too

### DIFF
--- a/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.cpp
+++ b/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.cpp
@@ -95,7 +95,7 @@ void Unicode::typeCode(uint32_t unicode) {
     if (digit == 0) {
       if (on_zero_start == false) {
         Key key;
-        if (::HostOS.os() == hostos::WINDOWS) {
+        if (::HostOS.os() != hostos::OSX) {
           key = hexToKeysWithNumpad(digit);
         } else {
           key = hexToKey(digit);
@@ -109,7 +109,7 @@ void Unicode::typeCode(uint32_t unicode) {
       }
     } else {
       Key key;
-      if (::HostOS.os() == hostos::WINDOWS) {
+      if (::HostOS.os() != hostos::OSX) {
         key = hexToKeysWithNumpad(digit);
       } else {
         key = hexToKey(digit);


### PR DESCRIPTION
When there are different input methods available on Linux (Chinese, Japanese, etc), using the numpad is more reliable than the number row. As both work, rather than making it configurable, just switch to numpad on Linux.

Fixes #1064.
