### PR TITLE
Migrate from hostos::OSX to hostos::MACOS

### DIFF
--- a/examples/Features/AppSwitcher/AppSwitcher.cpp
+++ b/examples/Features/AppSwitcher/AppSwitcher.cpp
@@ -40,7 +40,7 @@ EventHandlerResult AppSwitcher::onKeyEvent(KeyEvent &event) {
 
     // If AppSwitcher was not already active, hold its modifier first.
     if (!active_addr_.isValid()) {
-      if (::HostOS.os() == hostos::OSX) {
+      if (::HostOS.os() == hostos::MACOS) {
         event.key = Key_LeftGui;
       } else {
         event.key = Key_LeftAlt;

--- a/plugins/Kaleidoscope-HostOS/README.md
+++ b/plugins/Kaleidoscope-HostOS/README.md
@@ -25,8 +25,8 @@ void someFunction(void) {
   if (HostOS.os() == kaleidoscope::hostos::LINUX) {
     // do something linux-y
   }
-  if (HostOS.os() == kaleidoscope::hostos::OSX) {
-    // do something OSX-y
+  if (HostOS.os() == kaleidoscope::hostos::MACOS) {
+    // do something macOS-y
   }
 }
 
@@ -55,9 +55,12 @@ The extension provides the following methods on the `HostOS` singleton:
 The OS type (i.e. the return type of `.os()` and the arguments to `.os(type)`) will be one of the following:
 
    - `kaleidoscope::hostos::LINUX`
-   - `kaleidoscope::hostos::OSX`
+   - `kaleidoscope::hostos::MACOS`
    - `kaleidoscope::hostos::WINDOWS`
    - `kaleidoscope::hostos::OTHER`
+
+For compability reasons, `kaleidoscope::hostos::OSX` is an alias to
+`kaleidoscope::hostos::MACOS`.
 
 ## Focus commands
 

--- a/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS.h
+++ b/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-HostOS -- Host OS detection and tracking for Kaleidoscope
- * Copyright (C) 2016, 2017, 2018  Keyboard.io, Inc
+ * Copyright (C) 2016-2021  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -25,7 +25,8 @@ namespace hostos {
 
 typedef enum {
   LINUX,
-  OSX,
+  MACOS,
+  OSX = MACOS,
   WINDOWS,
   OTHER,
 

--- a/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.cpp
+++ b/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.cpp
@@ -42,7 +42,7 @@ void Unicode::start(void) {
     kaleidoscope::Runtime.hid().keyboard().releaseRawKey(Key_KeypadAdd);
     kaleidoscope::Runtime.hid().keyboard().sendReport();
     break;
-  case hostos::OSX:
+  case hostos::MACOS:
     kaleidoscope::Runtime.hid().keyboard().pressRawKey(Key_LeftAlt);
     break;
   default:
@@ -56,7 +56,7 @@ void Unicode::input(void) {
   case hostos::LINUX:
     break;
   case hostos::WINDOWS:
-  case hostos::OSX:
+  case hostos::MACOS:
     kaleidoscope::Runtime.hid().keyboard().pressRawKey(Key_LeftAlt);
     break;
   default:
@@ -75,7 +75,7 @@ void Unicode::end(void) {
     kaleidoscope::Runtime.hid().keyboard().sendReport();
     break;
   case hostos::WINDOWS:
-  case hostos::OSX:
+  case hostos::MACOS:
     kaleidoscope::Runtime.hid().keyboard().releaseRawKey(Key_LeftAlt);
     kaleidoscope::Runtime.hid().keyboard().sendReport();
     break;


### PR DESCRIPTION
As Apple started to call their operating system `macOS` rather than `OSX` a while ago, we should follow suit. This patchset changes the `HostOS` plugin to use `hostos::MACOS` (but keep `hostos::OSX` as an alias, indefinitely), documents the change in the readme, and also changes all internal users to use the new name.