### PR TITLE
CharShift: Configuration plugin

### DIFF
--- a/plugins/Kaleidoscope-CharShift/src/kaleidoscope/plugin/CharShift.cpp
+++ b/plugins/Kaleidoscope-CharShift/src/kaleidoscope/plugin/CharShift.cpp
@@ -34,6 +34,10 @@ namespace plugin {
 // CharShift class variables
 CharShift::KeyPair const * CharShift::progmem_keypairs_{nullptr};
 uint8_t CharShift::num_keypairs_{0};
+CharShift::GetNumKeyPairsFunction CharShift::numKeyPairs_ =
+    CharShift::numProgmemKeyPairs;
+CharShift::ReadKeyPairFunction CharShift::readKeyPair_ =
+    CharShift::readKeyPairFromProgmem;
 
 bool CharShift::reverse_shift_state_{false};
 
@@ -117,22 +121,10 @@ bool CharShift::isCharShiftKey(Key key) {
 
 CharShift::KeyPair CharShift::decodeCharShiftKey(Key key) {
   uint8_t i = key.getRaw() - ranges::CS_FIRST;
-  if (i < numKeyPairs()) {
-    return readKeyPair(i);
+  if (i < numKeyPairs_()) {
+    return readKeyPair_(i);
   }
   return {Key_NoKey, Key_NoKey};
-}
-
-// This should be overridden if the KeyPairs array is stored in EEPROM
-__attribute__((weak))
-uint8_t CharShift::numKeyPairs() {
-  return numProgmemKeyPairs();
-}
-
-// This should be overridden if the KeyPairs array is stored in EEPROM
-__attribute__((weak))
-CharShift::KeyPair CharShift::readKeyPair(uint8_t n) {
-  return readKeyPairFromProgmem(n);
 }
 
 uint8_t CharShift::numProgmemKeyPairs() {

--- a/plugins/Kaleidoscope-CharShift/src/kaleidoscope/plugin/CharShift.h
+++ b/plugins/Kaleidoscope-CharShift/src/kaleidoscope/plugin/CharShift.h
@@ -76,11 +76,24 @@ class CharShift : public Plugin {
     num_keypairs_ = _num_keypairs;
   }
 
+  typedef uint8_t (*GetNumKeyPairsFunction)();
+  typedef KeyPair (*ReadKeyPairFunction)(uint8_t n);
+
+  static void setNumKeyPairsFunction(GetNumKeyPairsFunction f) {
+    numKeyPairs_ = f;
+  }
+  static void setReadKeyPairFunction(ReadKeyPairFunction f) {
+    readKeyPair_ = f;
+  }
+
  private:
   // A pointer to an array of `KeyPair` objects in PROGMEM
   static KeyPair const * progmem_keypairs_;
   // The size of the PROGMEM array of `KeyPair` objects
   static uint8_t num_keypairs_;
+
+  static GetNumKeyPairsFunction numKeyPairs_;
+  static ReadKeyPairFunction readKeyPair_;
 
   // If a `shift` key needs to be suppressed in `beforeReportingState()`
   static bool reverse_shift_state_;
@@ -90,18 +103,6 @@ class CharShift : public Plugin {
 
   /// Look up the `KeyPair` specified by the given keymap entry
   static KeyPair decodeCharShiftKey(Key key);
-
-  /// Get the total number of KeyPairs defined
-  ///
-  /// This function can be overridden in order to store the `KeyPair` array in
-  /// EEPROM instead of PROGMEM.
-  static uint8_t numKeyPairs();
-
-  /// Get the `KeyPair` at the specified index from the defined `KeyPair` array
-  ///
-  /// This function can be overridden in order to store the `KeyPair` array in
-  /// EEPROM instead of PROGMEM.
-  static KeyPair readKeyPair(uint8_t n);
 
   // Default for `keypairsCount()`: size of the PROGMEM array
   static uint8_t numProgmemKeyPairs();

--- a/plugins/Kaleidoscope-CharShift/src/kaleidoscope/plugin/CharShift.h
+++ b/plugins/Kaleidoscope-CharShift/src/kaleidoscope/plugin/CharShift.h
@@ -86,6 +86,8 @@ class CharShift : public Plugin {
     readKeyPair_ = f;
   }
 
+  friend class CharShiftConfig;
+
  private:
   // A pointer to an array of `KeyPair` objects in PROGMEM
   static KeyPair const * progmem_keypairs_;
@@ -110,10 +112,34 @@ class CharShift : public Plugin {
   static KeyPair readKeyPairFromProgmem(uint8_t n);
 };
 
+class CharShiftConfig: public Plugin {
+ public:
+  CharShiftConfig() {}
+
+  EventHandlerResult onNameQuery();
+  EventHandlerResult onFocusEvent(const char *command);
+
+  static void setup(uint8_t dynamic_offset, uint8_t max_pairs);
+
+ private:
+  static uint8_t max_pairs_;
+  static uint16_t storage_base_;
+  static uint8_t dynamic_offset_;
+
+  static uint8_t numEEPROMPairs() {
+    return max_pairs_;
+  }
+  static CharShift::KeyPair readKeyPairFromEEPROM(uint8_t n);
+
+  static uint8_t numPairs();
+  static CharShift::KeyPair readKeyPair(uint8_t n);
+};
+
 } // namespace plugin
 } // namespace kaleidoscope
 
 extern kaleidoscope::plugin::CharShift CharShift;
+extern kaleidoscope::plugin::CharShiftConfig CharShiftConfig;
 
 /// Define an array of `KeyPair` objects in PROGMEM
 ///

--- a/plugins/Kaleidoscope-CharShift/src/kaleidoscope/plugin/CharShiftConfig.cpp
+++ b/plugins/Kaleidoscope-CharShift/src/kaleidoscope/plugin/CharShiftConfig.cpp
@@ -1,0 +1,110 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-CharShift -- Independently assign shifted and unshifted symbols
+ * Copyright (C) 2021  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "kaleidoscope/plugin/CharShift.h"
+
+#include <Kaleidoscope-FocusSerial.h>
+#include <Kaleidoscope-EEPROM-Settings.h>
+
+#include "kaleidoscope/Runtime.h"
+
+namespace kaleidoscope {
+namespace plugin {
+
+// =============================================================================
+// CharShiftConfig class variables
+
+uint8_t CharShiftConfig::max_pairs_;
+uint8_t CharShiftConfig::dynamic_offset_;
+uint16_t CharShiftConfig::storage_base_;
+
+// =============================================================================
+// Event handlers
+
+EventHandlerResult CharShiftConfig::onNameQuery() {
+  return ::Focus.sendName(F("CharShiftConfig"));
+}
+
+EventHandlerResult CharShiftConfig::onFocusEvent(const char *command) {
+  if (::Focus.handleHelp(command, PSTR("charshift.map")))
+    return EventHandlerResult::OK;
+
+  if (strcmp_P(command, PSTR("charshift.map")) != 0)
+    return EventHandlerResult::OK;
+
+  if (::Focus.isEOL()) {
+    // We dump key by key, rather than pairs, because the end result is the
+    // same, and dumping one by one is less code.
+    for (uint16_t i = 0; i < max_pairs_ * 2; i += 2) {
+      Key k;
+
+      Runtime.storage().get(storage_base_ + i, k);
+      ::Focus.send(k);
+    }
+  } else {
+    uint16_t pos = 0;
+
+    // We read one key at a time, rather than a keypair, to better handle
+    // partials and failure, and to make the code simpler.
+    while (!::Focus.isEOL()) {
+      Key k;
+
+      ::Focus.read(k);
+      Runtime.storage().put(storage_base_ + pos, k);
+      pos += 2;
+    }
+    Runtime.storage().commit();
+  }
+
+  return EventHandlerResult::EVENT_CONSUMED;
+}
+
+// =============================================================================
+// Support functions
+
+void CharShiftConfig::setup(uint8_t dynamic_offset, uint8_t max_pairs) {
+  dynamic_offset_ = dynamic_offset;
+  max_pairs_ = max_pairs;
+
+  storage_base_ = ::EEPROMSettings.requestSlice(max_pairs * 4);
+  ::CharShift.setNumKeyPairsFunction(numPairs);
+  ::CharShift.setReadKeyPairFunction(readKeyPair);
+}
+
+CharShift::KeyPair CharShiftConfig::readKeyPairFromEEPROM(uint8_t n) {
+  uint16_t pos = storage_base_ + n * 4; // 4: Size of a keypair.
+  uint16_t raw_lower = Runtime.storage().read(pos);
+  uint16_t raw_upper = Runtime.storage().read(pos + 2);
+
+  return CharShift::KeyPair(Key(raw_lower), Key(raw_upper));
+}
+
+uint8_t CharShiftConfig::numPairs() {
+  return CharShift::numProgmemKeyPairs() + numEEPROMPairs();
+}
+
+CharShift::KeyPair CharShiftConfig::readKeyPair(uint8_t n) {
+  if (n < dynamic_offset_) {
+    return CharShift::readKeyPairFromProgmem(n);
+  }
+  return readKeyPairFromEEPROM(n - dynamic_offset_);
+}
+
+} // namespace plugin
+} // namespace kaleidoscope
+
+kaleidoscope::plugin::CharShiftConfig CharShiftConfig;


### PR DESCRIPTION
This is a plugin on top of `CharShift`, similar to `AutoShiftConfig` and inspired by `DynamicTapDance`. Apart from a very quick compile, it is completely untested.

The core idea is that we have two function pointers in `CharShift` that allows anyone to override the `numKeyPairs()` and `readKeyPair()` functions, but without relying on weak symbols, and the `CharShiftConfig` uses this to extend the charshift map. The map is simply stored as an array of key pairs in EEPROM, allocation is to be done in `setup()`, as `CharShiftConfig.setup(0, 4)` (to allocate 4 keypairs, starting at index 0, thus, a complete override in this case).

There's at least one thing missing: we need to be able to query the dynamic offset via Focus, so Chrysalis can present the editor in the future correctly.