### PR TITLE
[WIP] Add (builtin) ModLayer combination keys

### DIFF
--- a/examples/Features/ModLayer/ModLayer.ino
+++ b/examples/Features/ModLayer/ModLayer.ino
@@ -1,0 +1,69 @@
+// -*- mode: c++ -*-
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-Qukeys.h>
+
+// *INDENT-OFF*
+KEYMAPS(
+  [0] = KEYMAP_STACKED
+  (
+      Key_NoKey,    Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
+      Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+      Key_PageUp,   Key_A, Key_S, Key_D, Key_F, Key_G,
+      Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+
+      Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+      ML(LeftShift, 1),
+
+      XXX,       Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
+      Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
+                 Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
+      Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
+
+      Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
+      ShiftToLayer(1)
+   ),
+  [1] = KEYMAP_STACKED
+  (
+      ___,   Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+
+      Key_1, Key_2, Key_3, Key_4,
+      ___,
+
+
+      ___,   Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+
+      Key_1, Key_2, Key_3, Key_4,
+      ___
+   ),
+)
+// *INDENT-ON*
+
+// Use Qukeys
+KALEIDOSCOPE_INIT_PLUGINS(Qukeys);
+
+void setup() {
+  QUKEYS(
+    kaleidoscope::plugin::Qukey(0, KeyAddr(2, 1), Key_LeftGui),      // A/cmd
+    kaleidoscope::plugin::Qukey(0, KeyAddr(2, 2), Key_LeftAlt),      // S/alt
+    kaleidoscope::plugin::Qukey(0, KeyAddr(2, 3), Key_LeftControl),  // D/ctrl
+    kaleidoscope::plugin::Qukey(0, KeyAddr(2, 4), Key_LeftShift),    // F/shift
+
+    kaleidoscope::plugin::Qukey(0, KeyAddr(1, 1), ML(LeftGui, 1)),      // Q/cmd+1
+    kaleidoscope::plugin::Qukey(0, KeyAddr(1, 2), ML(LeftAlt, 1)),      // W/alt+1
+    kaleidoscope::plugin::Qukey(0, KeyAddr(1, 3), ML(LeftControl, 1)),  // E/ctrl+1
+    kaleidoscope::plugin::Qukey(0, KeyAddr(1, 4), ML(LeftShift, 1))     // R/shift+1
+  )
+
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/examples/Features/ModLayer/sketch.json
+++ b/examples/Features/ModLayer/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:model01",
+    "port": ""
+  }
+}

--- a/plugins/Kaleidoscope-LED-ActiveModColor/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/plugins/Kaleidoscope-LED-ActiveModColor/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -44,8 +44,7 @@ EventHandlerResult ActiveModColorEffect::onKeyEvent(KeyEvent &event) {
     // If a key toggles on, we check its value. If it's a OneShot key, it will
     // get highlighted. Conditionally (if `highlight_normal_modifiers_` is set),
     // we also highlight modifier and layer-shift keys.
-    if (event.key.isKeyboardModifier() ||
-        event.key.isLayerShift() ||
+    if (event.key.isMomentary() ||
         ::OneShot.isOneShotKey(event.key) ||
         ::OneShot.isActive(event.addr)) {
       mod_key_bits_.set(event.addr);

--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.cpp
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.cpp
@@ -239,8 +239,7 @@ EventHandlerResult OneShot::onKeyEvent(KeyEvent& event) {
           (auto_layers_ && event.key.isLayerShift())) {
         temp_addrs_.set(event.addr);
         start_time_ = Runtime.millisAtCycleStart();
-      } else if (!event.key.isKeyboardModifier() &&
-                 !event.key.isLayerShift()) {
+      } else if (!event.key.isMomentary()) {
         // Only trigger release of temporary one-shot keys if the pressed key is
         // neither a modifier nor a layer shift. We need the actual release of
         // those keys to happen after the current event is finished, however, so

--- a/src/kaleidoscope/Runtime.cpp
+++ b/src/kaleidoscope/Runtime.cpp
@@ -163,9 +163,13 @@ Runtime_::handleKeyEvent(KeyEvent event) {
       event.key == Key_Transparent)
     return;
 
-  // If it's a built-in Layer key, we handle it here, and skip sending report(s)
-  if (event.key.isLayerKey()) {
+  // Built-in layer change keys are handled by the Layer object.
+  if (event.key.isLayerKey() || event.key.isModLayerKey()) {
     Layer.handleLayerKeyEvent(event);
+  }
+  // If the event is for a layer change key, there's no need to send a HID
+  // report, so we return early.
+  if (event.key.isLayerKey()) {
     return;
   }
 
@@ -266,6 +270,11 @@ Runtime_::addToReport(Key key) {
   auto result = Hooks::onAddToReport(key);
   if (result == EventHandlerResult::ABORT)
     return;
+
+  if (key.isModLayerKey()) {
+    uint8_t mod = key.getKeyCode() % 8;
+    key = Key(Key_LeftControl.getRaw() + mod);
+  }
 
   if (key.isKeyboardKey()) {
     // The only incidental Keyboard modifiers that are allowed are the ones on

--- a/src/kaleidoscope/key_defs.h
+++ b/src/kaleidoscope/key_defs.h
@@ -52,6 +52,12 @@
 #define SWITCH_TO_KEYMAP  0b00000100
 #define IS_CONSUMER       0b00001000
 
+// consumer: 01..1...
+// sysctl:   01..0001
+// layer:    01000100
+// modlayer: 01000110
+// macros:   01100000
+
 // HID Usage Types: Because these constants, like the ones above, are
 // used in the flags byte of the Key class, they can't overlap any of
 // the above bits. Nor can we use `SYNTHETIC` and `RESERVED` to encode
@@ -186,6 +192,9 @@ class Key {
   constexpr bool isLayerKey() const {
     return (flags_ == (SYNTHETIC | SWITCH_TO_KEYMAP));
   }
+  constexpr bool isModLayerKey() const {
+    return (flags_ == (SYNTHETIC | SWITCH_TO_KEYMAP | IS_INTERNAL));
+  }
 
   // ---------------------------------------------------------------------------
   // Additional utility functions for builtin `Key` variants
@@ -212,19 +221,26 @@ class Key {
   // used in a conceptually different way: to get a different symbol in the
   // output. We don't normally think "type `shift`+`1`"; we think "type `!`".
   constexpr bool isKeyboardShift() const {
-    return (isKeyboardModifier() &&
-            ((keyCode_ == HID_KEYBOARD_LEFT_SHIFT ||
-              keyCode_ == HID_KEYBOARD_RIGHT_SHIFT) ||
-             ((flags_ & SHIFT_HELD) != 0)));
+    return ((isKeyboardModifier() &&
+             ((keyCode_ == HID_KEYBOARD_LEFT_SHIFT ||
+               keyCode_ == HID_KEYBOARD_RIGHT_SHIFT) ||
+              ((flags_ & SHIFT_HELD) != 0))) ||
+            (isModLayerKey() &&
+             (keyCode_ % 8) % 4 == 1));
   }
   // Layer shift keys are conceptually similar to Keyboard modifier keys in that
   // they are used chorded to change the result of typing those other
   // keys. They're even more similar to `shift` keys. For both reasons, it's
   // worth singling them out.
   constexpr bool __attribute__((always_inline)) isLayerShift() const {
-    return (isLayerKey() &&
-            keyCode_ >= LAYER_SHIFT_OFFSET &&
-            keyCode_ < LAYER_MOVE_OFFSET);
+    return ((isLayerKey() &&
+             keyCode_ >= LAYER_SHIFT_OFFSET &&
+             keyCode_ < LAYER_MOVE_OFFSET) ||
+            isModLayerKey());
+  }
+
+  constexpr bool isMomentary() const {
+    return (isKeyboardModifier() || isLayerShift() || isModLayerKey());
   }
 
  private:
@@ -259,6 +275,14 @@ constexpr Key convertToKey(Key k) {
 
 constexpr Key addFlags(Key k, uint8_t add_flags) {
   return Key(k.getKeyCode(), k.getFlags() | add_flags);
+}
+
+// =============================================================================
+/// Generate a ModLayer key (unchecked)
+constexpr Key modLayerKey(Key modifier, uint8_t layer) {
+  uint8_t mod = modifier.getRaw() - Key_LeftControl.getRaw();
+  uint8_t code = mod + (layer * 8);
+  return Key(code, SYNTHETIC | SWITCH_TO_KEYMAP | IS_INTERNAL);
 }
 
 } // namespace kaleidoscope

--- a/src/kaleidoscope/key_defs/keymaps.h
+++ b/src/kaleidoscope/key_defs/keymaps.h
@@ -77,3 +77,6 @@ static const uint8_t LAYER_MOVE_OFFSET = LAYER_SHIFT_OFFSET + LAYER_OP_OFFSET;;
  * this is a one-way operation.
  */
 #define MoveToLayer(n) Key(n + LAYER_MOVE_OFFSET, KEY_FLAGS | SYNTHETIC | SWITCH_TO_KEYMAP)
+
+// Shorthand for keymap entry (e.g. `ML(LeftAlt, 3)`)
+#define ML(mod, layer) kaleidoscope::modLayerKey(Key_ ## mod, layer)

--- a/src/kaleidoscope/layers.cpp
+++ b/src/kaleidoscope/layers.cpp
@@ -54,6 +54,11 @@ void Layer_::handleLayerKeyEvent(const KeyEvent &event) {
   // The caller is responsible for checking that this is a Layer `Key`, so we
   // skip checking for it here.
   uint8_t key_code = event.key.getKeyCode();
+
+  // If this is a ModLayer key, we need to convert it into a layer shift first.
+  if (event.key.isModLayerKey())
+    key_code = (key_code / 8) + LAYER_SHIFT_OFFSET;
+
   uint8_t target_layer;
 
   if (key_code >= LAYER_MOVE_OFFSET) {

--- a/tests/features/layers/mod-layer/mod-layer.ino
+++ b/tests/features/layers/mod-layer/mod-layer.ino
@@ -1,0 +1,74 @@
+// -*- mode: c++ -*-
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-Qukeys.h>
+
+// *INDENT-OFF*
+KEYMAPS(
+  [0] = KEYMAP_STACKED
+  (
+      Key_NoKey,    Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
+      Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+      Key_PageUp,   Key_A, Key_S, Key_D, Key_F, Key_G,
+      Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+
+      Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+      ML(LeftShift, 1),
+
+      XXX,       Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
+      Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
+                 Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
+      Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
+
+      Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
+      ShiftToLayer(1)
+   ),
+  [1] = KEYMAP_STACKED
+  (
+      ___,   Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+
+      Key_1, Key_2, Key_3, Key_4,
+      ___,
+
+
+      ___,   Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+
+      Key_1, Key_2, Key_3, Key_4,
+      ___
+   ),
+)
+// *INDENT-ON*
+
+// Use Qukeys
+KALEIDOSCOPE_INIT_PLUGINS(Qukeys);
+
+void setup() {
+  QUKEYS(
+    kaleidoscope::plugin::Qukey(0, KeyAddr(2, 1), Key_LeftGui),      // A/cmd
+    kaleidoscope::plugin::Qukey(0, KeyAddr(2, 2), Key_LeftAlt),      // S/alt
+    kaleidoscope::plugin::Qukey(0, KeyAddr(2, 3), Key_LeftControl),  // D/ctrl
+    kaleidoscope::plugin::Qukey(0, KeyAddr(2, 4), Key_LeftShift),    // F/shift
+
+    kaleidoscope::plugin::Qukey(0, KeyAddr(1, 1), ML(LeftGui, 1)),      // Q/cmd+1
+    kaleidoscope::plugin::Qukey(0, KeyAddr(1, 2), ML(LeftAlt, 1)),      // W/alt+1
+    kaleidoscope::plugin::Qukey(0, KeyAddr(1, 3), ML(LeftControl, 1)),  // E/ctrl+1
+    kaleidoscope::plugin::Qukey(0, KeyAddr(1, 4), ML(LeftShift, 1))     // R/shift+1
+  );
+  Qukeys.setHoldTimeout(20);
+  Qukeys.setOverlapThreshold(0);
+  Qukeys.setMinimumHoldTime(0);
+  Qukeys.setMinimumPriorInterval(0);
+  Qukeys.setMaxIntervalForTapRepeat(10);
+
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/features/layers/mod-layer/sketch.json
+++ b/tests/features/layers/mod-layer/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:model01",
+    "port": ""
+  }
+}

--- a/tests/features/layers/mod-layer/test.ktest
+++ b/tests/features/layers/mod-layer/test.ktest
@@ -1,0 +1,76 @@
+VERSION 1
+
+KEYSWITCH QML   1  1
+KEYSWITCH A     0  1
+KEYSWITCH MLB   3  6
+
+
+# ==============================================================================
+NAME Foo
+
+RUN 4 ms
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_1
+
+RUN 4 ms
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+RUN 4 ms
+PRESS MLB
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift
+
+RUN 4 ms
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift Key_B
+
+RUN 4 ms
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift
+
+RUN 4 ms
+RELEASE MLB
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+RUN 4 ms
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_1
+
+RUN 4 ms
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+RUN 5 ms
+
+# ==============================================================================
+NAME Qukeys ModLayer
+
+RUN 4 ms
+PRESS QML
+RUN 1 cycle
+
+RUN 4 ms
+PRESS A
+RUN 1 cycle
+
+RUN 4 ms
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftGui
+EXPECT keyboard-report Key_LeftGui Key_B
+EXPECT keyboard-report Key_LeftGui
+
+RUN 4 ms
+RELEASE QML
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+RUN 5 ms


### PR DESCRIPTION
This is a replacement for #1051, but with support for ModLayer keys in the Kaleidoscope core.  This way, the feature takes substantially less space in PROGMEM (~250 bytes), and provides more functionality (plugins can treat ModLayer keys the same way as other "momentary" keys.

There are a number of open questions about how to this should be implemented (function naming, keymap markup, helper function(s)), but the basic functionality is there.