### PR TITLE
Use POSIX compatible shell read

### DIFF
--- a/etc/makefiles/sketch.mk
+++ b/etc/makefiles/sketch.mk
@@ -214,7 +214,7 @@ flash: ensure-device-port-defined
 	$(info )
 	$(info When you're ready to proceed, press 'Enter'.)
 	$(info )
-	@$(shell read)
+	@$(shell read _)
 	$(QUIET) $(ARDUINO_CLI) upload --fqbn $(FQBN) \
 	  --input-dir "${OUTPUT_PATH}" \
 	  --port $(KALEIDOSCOPE_DEVICE_PORT) $(ARDUINO_VERBOSE)


### PR DESCRIPTION
With Dash, and presumably other shells that aren't Bash, calling read
with no arguments produces the error:

	/bin/sh: 1: read: arg count

Passing a dummy argument produces the desired behavior.