### PR TITLE
Add ranges import to escape-oneshot plugin

### DIFF
--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.h
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "kaleidoscope/Runtime.h"
+#include <Kaleidoscope-Ranges.h>
 
 constexpr Key OneShotCancelKey {kaleidoscope::ranges::OS_CANCEL};
 


### PR DESCRIPTION
Fix compilation issue with escape-oneshot plugin referencing unknown kaleidoscope::ranges.

```
Kaleidoscope/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.h:22:47: error: 'kaleidoscope::ranges' has not been declared
 constexpr Key OneShotCancelKey {kaleidoscope::ranges::OS_CANCEL};
```

Signed-off-by: Justin Moy <justincmoy@users.noreply.github.com>