### PR TITLE
Atreus: Add build date/time to version info

### DIFF
--- a/examples/Devices/Keyboardio/Atreus/Atreus.ino
+++ b/examples/Devices/Keyboardio/Atreus/Atreus.ino
@@ -18,7 +18,7 @@
  */
 
 #ifndef BUILD_INFORMATION
-#define BUILD_INFORMATION "locally built"
+#define BUILD_INFORMATION "locally built on " __DATE__ " at " __TIME__
 #endif
 
 #include "Kaleidoscope.h"


### PR DESCRIPTION
Example output:

    Keyboardio Atreus - Kaleidoscope locally built on Sep  3 2021 at 09:40:27

Let me note that I've only tested this on my Model01 (https://github.com/keyboardio/Model01-Firmware/pull/110) and the example output is based on that. I can test on a real Atreus later, but I don't see why anything would be different to the Model01 in this regard.