### PR TITLE
Add keyIsInjected helper

### DIFF
--- a/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShift.cpp
+++ b/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShift.cpp
@@ -127,7 +127,7 @@ EventHandlerResult AutoShift::onKeyswitchEvent(KeyEvent &event) {
 
   // If event.addr is not a physical key, ignore it; some other plugin injected
   // it.  This check should be unnecessary.
-  if (!event.addr.isValid() || (event.state & INJECTED) != 0) {
+  if (!event.addr.isValid() || keyIsInjected(event.state)) {
     return EventHandlerResult::OK;
   }
 

--- a/plugins/Kaleidoscope-Cycle/src/kaleidoscope/plugin/Cycle.cpp
+++ b/plugins/Kaleidoscope-Cycle/src/kaleidoscope/plugin/Cycle.cpp
@@ -56,7 +56,7 @@ EventHandlerResult Cycle::onNameQuery() {
 }
 
 EventHandlerResult Cycle::onKeyEvent(KeyEvent &event) {
-  if (event.state & INJECTED)
+  if (keyIsInjected(event.state))
     return EventHandlerResult::OK;
 
   if (!isCycle(event.key)) {

--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.cpp
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.cpp
@@ -33,7 +33,7 @@ EventHandlerResult EscapeOneShot::onKeyEvent(KeyEvent &event) {
   // sticky. Last, only if there are no OneShot keys currently being held.
   if (event.key == cancel_oneshot_key_ &&
       keyToggledOn(event.state) &&
-      (event.state & INJECTED) == 0 &&
+      !keyIsInjected(event.state) &&
       ::OneShot.isActive()) {
     // Cancel all OneShot keys
     ::OneShot.cancel(true);

--- a/plugins/Kaleidoscope-Heatmap/src/kaleidoscope/plugin/Heatmap.cpp
+++ b/plugins/Kaleidoscope-Heatmap/src/kaleidoscope/plugin/Heatmap.cpp
@@ -144,7 +144,7 @@ EventHandlerResult Heatmap::onKeyEvent(KeyEvent &event) {
     return EventHandlerResult::OK;
 
   // if it is a synthetic key, skip it
-  if (event.state & INJECTED)
+  if (keyIsInjected(event.state))
     return EventHandlerResult::OK;
 
   // if the key is not toggled on, skip it

--- a/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
+++ b/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
@@ -68,7 +68,7 @@ EventHandlerResult AlphaSquareEffect::onKeyEvent(KeyEvent &event) {
   if (::LEDControl.get_mode_index() != led_mode_id_)
     return EventHandlerResult::OK;
 
-  if (event.state & INJECTED)
+  if (keyIsInjected(event.state))
     return EventHandlerResult::OK;
 
   if (event.key < Key_A || event.key > Key_0)

--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.cpp
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.cpp
@@ -215,7 +215,7 @@ EventHandlerResult OneShot::onKeyEvent(KeyEvent& event) {
   // hook functions generate (by calling `injectNormalKey()` via one of the
   // `*OneShot()` functions). There are more robust ways to do this, but since
   // OneShot is intended to react to only physical keypresses, this is adequate.
-  if (event.state & INJECTED)
+  if (keyIsInjected(event.state))
     return EventHandlerResult::OK;
 
   bool temp = temp_addrs_.read(event.addr);

--- a/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.cpp
+++ b/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.cpp
@@ -48,7 +48,7 @@ EventHandlerResult Qukeys::onKeyswitchEvent(KeyEvent &event) {
   }
 
   // If event.addr is not a physical key, ignore it; some other plugin injected it.
-  if (! event.addr.isValid() || (event.state & INJECTED) != 0) {
+  if (! event.addr.isValid() || keyIsInjected(event.state)) {
     return EventHandlerResult::OK;
   }
 

--- a/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadet.cpp
+++ b/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadet.cpp
@@ -100,7 +100,7 @@ EventHandlerResult SpaceCadet::onKeyswitchEvent(KeyEvent &event) {
 
   // If event.addr is not a physical key, ignore it; some other plugin injected
   // it. This check should be unnecessary.
-  if (!event.addr.isValid() || (event.state & INJECTED) != 0) {
+  if (!event.addr.isValid() || keyIsInjected(event.state)) {
     return EventHandlerResult::OK;
   }
 

--- a/plugins/Kaleidoscope-Syster/src/kaleidoscope/plugin/Syster.cpp
+++ b/plugins/Kaleidoscope-Syster/src/kaleidoscope/plugin/Syster.cpp
@@ -68,7 +68,7 @@ EventHandlerResult Syster::onKeyEvent(KeyEvent &event) {
 
   // Always ignore events marked as artificially injected (it might actually be
   // better to drop this, but it's not really clear).
-  if (event.state & INJECTED)
+  if (keyIsInjected(event.state))
     return EventHandlerResult::OK;
 
   // If a Syster key gets pressed while we're reading an input sequence, ignore

--- a/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.cpp
+++ b/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.cpp
@@ -83,7 +83,7 @@ EventHandlerResult TapDance::onKeyswitchEvent(KeyEvent &event) {
   }
 
   // If event.addr is not a physical key, ignore it; some other plugin injected it.
-  if (! event.addr.isValid() || (event.state & INJECTED) != 0) {
+  if (! event.addr.isValid() || keyIsInjected(event.state)) {
     return EventHandlerResult::OK;
   }
 

--- a/src/kaleidoscope/keyswitch_state.h
+++ b/src/kaleidoscope/keyswitch_state.h
@@ -50,3 +50,9 @@
  *   "key-up" event.
  */
 #define keyToggledOff(keyState) (keyWasPressed(keyState) && ! keyIsPressed(keyState))
+
+/* keyIsInjected(): This is true if the key was marked as injected by another
+ * plugin, i.e. it was generated artificially instead of corresponding to a
+ * "real" keypress.
+ */
+#define keyIsInjected(keyState) ((keyState) & INJECTED)

--- a/tests/issues/1061/1061.ino
+++ b/tests/issues/1061/1061.ino
@@ -44,7 +44,7 @@ namespace plugin {
 class OneShotInsert : public Plugin {
  public:
   EventHandlerResult onKeyEvent(KeyEvent &event) {
-    if (keyToggledOn(event.state) && (event.state & INJECTED) == 0 &&
+    if (keyToggledOn(event.state) && !keyIsInjected(event.state) &&
         event.key == Key_Insert && live_keys[event.addr] != event.key)
       ::OneShot.setPending(event.addr);
     return EventHandlerResult::OK;


### PR DESCRIPTION
So that the bits don't have to be masked and checked manually, like with the other helpers. This avoids mistakes like in #1076 (will add a review comment with details shortly).

I was unable to run the tests locally due to #1081, so I'll rely on the CI instead and hope I didn't mess something up. Refactorings were done via:

```
git ls-files | xargs sed -i 's/(event\.state \& INJECTED) != 0/keyIsInjected(event.state)/g'
git ls-files | xargs sed -i 's/(event\.state \& INJECTED) == 0/!keyIsInjected(event.state)/g'  
git ls-files | xargs sed -i 's/(event\.state \& INJECTED)/(keyIsInjected(event.state))/g'   
```