### PR TITLE
Correct `KeyPair` references in CharShift docs

### DIFF
--- a/plugins/Kaleidoscope-CharShift/README.md
+++ b/plugins/Kaleidoscope-CharShift/README.md
@@ -37,10 +37,10 @@ referenced by entries in the keymap.  This is easiest to do by using the
 void setup() {
   Kaleidoscope.setup();
   CS_KEYS(
-    kaleidoscope::plugin::KeyPair(Key_Comma, Key_Semicolon),                   // `,`/`;`
-    kaleidoscope::plugin::KeyPair(Key_Period, LSHIFT(Key_Semicolon)),          // `.`/`:`
-    kaleidoscope::plugin::KeyPair(LSHIFT(Key_9), Key_LeftBracket),             // `(`/`[`
-    kaleidoscope::plugin::KeyPair(LSHIFT(Key_Comma), LSHIFT(Key_LeftBracket)), // `<`/`{`
+    kaleidoscope::plugin::CharShift::KeyPair(Key_Comma, Key_Semicolon),                   // `,`/`;`
+    kaleidoscope::plugin::CharShift::KeyPair(Key_Period, LSHIFT(Key_Semicolon)),          // `.`/`:`
+    kaleidoscope::plugin::CharShift::KeyPair(LSHIFT(Key_9), Key_LeftBracket),             // `(`/`[`
+    kaleidoscope::plugin::CharShift::KeyPair(LSHIFT(Key_Comma), LSHIFT(Key_LeftBracket)), // `<`/`{`
   );
 }
 ```


### PR DESCRIPTION
The `KeyPair` struct is defined inside the `CharShift` class, but the latter was missing from the code sample in the README.