### PR TITLE
Document that Debian's arduino package doesn't work

### DIFF
--- a/docs/setup_toolchain.md
+++ b/docs/setup_toolchain.md
@@ -47,7 +47,7 @@ Next step: [Add keyboard support to Arduino](#add-keyboard-support-to-arduino)
    Snap:        https://snapcraft.io/arduino
    Arch:        sudo pacman -S arduino
    ``` 
-   Unfortunately, the version of the Arduino IDE packaged in Ubuntu is unmaintained and too old to use.
+   Unfortunately, the version of the Arduino IDE packaged in Ubuntu is unmaintained and too old to use, and the version packaged in Debian has been heavily modified and might not be able to compile your keyboard's firmware.
 
 2. Assuming you're using the tar archive, and untarring in the download directory:
 


### PR DESCRIPTION
I was unable to compile the default firmware with the version of arduino that was packaged with Debian. On issue #1098, @obra explained that Debian's version of arduino has been heavily modified, and installing the version of arduino that's available on the arduino website fixed my compilation problems. I have therefore added a note to the docs suggesting not to use the Debian version of arduino.

Fixes #1098 

Signed-off-by: Joshua Hunt