### PR TITLE
DynamicMacros: Allow large macro maps

### DIFF
--- a/plugins/Kaleidoscope-DynamicMacros/README.md
+++ b/plugins/Kaleidoscope-DynamicMacros/README.md
@@ -58,7 +58,8 @@ The plugin provides a `DynamicMacros` object, with the following methods and pro
 
 > Reserves `size` bytes of storage for dynamic macros. This must be called from
 > the `setup()` method of your sketch, otherwise dynamic macros will not
-> function.
+> function. Two bytes of this are used for internal tracking, the remainder is used
+> for your macro map.
 
 ### `.play(macro_id)`
 
@@ -73,21 +74,28 @@ please refer to the documentation therein.
 
 ## Focus commands
 
-The plugin provides two Focus commands: `macros.map` and `macros.trigger`.
+The plugin provides the following Focus commands:
 
 ### `macros.map [macros...]`
 
 > Without arguments, displays all the stored macros. Each macro is terminated by
-> an end marker (`MACRO_ACTION_END`), and the last macro is followed by an
-> additional marker. The plugin will send back the entire dynamic macro storage
-> space, even the data after the final marker.
+> an end marker (`MACRO_ACTION_END`). The plugin will send back only the used
+> dynamic macro storage space.
 
 > With arguments, it replaces the current set of dynamic macros with the newly
-> given ones. Macros are terminated by an end marker, and the last macro must be
-> terminated by an additional one.
+> given ones. Macros are terminated by an end marker.
 
 > In both cases, the data sent or expected is a sequence of 8-bit values, a
 > memory dump.
+
+### `macros.appendMap [macros...]`
+
+> Append to the current macro map. This is provided to allow for macro maps that
+> exceed the serial input buffer for a single line.
+
+### `macros.reset`
+
+> Clear all previously defined macros.
 
 ### `macros.trigger macro_id`
 

--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.h
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.h
@@ -42,8 +42,12 @@ class DynamicMacros : public kaleidoscope::Plugin {
  private:
   static uint16_t storage_base_;
   static uint16_t storage_size_;
+  static uint16_t used_size_base_;
+  static uint16_t used_size_;
   static uint16_t map_[31];
   static void updateDynamicMacroCache();
+  static void resetMap();
+  static void readMap();
   static Key active_macro_keys_[MAX_CONCURRENT_DYNAMIC_MACRO_KEYS];
   static void press(Key key);
   static void release(Key key);


### PR DESCRIPTION
The previous implementation required that the entire macro map be provided all at once on one serial line of input. For large macro maps, this could exceed the input buffer size.

This provides new serial commands `macros.reset` and `macros.appendMap` to allow breaking a large macro map across multiple serial lines. This necessitated an alternate tracking of the end of the macro map, saving it explicitly to be able to pick back up where writing last left off, which allowed some other quality of life improvements:
  - No longer requires the extra `MACRO_ACTION_END`
  - A macros.map read can easily send only the active macro map instead of the entire memory space.

Old serial scripts will continue to work.

Breaking changes:
  - We use two bytes that could previously have been part of a macro map internally. Maps which just fit in the reserved space will need more space reserved.
  - Previously stored maps will need to be recreated, since the use of the storage space has changed.