### PR TITLE
The intent of Focus.drain is to consume input until we hit an \n, and…

### DIFF
--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -27,8 +27,8 @@ namespace plugin {
 char FocusSerial::command_[32];
 
 void FocusSerial::drain(void) {
-    while (Runtime.serialPort().available() && Runtime.serialPort().peek() != '\n')
-      Runtime.serialPort().read();
+  while (Runtime.serialPort().available() && Runtime.serialPort().peek() != '\n')
+    Runtime.serialPort().read();
 }
 
 EventHandlerResult FocusSerial::afterEachCycle() {

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -27,8 +27,7 @@ namespace plugin {
 char FocusSerial::command_[32];
 
 void FocusSerial::drain(void) {
-  if (Runtime.serialPort().available())
-    while (Runtime.serialPort().peek() != '\n')
+    while (Runtime.serialPort().available() && Runtime.serialPort().peek() != '\n')
       Runtime.serialPort().read();
 }
 


### PR DESCRIPTION
… leave that \n in (to be consumed elsewhere)

It's to get to a state where \n is the first in the buffer

The existing implementation could cause a lockup if we got unexpected
input on serial that did not end in "\n"