### PR TITLE
Reimplement focus' parser to work on GD32

### DIFF
--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -63,6 +63,7 @@ EventHandlerResult FocusSerial::afterEachCycle() {
       break;
     }
   }
+  // End of command processing is signalled with a CRLF followed by a single period
   Runtime.serialPort().println(F("\r\n."));
 
 

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -31,11 +31,11 @@ EventHandlerResult FocusSerial::afterEachCycle() {
   // If the serial buffer is empty, we don't have any work to do
   if (Runtime.serialPort().available() == 0) {
     return EventHandlerResult::OK;
-    }
+  }
 
   do {
     command_[buf_cursor_++] = Runtime.serialPort().read();
-  } while ( command_[buf_cursor_ - 1] != SEPARATOR
+  } while (command_[buf_cursor_ - 1] != SEPARATOR
            && buf_cursor_ < sizeof(command_)
            && Runtime.serialPort().available()
            && (Runtime.serialPort().peek() != NEWLINE));
@@ -48,17 +48,17 @@ EventHandlerResult FocusSerial::afterEachCycle() {
     return EventHandlerResult::OK;
   }
 
-  if ( (command_[buf_cursor_ - 1] != SEPARATOR)  && (Runtime.serialPort().peek() != NEWLINE)
-	 && buf_cursor_ < sizeof(command_)
-		  ) {
-	// We don't have enough command to work with yet.
-	// Let's leave the buffer around for another cycle
-  	return EventHandlerResult::OK;
+  if ((command_[buf_cursor_ - 1] != SEPARATOR)  && (Runtime.serialPort().peek() != NEWLINE)
+      && buf_cursor_ < sizeof(command_)
+     ) {
+    // We don't have enough command to work with yet.
+    // Let's leave the buffer around for another cycle
+    return EventHandlerResult::OK;
   }
 
-  // If this was a command with a space-delimited payload, 
+  // If this was a command with a space-delimited payload,
   // strip the space delimiter off
-  if ( (command_[buf_cursor_ - 1] == SEPARATOR) ) {
+  if ((command_[buf_cursor_ - 1] == SEPARATOR)) {
     command_[buf_cursor_ - 1] = '\0';
   }
 

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -33,6 +33,7 @@ void FocusSerial::drain(void) {
 }
 
 EventHandlerResult FocusSerial::afterEachCycle() {
+  // If the serial buffer is empty, we don't have any work to do
   if (Runtime.serialPort().available() == 0)
     return EventHandlerResult::OK;
 

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -42,8 +42,6 @@ EventHandlerResult FocusSerial::afterEachCycle() {
   } while (command_[i - 1] != ' ' && i < 32);
   if (command_[i - 1] == ' ')
     command_[i - 1] = '\0';
-  else
-    command_[i] = '\0';
 
   Runtime.onFocusEvent(command_);
 

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -32,6 +32,8 @@ EventHandlerResult FocusSerial::afterEachCycle() {
     return EventHandlerResult::OK;
 
   uint8_t i = 0;
+  memset(command_, 0, sizeof(command_));
+
   do {
     command_[i++] = Runtime.serialPort().read();
 

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -38,13 +38,13 @@ EventHandlerResult FocusSerial::afterEachCycle() {
   do {
     command_[i++] = Runtime.serialPort().read();
   } while (command_[i - 1] != SEPARATOR
-		  && i < sizeof(command_) 
-		  && Runtime.serialPort().available() 
-		  && (Runtime.serialPort().peek() != NEWLINE ));
+           && i < sizeof(command_)
+           && Runtime.serialPort().available()
+           && (Runtime.serialPort().peek() != NEWLINE));
 
 
   // If this was a command with a space-delimited payload, strip the space delimiter off
-  if (command_[i - 1] == SEPARATOR )
+  if (command_[i - 1] == SEPARATOR)
     command_[i - 1] = '\0';
 
 

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -45,6 +45,12 @@ EventHandlerResult FocusSerial::afterEachCycle() {
   if (command_[i - 1] == SEPARATOR )
     command_[i - 1] = '\0';
 
+
+  // If there was no command, there's nothing to do
+  if (command_[0] == '\0') {
+    return EventHandlerResult::OK;
+  }
+
   Runtime.onFocusEvent(command_);
 
   while (Runtime.serialPort().available()) {

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -31,15 +31,17 @@ EventHandlerResult FocusSerial::afterEachCycle() {
   if (Runtime.serialPort().available() == 0)
     return EventHandlerResult::OK;
 
+
   uint8_t i = 0;
   memset(command_, 0, sizeof(command_));
 
   do {
     command_[i++] = Runtime.serialPort().read();
+  } while (command_[i - 1] != SEPARATOR
+		  && i < sizeof(command_) 
+		  && Runtime.serialPort().available() 
+		  && (Runtime.serialPort().peek() != NEWLINE ));
 
-    if (Runtime.serialPort().peek() == '\n')
-      break;
-  } while (command_[i - 1] != ' ' && i < 32);
 
   // If this was a command with a space-delimited payload, strip the space delimiter off
   if (command_[i - 1] == SEPARATOR )

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -40,7 +40,9 @@ EventHandlerResult FocusSerial::afterEachCycle() {
     if (Runtime.serialPort().peek() == '\n')
       break;
   } while (command_[i - 1] != ' ' && i < 32);
-  if (command_[i - 1] == ' ')
+
+  // If this was a command with a space-delimited payload, strip the space delimiter off
+  if (command_[i - 1] == SEPARATOR )
     command_[i - 1] = '\0';
 
   Runtime.onFocusEvent(command_);

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -25,6 +25,10 @@ class FocusSerial : public kaleidoscope::Plugin {
  public:
   FocusSerial(void) {}
 
+  static constexpr char COMMENT = '#';
+  static constexpr char SEPARATOR = ' ';
+  static constexpr char NEWLINE = '\n';
+
   bool handleHelp(const char *command,
                   const char *help_message);
 
@@ -83,12 +87,9 @@ class FocusSerial : public kaleidoscope::Plugin {
   }
 
   bool isEOL() {
-    return Runtime.serialPort().peek() == '\n';
+    return Runtime.serialPort().peek() == NEWLINE;
   }
 
-  static constexpr char COMMENT = '#';
-  static constexpr char SEPARATOR = ' ';
-  static constexpr char NEWLINE = '\n';
 
   /* Hooks */
   EventHandlerResult afterEachCycle();

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -97,7 +97,7 @@ class FocusSerial : public kaleidoscope::Plugin {
 
  private:
   static char command_[32];
-
+  static uint8_t buf_cursor_;
   static void printBool(bool b);
 };
 }

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -97,7 +97,6 @@ class FocusSerial : public kaleidoscope::Plugin {
  private:
   static char command_[32];
 
-  static void drain(void);
   static void printBool(bool b);
 };
 }


### PR DESCRIPTION
The existing parser could easily get sent into a tailspin due to differences in how the GD32 and AVR CDCACM serial implementations work.


Obsoletes #1104