### PR TITLE
driver/storage/GD32Flash: Fix GD32Flash::commit

### DIFF
--- a/src/kaleidoscope/driver/storage/GD32Flash.h
+++ b/src/kaleidoscope/driver/storage/GD32Flash.h
@@ -37,7 +37,9 @@ class GD32Flash: public EEPROMClass<_StorageProps::length> {
   void setup() {
     EEPROMClass<_StorageProps::length>::begin();
   }
-  void commit() {}
+  void commit() {
+    EEPROMClass<_StorageProps::length>::commit();
+  }
 };
 
 } // namespace storage


### PR DESCRIPTION
The commit method of the GD32Flash storage driver was accidentally left empty, disabling the functionality. Call the parent's commit method to restore it.