### PR TITLE
Distinguish between TapDance "tap" and "hold" timeouts

### DIFF
--- a/plugins/Kaleidoscope-TapDance/README.md
+++ b/plugins/Kaleidoscope-TapDance/README.md
@@ -32,20 +32,22 @@ timer expires, then the tap-dance key will trigger an action first, perform it,
 and only then will the firmware continue handling the interrupting key press.
 This is to preserve the order of keys pressed.
 
-In both of these cases, the [`tapDanceAction`][tdaction] will be called, with
-`tapDanceIndex` set to the index of the tap-dance action (as set in the keymap),
-the `tapCount`, and `tapDanceAction` set to either
-`kaleidoscope::plugin::TapDance::Interrupt`, or
-`kaleidoscope::plugin::TapDance::Timeout`. If we continue holding the key, then
-as long as it is held, the same function will be called with `tapDanceAction`
-set to `kaleidoscope::plugin::TapDance::Hold`. When the key is released, after
-either an `Interrupt` or `Timeout` action was triggered, the function will be
-called with `tapDanceAction` set to `kaleidoscope::plugin::TapDance::Release`.
+In both of these cases, the user-defined `tapDanceAction()` function will be
+called, with `tap_dance_index` set to the index of the tap-dance action (as set
+in the keymap), the `tap_count`, and `tap_dance_action` set to one of the
+following values:
+
+- `kaleidoscope::plugin::TapDance::Hold`, if the tap-dance key is still being
+  held when its timeout expires.
+- `kaleidoscope::plugin::TapDance::Timeout`, if the tap-dance key has been
+  released when its timeout expires.
+- `kaleidoscope::plugin::TapDance::Interrupt`, if another key is pressed before
+  the tap-dance key's timeout expires.
 
 These actions allow us to create sophisticated tap-dance setups, where one can
 tap a key twice and hold it, and have it repeat, for example.
 
-There is one additional value the `tapDanceAction` parameter can take:
+There is one additional value the `tap_dance_action` parameter can take:
 `kaleidoscope::plugin::TapDance::Tap`. It is called with this argument for each
 and every tap, even if no action is to be triggered yet. This is so that we can
 have a way to do some side-effects, like light up LEDs to show progress, and so

--- a/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.h
+++ b/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.h
@@ -36,13 +36,13 @@ namespace kaleidoscope {
 namespace plugin {
 class TapDance : public kaleidoscope::Plugin {
  public:
-  typedef enum {
+  enum ActionType {
     Tap,
     Hold,
     Interrupt,
     Timeout,
     Release,
-  } ActionType;
+  };
 
   TapDance(void) {}
 

--- a/tests/plugins/TapDance/basic/basic.ino
+++ b/tests/plugins/TapDance/basic/basic.ino
@@ -46,8 +46,13 @@ void tapDanceAction(uint8_t tap_dance_index,
                     kaleidoscope::plugin::TapDance::ActionType tap_dance_action) {
   switch (tap_dance_index) {
   case 0:
-    return tapDanceActionKeys(tap_count, tap_dance_action,
-                              Key_A, Key_B, Key_C);
+    if (tap_dance_action == TapDance.Hold) {
+      return tapDanceActionKeys(tap_count, tap_dance_action,
+                                Key_A, Key_H, Key_C);
+    } else {
+      return tapDanceActionKeys(tap_count, tap_dance_action,
+                                Key_A, Key_B, Key_C);
+    }
   default:
     break;
   }

--- a/tests/plugins/TapDance/basic/test.ktest
+++ b/tests/plugins/TapDance/basic/test.ktest
@@ -89,7 +89,7 @@ RUN 10 ms
 PRESS TD_0
 RUN 1 cycle
 RUN 25 ms
-EXPECT keyboard-report Key_B # The report should contain `B`
+EXPECT keyboard-report Key_H # The report should contain `H`
 
 RUN 10 ms
 RELEASE TD_0


### PR DESCRIPTION
We got a request via Discord for TapDance behaviour that would allow different `Key` values depending on whether the TapDance key was tapped or pressed and held (at any tap count).  This is a minimal change that enables such a configuration, by using `ActionType::Hold` if the TapDance key is still being held when it times out, and `ActionType::Timeout` if it has already been released.  The user `tapDanceAction()` function can then check which action type was sent, and call one of two different `tapDanceActionKeys()` functions to get the different key values.