### PR TITLE
driver::storage::GD32Flash: Adjust the default storage size

### DIFF
--- a/src/kaleidoscope/driver/storage/GD32Flash.h
+++ b/src/kaleidoscope/driver/storage/GD32Flash.h
@@ -28,7 +28,7 @@ namespace driver {
 namespace storage {
 
 struct GD32FlashProps : kaleidoscope::driver::storage::BaseProps {
-  static constexpr uint16_t length = 10240;
+  static constexpr uint16_t length = 16384;
 };
 
 template <typename _StorageProps>


### PR DESCRIPTION
Storage must be page aligned and must span full pages. Adjust the default storage size accordingly, so it is a multiple of 4096.