### PR TITLE
Restructure MouseKeys to be aware of Macros virtual keys

### DIFF
--- a/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.h
+++ b/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.h
@@ -57,6 +57,7 @@ class MouseKeys_ : public kaleidoscope::Plugin {
   static constexpr uint8_t move_mask_  = 0b00001111;
   static uint8_t directions_;
   static uint8_t pending_directions_;
+  static uint8_t buttons_;
 
   bool isMouseKey(const Key &key) const;
   bool isMouseButtonKey(const Key &key) const;
@@ -64,7 +65,7 @@ class MouseKeys_ : public kaleidoscope::Plugin {
   bool isMouseWarpKey(const Key &key) const;
   bool isMouseWheelKey(const Key &key) const;
 
-  void sendMouseButtonReport(const KeyEvent &event) const;
+  void sendMouseButtonReport() const;
   void sendMouseWarpReport(const KeyEvent &event) const;
   void sendMouseMoveReport();
   void sendMouseWheelReport();

--- a/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.h
+++ b/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.h
@@ -41,11 +41,18 @@ class MouseKeys_ : public kaleidoscope::Plugin {
   EventHandlerResult onNameQuery();
   EventHandlerResult afterEachCycle();
   EventHandlerResult onKeyEvent(KeyEvent &event);
+  EventHandlerResult onAddToReport(Key key);
+  EventHandlerResult afterReportingState(const KeyEvent &event);
 
  private:
   static uint16_t move_start_time_;
   static uint16_t accel_start_time_;
   static uint16_t wheel_start_time_;
+
+  static uint8_t move_direction_;
+  static uint8_t wheel_direction_;
+  static uint8_t pending_move_direction_;
+  static uint8_t pending_wheel_direction_;
 
   bool isMouseKey(const Key &key) const;
   bool isMouseButtonKey(const Key &key) const;
@@ -55,6 +62,8 @@ class MouseKeys_ : public kaleidoscope::Plugin {
 
   void sendMouseButtonReport(const KeyEvent &event) const;
   void sendMouseWarpReport(const KeyEvent &event) const;
+  void sendMouseMoveReport();
+  void sendMouseWheelReport();
 
 };
 }

--- a/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.h
+++ b/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.h
@@ -49,10 +49,14 @@ class MouseKeys_ : public kaleidoscope::Plugin {
   static uint16_t accel_start_time_;
   static uint16_t wheel_start_time_;
 
-  static uint8_t move_direction_;
-  static uint8_t wheel_direction_;
-  static uint8_t pending_move_direction_;
-  static uint8_t pending_wheel_direction_;
+  // Mouse cursor and wheel movement directions are stored in a single bitfield
+  // to save space.  The low four bits are for cursor movement, and the high
+  // four are for wheel movement.
+  static constexpr uint8_t wheel_offset_ = 4;
+  static constexpr uint8_t wheel_mask_ = 0b11110000;
+  static constexpr uint8_t move_mask_  = 0b00001111;
+  static uint8_t directions_;
+  static uint8_t pending_directions_;
 
   bool isMouseKey(const Key &key) const;
   bool isMouseButtonKey(const Key &key) const;

--- a/tests/issues/1113/1113.ino
+++ b/tests/issues/1113/1113.ino
@@ -1,0 +1,67 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2022  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-Macros.h>
+#include <Kaleidoscope-MouseKeys.h>
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        Key_mouseUp, Key_mouseDn, Key_mouseL, Key_mouseR, ___, ___, ___,
+        Key_mouseScrollUp, Key_mouseScrollDn, Key_mouseScrollL, Key_mouseScrollR, ___, ___, ___,
+        Key_mouseBtnL, Key_mouseBtnM, Key_mouseBtnR, ___, ___, ___,
+        M(0), M(1), ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+const macro_t *macroAction(uint8_t macro_id, KeyEvent &event) {
+  if (keyToggledOn(event.state)) {
+    switch (macro_id) {
+    case 0:
+      Macros.tap(Key_mouseBtnR);
+      break;
+    case 1:
+      Macros.press(Key_mouseScrollUp);
+      Macros.release(Key_mouseScrollUp);
+      break;
+    default:
+      break;
+    }
+  }
+  return MACRO_NONE;
+}
+
+KALEIDOSCOPE_INIT_PLUGINS(Macros, MouseKeys);
+
+void setup() {
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/issues/1113/sketch.json
+++ b/tests/issues/1113/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:virtual:model01",
+    "port": ""
+  }
+}

--- a/tests/issues/1113/test.ktest
+++ b/tests/issues/1113/test.ktest
@@ -1,0 +1,49 @@
+VERSION 1
+
+KEYSWITCH MOVE_UP       0  0
+KEYSWITCH MOVE_DOWN     0  1
+KEYSWITCH MOVE_LEFT     0  2
+KEYSWITCH MOVE_RIGHT    0  3
+
+KEYSWITCH SCROLL_UP     1  0
+KEYSWITCH SCROLL_DOWN   1  1
+KEYSWITCH SCROLL_LEFT   1  2
+KEYSWITCH SCROLL_RIGHT  1  3
+
+KEYSWITCH BUTTON_L      2  0
+KEYSWITCH BUTTON_M      2  1
+KEYSWITCH BUTTON_R      2  2
+
+KEYSWITCH MACRO_0       3  0
+KEYSWITCH MACRO_1       3  1
+
+# ==============================================================================
+NAME Mouse button key tap in Macros
+
+RUN 3 ms
+PRESS MACRO_0
+RUN 1 cycle
+EXPECT mouse-report button=R
+EXPECT mouse-report empty
+
+RUN 5 ms
+RELEASE MACRO_0
+RUN 1 cycle
+EXPECT no mouse-report
+
+RUN 5 ms
+
+# ==============================================================================
+NAME Mouse scroll key tap in Macros
+
+RUN 4 ms
+PRESS MACRO_1
+RUN 1 cycle
+EXPECT mouse-report v=1
+
+RUN 5 ms
+RELEASE MACRO_1
+RUN 1 cycle
+EXPECT no mouse-report
+
+RUN 5 ms


### PR DESCRIPTION
This change is designed to fix #1113 by restructuring how MouseKeys processes key events for mouse cursor and wheel movement.  Instead of only sending those reports in `afterEachCycle()` directly, I've shifted that code out to two new helper functions: `sendMouseMoveReport()` & `sendMouseWheelReport()`.  This allows us to both send periodic reports when a key is held, but also in response to key events directly, even when a mouse movement (or wheel) key toggles on and off within a single cycle.

However, because MouseKeys used to poll the keys of the keyboard to find out which direction to move the cursor (or wheel), it still wouldn't respond properly to mouse wheel keys (for example) that appear in Macros' virtual keys array.  So, rather than simply iterating through `live_keys[]` looking for mouse movement keys, we store the movement and wheel directions in persistent variables, and update those from a new `onAddToReport()` handler.  Last, because Macros virtual keys only call `Hooks::onAddToReport()` from the `beforeReportingState()`, we need to wait until after that to send the mouse move and wheel reports, so we can't send the reports from the `onKeyEvent()` handler, and doing it from `beforeReportingState()` would be plugin initialization order dependent, so I also added an `afterReportingState()` handler to MouseKeys to call the new move and wheel report functions.

I haven't tested this yet, and I don't even know if our automated testing infrastructure is set up to test mouse reports, so this is still a work in progress.