### PR TITLE
When working from the command line, use git cores exclusively. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,35 +28,18 @@ $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/virtual/boards.txt:
 
 $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/boards.txt:
 	git clone -c core.symlinks=true \
-		--recurse-submodules=":(exclude)avr/libraries/Kaleidoscope" \
-		--recurse-submodules=":(exclude)gd32/libraries/Kaleidoscope" \
-		--recurse-submodules=avr/libraries/ \
-		--recurse-submodules=gd32/ \
-		--recurse-submodules=gd32/libraries/ \
+		--recurse-submodules \
 		git://github.com/keyboardio/Kaleidoscope-Bundle-Keyboardio \
 		$(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio
-	-rm -d $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/libraries/Kaleidoscope
-	ln -s $(KALEIDOSCOPE_DIR) $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/libraries/Kaleidoscope
 	git clone -c core.symlinks=true \
-		--recurse-submodules=":(exclude)libraries/Kaleidoscope" \
-		--recurse-submodules=libraries/ \
+		--recurse-submodules \
 		git://github.com/keyboardio/ArduinoCore-GD32-Keyboardio $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/gd32
-	-rm -d $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/gd32/libraries/Kaleidoscope
-	ln -s $(KALEIDOSCOPE_DIR) $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/gd32/libraries/Kaleidoscope
 
 update:
-	# Clear out our hacked up symlinked Kaleidoscope
-	-rm -rf $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/libraries/Kaleidoscope
 	cd $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio; git pull; \
 		git submodule update --init --recursive
-	-rm -rf $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/libraries/Kaleidoscope
-	ln -s $(KALEIDOSCOPE_DIR) $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/libraries/Kaleidoscope
-	# Clear out our hacked up Kaleidoscope
-	-rm -rf $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/gd32/libraries/Kaleidoscope
 	cd $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/gd32; git pull; \
 		git submodule update --init --recursive
-	-rm -rf $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/gd32/libraries/Kaleidoscope
-	ln -s $(KALEIDOSCOPE_DIR) $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/gd32/libraries/Kaleidoscope
 
 simulator-tests:
 	$(MAKE) -C tests all

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,20 @@ $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/boards.txt:
 	-rm -d $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/gd32/libraries/Kaleidoscope
 	ln -s $(KALEIDOSCOPE_DIR) $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/gd32/libraries/Kaleidoscope
 
+update:
+	# Clear out our hacked up symlinked Kaleidoscope
+	-rm -rf $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/libraries/Kaleidoscope
+	cd $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio; git pull; \
+		git submodule update --init --recursive
+	-rm -rf $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/libraries/Kaleidoscope
+	ln -s $(KALEIDOSCOPE_DIR) $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/libraries/Kaleidoscope
+	# Clear out our hacked up Kaleidoscope
+	-rm -rf $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/gd32/libraries/Kaleidoscope
+	cd $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/gd32; git pull; \
+		git submodule update --init --recursive
+	-rm -rf $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/gd32/libraries/Kaleidoscope
+	ln -s $(KALEIDOSCOPE_DIR) $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/gd32/libraries/Kaleidoscope
+
 simulator-tests:
 	$(MAKE) -C tests all
 

--- a/etc/makefiles/arduino-cli.mk
+++ b/etc/makefiles/arduino-cli.mk
@@ -35,7 +35,8 @@ ARDUINO_CONTENT ?= $(KALEIDOSCOPE_DIR)/.arduino
 export ARDUINO_DIRECTORIES_DATA ?= $(ARDUINO_CONTENT)/data
 export ARDUINO_DIRECTORIES_DOWNLOADS ?= $(ARDUINO_CONTENT)/downloads
 export ARDUINO_CLI_CONFIG ?= $(ARDUINO_DIRECTORIES_DATA)/arduino-cli.yaml
-export ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS ?= https://raw.githubusercontent.com/keyboardio/boardsmanager/master/package_keyboardio_index.json
+export ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS ?= https://raw.githubusercontent.com/keyboardio/boardsmanager/master/devel/package_kaleidoscope_devel_index.json
+
 
 # If it looks like Kaleidoscope is inside a "traditional" Arduino hardware directory 
 # in the user's homedir, let's use that.
@@ -163,9 +164,15 @@ arduino-update-cores:
 
 
 install-arduino-core-kaleidoscope: arduino-update-cores
-	$(QUIET) $(ARDUINO_CLI) core install "keyboardio:avr"
-	$(QUIET) $(ARDUINO_CLI) core install "keyboardio:gd32"
+	$(QUIET) $(ARDUINO_CLI) core install "keyboardio:avr-tools-only"
+	$(QUIET) $(ARDUINO_CLI) core install "keyboardio:gd32-tools-only"
 
 install-arduino-core-avr: arduino-update-cores
 	$(QUIET) $(ARDUINO_CLI) core install "arduino:avr"
+
+
+install-arduino-core-deps:
+	$(QUIET) $(ARDUINO_CLI) core install "keyboardio:avr-tools-only"
+	$(QUIET) $(ARDUINO_CLI) core install "keyboardio:gd32-tools-only"
+
 


### PR DESCRIPTION
Instead of installing both prebuilt and git cores when working from the commandline, install the devtools using the package manager and then get the arduino cores exclusively with git.