### PR TITLE
Fix docker simulator tests

### DIFF
--- a/etc/docker-entrypoint.sh
+++ b/etc/docker-entrypoint.sh
@@ -13,9 +13,6 @@ tar xf /kaleidoscope-src/kaleidoscope.tar -C /kaleidoscope/
 echo "Syncing the bundle..."
 tar xf /kaleidoscope-src/bundle.tar -C /kaleidoscope/.arduino/user/hardware/keyboardio
 
-rm -f /kaleidoscope/.arduino/user/hardware/keyboardio/avr/libraries/Kaleidoscope
-ln -s /kaleidoscope /kaleidoscope/.arduino/user/hardware/keyboardio/avr/libraries/Kaleidoscope
-
 
 cd /kaleidoscope/
 export ARDUINO_DIRECTORIES_DATA=/arduino-cli/data


### PR DESCRIPTION
With the reorganization of arduino-cli libraries in .arduino, we no longer use a symlink for Kaleidoscope, so don't try to delete it or create it inside the Docker container.
