### PR TITLE
Replace deprecated Leader code in docs and testcases

### DIFF
--- a/plugins/Kaleidoscope-Leader/README.md
+++ b/plugins/Kaleidoscope-Leader/README.md
@@ -77,7 +77,7 @@ The plugin provides the `Leader` object, with the following methods and properti
 > are final actions, where one does not wish to continue the leader sequence
 > further in the hopes of finding a longer match.
 
-### `.time_out`
+### `.setTimeout(ms)`
 
 > The number of milliseconds to wait before a sequence times out. Once the
 > sequence timed out, if there is a partial match with an action, that will be

--- a/tests/plugins/Leader/basic/basic.ino
+++ b/tests/plugins/Leader/basic/basic.ino
@@ -72,7 +72,7 @@ static const kaleidoscope::plugin::Leader::dictionary_t leader_dictionary[] PROG
 
 void setup() {
   Kaleidoscope.setup();
-  Leader.time_out = 20;
+  Leader.setTimeout(20);
   Leader.dictionary = leader_dictionary;
 }
 


### PR DESCRIPTION
I overlooked a couple of things when deprecating some Leader code.