### PR TITLE
Fix setStickyColor() typo

### DIFF
--- a/plugins/Kaleidoscope-LED-ActiveModColor/src/kaleidoscope/plugin/LED-ActiveModColor.h
+++ b/plugins/Kaleidoscope-LED-ActiveModColor/src/kaleidoscope/plugin/LED-ActiveModColor.h
@@ -35,7 +35,7 @@ class ActiveModColorEffect : public kaleidoscope::Plugin {
   static void setOneShotColor(cRGB color) {
     oneshot_color_ = color;
   }
-  static void setOnestickyColor(cRGB color) {
+  static void setStickyColor(cRGB color) {
     sticky_color_ = color;
   }
 


### PR DESCRIPTION
Just found this little typo while flashing: `setOnestickyColor` should be `setStickyColor`