### PR TITLE
Update MouseKeys testcase for current KeyboardioHID

### DIFF
--- a/tests/plugins/MouseKeys/basic/test.ktest
+++ b/tests/plugins/MouseKeys/basic/test.ktest
@@ -24,12 +24,10 @@ RUN 1 cycle
 RUN 15 ms
 EXPECT mouse-report y=-1
 RUN 1 cycle
-EXPECT mouse-report empty
 
 RUN 15 ms
 EXPECT mouse-report y=-1
 RUN 1 cycle
-EXPECT mouse-report empty
 
 RUN 5 ms
 RELEASE MOVE_UP


### PR DESCRIPTION
With keyboardio/KeyboardioHID#82, we no longer expect a no-op mouse report after each mouse cursor move report.