### PR TITLE
fix minor typo in plugin author guide

### DIFF
--- a/docs/customization/plugin-authors-guide.md
+++ b/docs/customization/plugin-authors-guide.md
@@ -45,7 +45,7 @@ To make our plugin do anything useful, we need to add [[event-handler-hooks]] to
 ```c++
 class MyPlugin : public Plugin {
  public:
-  EventHanderResult onKeyEvent(KeyEvent &event);
+  EventHandlerResult onKeyEvent(KeyEvent &event);
 };
 ```
 


### PR DESCRIPTION
Self-explanatory PR, only one character away and for once the compiler helped me find what was broken :-).