### PR TITLE
Improve ActiveModColor example sketch

### DIFF
--- a/examples/LEDs/LED-ActiveModColor/LED-ActiveModColor.ino
+++ b/examples/LEDs/LED-ActiveModColor/LED-ActiveModColor.ino
@@ -18,6 +18,7 @@
 #include <Kaleidoscope.h>
 #include <Kaleidoscope-LEDControl.h>
 #include <Kaleidoscope-LED-ActiveModColor.h>
+#include <Kaleidoscope-OneShot.h>
 
 // *INDENT-OFF*
 KEYMAPS(
@@ -36,18 +37,26 @@ KEYMAPS(
                Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
     Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
 
-    Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
+    OSM(RightShift), OSM(RightAlt), Key_Spacebar, OSM(RightControl),
     Key_skip),
 )
 // *INDENT-ON*
 
+// OneShot is included to illustrate the different colors highlighting sticky
+// and one-shot keys.  LEDOff is included because we need an LED mode active to
+// allow highlighted keys to return to "normal" when released (or timed out).
 KALEIDOSCOPE_INIT_PLUGINS(LEDControl,
-                          ActiveModColorEffect);
+                          LEDOff,
+                          ActiveModColorEffect,
+                          OneShot);
 
 void setup() {
   Kaleidoscope.setup();
 
   ActiveModColorEffect.setHighlightColor(CRGB(0x00, 0xff, 0xff));
+
+  // Uncomment the following to enable OneShot on normal modifier keys:
+  // OneShot.enableAutoOneShot();
 }
 
 void loop() {


### PR DESCRIPTION
LED-ActiveModColor needs some LED mode active for the LEDs to return to their normal state upon release.  This adds the simple `LEDOff` mode to accomplish that, and also adds OneShot keys as a better demonstration of the capabilities of the plugin.
