### PR TITLE
EEPROM-Settings: Do commit the storage after handling eeprom.contents

### DIFF
--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -233,6 +233,7 @@ EventHandlerResult FocusEEPROMCommand::onFocusEvent(const char *command) {
         ::Focus.read(d);
         Runtime.storage().update(i, d);
       }
+      Runtime.storage().commit();
     }
 
     break;


### PR DESCRIPTION
When handling the update variant of `eeprom.contents`, we need to commit the update storage, too. This does not affect AVR that doesn't need an explicit commit, but it does affect ARM, where `eeprom.contents` likely didn't work at all in update mode.
