### PR TITLE
EEPROM-Settings: Implement an `eeprom.erase` command

### DIFF
--- a/plugins/Kaleidoscope-EEPROM-Settings/README.md
+++ b/plugins/Kaleidoscope-EEPROM-Settings/README.md
@@ -172,6 +172,11 @@ following commands:
 
 > Returns the amount of free bytes in `EEPROM`.
 
+### `eeprom.erase`
+
+> Erases the entire `EEPROM`, and reboots the keyboard to make sure the erase is
+> picked up by every single plugin.
+
 ## Dependencies
 
 * (Kaleidoscope-FocusSerial)[Kaleidoscope-FocusSerial.md]

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -208,15 +208,18 @@ EventHandlerResult FocusEEPROMCommand::onFocusEvent(const char *command) {
   enum {
     CONTENTS,
     FREE,
+    ERASE,
   } sub_command;
 
-  if (::Focus.handleHelp(command, PSTR("eeprom.contents\neeprom.free")))
+  if (::Focus.handleHelp(command, PSTR("eeprom.contents\neeprom.free\neeprom.erase")))
     return EventHandlerResult::OK;
 
   if (strcmp_P(command, PSTR("eeprom.contents")) == 0)
     sub_command = CONTENTS;
   else if (strcmp_P(command, PSTR("eeprom.free")) == 0)
     sub_command = FREE;
+  else if (strcmp_P(command, PSTR("eeprom.erase")) == 0)
+    sub_command = ERASE;
   else
     return EventHandlerResult::OK;
 
@@ -240,8 +243,15 @@ EventHandlerResult FocusEEPROMCommand::onFocusEvent(const char *command) {
   case FREE:
     ::Focus.send(Runtime.storage().length() - ::EEPROMSettings.used());
     break;
+  case ERASE: {
+    for (uint16_t i = 0; i < Runtime.storage().length(); i++) {
+      Runtime.storage().update(i, 255);
+    }
+    Runtime.storage().commit();
+    Runtime.device().rebootBootloader();
+    break;
   }
-
+  }
   return EventHandlerResult::EVENT_CONSUMED;
 }
 


### PR DESCRIPTION
The `eeprom.erase` command makes it easier to erase the whole of EEPROM, and in addition, it will reboot the keyboard so that the changes are picked up by every single plugin.

Fixes #1134.

This depends on the device correctly implementing `Kaleidoscope.device().rebootBootloader()`, the reboot will not function without that. GD32 currently does not implement that correctly, but that can be addressed in a separate pull request.