### PR TITLE
Reorganize header includes with help from `include-what-you-use`

### DIFF
--- a/examples/Features/GhostInTheFirmware/GhostInTheFirmware.ino
+++ b/examples/Features/GhostInTheFirmware/GhostInTheFirmware.ino
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope.h>
+#include <Kaleidoscope-LEDControl.h>
 #include <Kaleidoscope-GhostInTheFirmware.h>
 #include <Kaleidoscope-LED-Stalker.h>
 #include <Kaleidoscope-Macros.h>

--- a/examples/LEDs/Colormap/Colormap.ino
+++ b/examples/LEDs/Colormap/Colormap.ino
@@ -20,6 +20,7 @@
 #include <Kaleidoscope-Colormap.h>
 #include <Kaleidoscope-FocusSerial.h>
 #include <Kaleidoscope-LED-Palette-Theme.h>
+#include <Kaleidoscope-LEDControl.h>
 
 // *INDENT-OFF*
 KEYMAPS(

--- a/examples/LEDs/LED-Brightness/LED-Brightness.ino
+++ b/examples/LEDs/LED-Brightness/LED-Brightness.ino
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope.h>
+#include <Kaleidoscope-LEDControl.h>
 #include <Kaleidoscope-LEDEffect-Rainbow.h>
 #include <Kaleidoscope-Macros.h>
 

--- a/examples/LEDs/LEDEffects/LEDEffects.ino
+++ b/examples/LEDs/LEDEffects/LEDEffects.ino
@@ -16,6 +16,7 @@
  */
 
 #include <Kaleidoscope.h>
+#include <Kaleidoscope-LEDControl.h>
 #include <Kaleidoscope-LEDEffects.h>
 
 // *INDENT-OFF*

--- a/plugins/Kaleidoscope-AutoShift/src/Kaleidoscope-AutoShift.h
+++ b/plugins/Kaleidoscope-AutoShift/src/Kaleidoscope-AutoShift.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/AutoShift.h>
+#include "kaleidoscope/plugin/AutoShift.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShift.cpp
+++ b/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShift.cpp
@@ -17,11 +17,14 @@
 
 #include "kaleidoscope/plugin/AutoShift.h"
 
-#include "kaleidoscope/KeyAddr.h"
-#include "kaleidoscope/key_defs.h"
-#include "kaleidoscope/KeyEvent.h"
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/KeyAddr.h"          // for KeyAddr, MatrixAddr
+#include "kaleidoscope/KeyEvent.h"         // for KeyEvent
+#include "kaleidoscope/KeyEventTracker.h"  // for KeyEventTracker
+#include "kaleidoscope/Runtime.h"          // for Runtime, Runtime_
+#include "kaleidoscope/key_defs.h"         // for Key, Key_0, Key_1, Key_A
+#include "kaleidoscope/keyswitch_state.h"  // for keyToggledOn, keyIsInjected
+
+// IWYU pragma: no_include "HIDAliases.h"
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShift.h
+++ b/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShift.h
@@ -17,9 +17,14 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include "kaleidoscope/KeyEventTracker.h"
-#include "kaleidoscope/KeyAddrEventQueue.h"
+#include <stdint.h>                             // for uint8_t, uint16_t
+
+#include "kaleidoscope/KeyAddrEventQueue.h"     // for KeyAddrEventQueue
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/KeyEventTracker.h"       // for KeyEventTracker
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
+++ b/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
@@ -15,12 +15,17 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/plugin/AutoShift.h"
+#include "kaleidoscope/plugin/AutoShift.h"  // IWYU pragma: associated
 
-#include <Kaleidoscope-EEPROM-Settings.h>
-#include <Kaleidoscope-FocusSerial.h>
+#include <Arduino.h>                              // for PSTR, strcmp_P, str...
+#include <Kaleidoscope-EEPROM-Settings.h>         // for EEPROMSettings
+#include <Kaleidoscope-FocusSerial.h>             // for Focus, FocusSerial
+#include <stdint.h>                               // for uint16_t, uint8_t
 
-#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/Runtime.h"                 // for Runtime, Runtime_
+#include "kaleidoscope/device/Base.h"             // for Base<>::Storage
+#include "kaleidoscope/device/virtual/Virtual.h"  // for VirtualProps::Storage
+#include "kaleidoscope/event_handler_result.h"    // for EventHandlerResult
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-CharShift/src/Kaleidoscope-CharShift.h
+++ b/plugins/Kaleidoscope-CharShift/src/Kaleidoscope-CharShift.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/CharShift.h>
+#include "kaleidoscope/plugin/CharShift.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-CharShift/src/kaleidoscope/plugin/CharShift.cpp
+++ b/plugins/Kaleidoscope-CharShift/src/kaleidoscope/plugin/CharShift.cpp
@@ -17,15 +17,21 @@
 
 #include "kaleidoscope/plugin/CharShift.h"
 
-#include <Kaleidoscope-Ranges.h>
-#include <Kaleidoscope-FocusSerial.h>
+#include <Arduino.h>                                      // for F, __FlashS...
+#include <Kaleidoscope-FocusSerial.h>                     // for Focus, Focu...
+#include <Kaleidoscope-Ranges.h>                          // for CS_FIRST
 
-#include "kaleidoscope/KeyAddr.h"
-#include "kaleidoscope/key_defs.h"
-#include "kaleidoscope/KeyEvent.h"
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/progmem_helpers.h"
-#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/KeyAddrMap.h"                      // for KeyAddrMap<...
+#include "kaleidoscope/KeyEvent.h"                        // for KeyEvent
+#include "kaleidoscope/KeyMap.h"                          // for KeyMap
+#include "kaleidoscope/LiveKeys.h"                        // for LiveKeys
+#include "kaleidoscope/Runtime.h"                         // for Runtime
+#include "kaleidoscope/device/Base.h"                     // for Base<>::HID
+#include "kaleidoscope/device/virtual/Virtual.h"          // for VirtualProp...
+#include "kaleidoscope/driver/hid/keyboardio/Keyboard.h"  // for Keyboard
+#include "kaleidoscope/key_defs.h"                        // for Key, Key_NoKey
+#include "kaleidoscope/keyswitch_state.h"                 // for keyToggledOff
+#include "kaleidoscope/progmem_helpers.h"                 // for cloneFromPr...
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-CharShift/src/kaleidoscope/plugin/CharShift.h
+++ b/plugins/Kaleidoscope-CharShift/src/kaleidoscope/plugin/CharShift.h
@@ -17,9 +17,14 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include <Kaleidoscope-Ranges.h>                // for CS_FIRST
+#include <stdint.h>                             // for uint8_t
 
-#include <Kaleidoscope-Ranges.h>
+#include "Arduino.h"                            // for PROGMEM
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Colormap/src/Kaleidoscope-Colormap.h
+++ b/plugins/Kaleidoscope-Colormap/src/Kaleidoscope-Colormap.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/Colormap.h>
+#include "kaleidoscope/plugin/Colormap.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/Colormap.cpp
+++ b/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/Colormap.cpp
@@ -15,11 +15,18 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "kaleidoscope/plugin/Colormap.h"
 
-#include <Kaleidoscope-Colormap.h>
-#include <Kaleidoscope-EEPROM-Settings.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/layers.h"
+#include <Arduino.h>                            // for F, PSTR, __FlashStrin...
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <Kaleidoscope-LED-Palette-Theme.h>     // for LEDPaletteTheme
+#include <stdint.h>                             // for uint8_t, uint16_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/layers.h"                // for Layer, Layer_
+#include "kaleidoscope/plugin/LEDControl.h"     // for LEDControl
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/Colormap.h
+++ b/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/Colormap.h
@@ -17,8 +17,14 @@
 
 #pragma once
 
-#include <Kaleidoscope-LEDControl.h>
-#include <Kaleidoscope-LED-Palette-Theme.h>
+#include <stdint.h>                                      // for uint8_t, uin...
+
+#include "kaleidoscope/KeyAddr.h"                        // for KeyAddr
+#include "kaleidoscope/event_handler_result.h"           // for EventHandler...
+#include "kaleidoscope/plugin.h"                         // for Plugin
+#include "kaleidoscope/plugin/AccessTransientLEDMode.h"  // for AccessTransi...
+#include "kaleidoscope/plugin/LEDMode.h"                 // for LEDMode
+#include "kaleidoscope/plugin/LEDModeInterface.h"        // for LEDModeInter...
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Cycle/src/Kaleidoscope-Cycle.h
+++ b/plugins/Kaleidoscope-Cycle/src/Kaleidoscope-Cycle.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/Cycle.h>
+#include "kaleidoscope/plugin/Cycle.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Cycle/src/kaleidoscope/plugin/Cycle.cpp
+++ b/plugins/Kaleidoscope-Cycle/src/kaleidoscope/plugin/Cycle.cpp
@@ -15,10 +15,19 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-Cycle.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/plugin/Cycle.h"
+
+#include <Arduino.h>                            // for F, __FlashStringHelper
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <Kaleidoscope-Ranges.h>                // for CYCLE
+#include <stdint.h>                             // for uint8_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr, MatrixAddr
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_Backspace
+#include "kaleidoscope/keyswitch_state.h"       // for INJECTED, IS_PRESSED
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Cycle/src/kaleidoscope/plugin/Cycle.h
+++ b/plugins/Kaleidoscope-Cycle/src/kaleidoscope/plugin/Cycle.h
@@ -17,8 +17,15 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-Ranges.h>
+#include <Kaleidoscope-Ranges.h>                // for CYCLE
+#include <stdint.h>                             // for uint8_t
+
+#include "Arduino.h"                            // for PROGMEM
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 constexpr Key Key_Cycle = Key(kaleidoscope::ranges::CYCLE);
 

--- a/plugins/Kaleidoscope-CycleTimeReport/src/Kaleidoscope-CycleTimeReport.h
+++ b/plugins/Kaleidoscope-CycleTimeReport/src/Kaleidoscope-CycleTimeReport.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/CycleTimeReport.h>
+#include "kaleidoscope/plugin/CycleTimeReport.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.cpp
+++ b/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.cpp
@@ -15,8 +15,14 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-CycleTimeReport.h>
-#include <Kaleidoscope-FocusSerial.h>
+#include "kaleidoscope/plugin/CycleTimeReport.h"
+
+#include <Arduino.h>                            // for micros, F, __FlashStr...
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <stdint.h>                             // for uint16_t, uint32_t
+
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.h
+++ b/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.h
@@ -17,7 +17,10 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include <stdint.h>                             // for uint32_t, uint16_t
+
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Devel-ArduinoTrace/src/ArduinoTrace.h
+++ b/plugins/Kaleidoscope-Devel-ArduinoTrace/src/ArduinoTrace.h
@@ -17,7 +17,8 @@
 
 #pragma once
 
-#include <Arduino.h>
+#include <Arduino.h>  // for PROGMEM, F
+#include <stddef.h>   // for size_t
 
 #ifndef ARDUINOTRACE_ENABLE
 #define ARDUINOTRACE_ENABLE 1

--- a/plugins/Kaleidoscope-Devel-ArduinoTrace/src/Kaleidoscope-Devel-ArduinoTrace.h
+++ b/plugins/Kaleidoscope-Devel-ArduinoTrace/src/Kaleidoscope-Devel-ArduinoTrace.h
@@ -17,14 +17,13 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-
 #ifndef ARDUINOTRACE_SERIAL
 #ifdef KALEIDOSCOPE_VIRTUAL_BUILD
 #define ARDUINOTRACE_SERIAL DebugStderr
 #endif
 #endif
 
-#include "ArduinoTrace.h"
+#include "ArduinoTrace.h"    // for ARDUINOTRACE_INIT
+#include <HardwareSerial.h>  // for DebugStderrSerial, DebugStderr
 
 ARDUINOTRACE_INIT(9600)

--- a/plugins/Kaleidoscope-DynamicMacros/src/Kaleidoscope-DynamicMacros.h
+++ b/plugins/Kaleidoscope-DynamicMacros/src/Kaleidoscope-DynamicMacros.h
@@ -16,5 +16,6 @@
 
 #pragma once
 
-#include "Kaleidoscope-Macros.h"
-#include "kaleidoscope/plugin/DynamicMacros.h"
+#include <Kaleidoscope-Macros.h> // IWYU pragma: keep
+
+#include "kaleidoscope/plugin/DynamicMacros.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -14,9 +14,23 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope-DynamicMacros.h"
-#include "Kaleidoscope-FocusSerial.h"
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/plugin/DynamicMacros.h"
+
+#include <Arduino.h>                                // for delay, PSTR, strc...
+#include <Kaleidoscope-FocusSerial.h>               // for Focus, FocusSerial
+#include <Kaleidoscope-Ranges.h>                    // for DYNAMIC_MACRO_FIRST
+
+#include "kaleidoscope/KeyAddr.h"                   // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"                  // for KeyEvent
+#include "kaleidoscope/Runtime.h"                   // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"             // for VirtualProps::Sto...
+#include "kaleidoscope/keyswitch_state.h"           // for INJECTED, IS_PRESSED
+#include "kaleidoscope/plugin/EEPROM-Settings.h"    // for EEPROMSettings
+
+// This is a special exception to the rule of only including a plugin's
+// top-level header file, because DynamicMacros doesn't depend on the Macros
+// plugin itself; it's just using the same macro step definitions.
+#include "kaleidoscope/plugin/Macros/MacroSteps.h"  // for MACRO_ACTION_END
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -176,7 +176,7 @@ void DynamicMacros::play(uint8_t macro_id) {
     case MACRO_ACTION_STEP_TAP_SEQUENCE: {
       while (true) {
         key.setFlags(0);
-        key.setKeyCode(pgm_read_byte(pos++));
+        key.setKeyCode(Runtime.storage().read(pos++));
         if (key == Key_NoKey)
           break;
         tap(key);
@@ -187,7 +187,7 @@ void DynamicMacros::play(uint8_t macro_id) {
     case MACRO_ACTION_STEP_TAP_CODE_SEQUENCE: {
       while (true) {
         key.setFlags(0);
-        key.setKeyCode(pgm_read_byte(pos++));
+        key.setKeyCode(Runtime.storage().read(pos++));
         if (key.getKeyCode() == 0)
           break;
         tap(key);

--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.h
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.h
@@ -16,11 +16,13 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-EEPROM-Settings.h>
-#include <Kaleidoscope-Ranges.h>
+#include <Kaleidoscope-Ranges.h>                // for DYNAMIC_MACRO_FIRST
+#include <stdint.h>                             // for uint16_t, uint8_t
 
-#include "kaleidoscope/plugin/Macros/MacroSteps.h"
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 #define DM(n) ::kaleidoscope::plugin::DynamicMacrosKey(n)
 

--- a/plugins/Kaleidoscope-DynamicTapDance/src/Kaleidoscope-DynamicTapDance.h
+++ b/plugins/Kaleidoscope-DynamicTapDance/src/Kaleidoscope-DynamicTapDance.h
@@ -17,5 +17,4 @@
 
 #pragma once
 
-#include "Kaleidoscope-TapDance.h"
-#include "kaleidoscope/plugin/DynamicTapDance.h"
+#include "kaleidoscope/plugin/DynamicTapDance.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
+++ b/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
@@ -15,12 +15,21 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope-DynamicTapDance.h"
+#include "kaleidoscope/plugin/DynamicTapDance.h"
 
-#include <Kaleidoscope-EEPROM-Settings.h>
-#include "Kaleidoscope-FocusSerial.h"
-#include "kaleidoscope/Runtime.h"
-#include "kaleidoscope/KeyEvent.h"
+#include <Arduino.h>                            // for PSTR, F, __FlashStrin...
+#include <Kaleidoscope-EEPROM-Settings.h>       // for EEPROMSettings
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <stdint.h>                             // for uint16_t, uint8_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for VirtualProps::Storage
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_NoKey
+#include "kaleidoscope/keyswitch_state.h"       // for IS_PRESSED, WAS_PRESSED
+#include "kaleidoscope/plugin/TapDance.h"       // for TapDance, TapDance::A...
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.h
+++ b/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.h
@@ -17,8 +17,13 @@
 
 #pragma once
 
-#include <Kaleidoscope.h>
-#include <Kaleidoscope-TapDance.h>
+#include <Kaleidoscope-Ranges.h>                // for TD_FIRST, TD_LAST
+#include <Kaleidoscope-TapDance.h>              // for TapDance, TapDance::A...
+#include <stdint.h>                             // for uint8_t, uint16_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/Kaleidoscope-EEPROM-Keymap-Programmer.h
+++ b/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/Kaleidoscope-EEPROM-Keymap-Programmer.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/EEPROM-Keymap-Programmer.h>
+#include "kaleidoscope/plugin/EEPROM-Keymap-Programmer.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
@@ -15,10 +15,21 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-EEPROM-Keymap-Programmer.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/layers.h"
+#include "kaleidoscope/plugin/EEPROM-Keymap-Programmer.h"
+
+#include <Arduino.h>                            // for PSTR, strcmp_P
+#include <Kaleidoscope-EEPROM-Keymap.h>         // for EEPROMKeymap
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <stdint.h>                             // for uint16_t, uint8_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for Device, Base<>::Storage
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_0, Key_1
+#include "kaleidoscope/keyswitch_state.h"       // for keyToggledOn, keyTogg...
+#include "kaleidoscope/layers.h"                // for Layer, Layer_
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.h
+++ b/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.h
@@ -17,8 +17,12 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-EEPROM-Keymap.h>
+#include <stdint.h>                             // for uint16_t
+
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/Kaleidoscope-EEPROM-Keymap.h
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/Kaleidoscope-EEPROM-Keymap.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/EEPROM-Keymap.h>
+#include "kaleidoscope/plugin/EEPROM-Keymap.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -15,10 +15,19 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-EEPROM-Settings.h>
-#include <Kaleidoscope-EEPROM-Keymap.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/layers.h"
+#include "kaleidoscope/plugin/EEPROM-Keymap.h"
+
+#include <Arduino.h>                            // for PSTR, strcmp_P, F
+#include <Kaleidoscope-EEPROM-Settings.h>       // for EEPROMSettings
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <stdint.h>                             // for uint8_t, uint16_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr, MatrixAddr
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for VirtualProps::Storage
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_NoKey
+#include "kaleidoscope/layers.h"                // for Layer_, Layer, layer_...
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.h
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.h
@@ -17,8 +17,12 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-EEPROM-Settings.h>
+#include <stdint.h>                             // for uint8_t, uint16_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/Kaleidoscope-EEPROM-Settings.h
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/Kaleidoscope-EEPROM-Settings.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/EEPROM-Settings.h>
+#include "kaleidoscope/plugin/EEPROM-Settings.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -15,10 +15,17 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-EEPROM-Settings.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/plugin/EEPROM-Settings/crc.h"
-#include "kaleidoscope/layers.h"
+#include "kaleidoscope/plugin/EEPROM-Settings.h"
+
+#include <Arduino.h>                                  // for PSTR, strcmp_P, F
+#include <Kaleidoscope-FocusSerial.h>                 // for Focus, FocusSerial
+#include <stdint.h>                                   // for uint16_t, uint8_t
+
+#include "kaleidoscope/Runtime.h"                     // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"               // for VirtualProps::S...
+#include "kaleidoscope/event_handler_result.h"        // for EventHandlerResult
+#include "kaleidoscope/layers.h"                      // for Layer, Layer_
+#include "kaleidoscope/plugin/EEPROM-Settings/crc.h"  // for CRCCalculator
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.h
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.h
@@ -17,7 +17,10 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include <stdint.h>                             // for uint8_t, uint16_t
+
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings/crc.h
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings/crc.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#include <Arduino.h>
+#include <stdint.h>  // for uint8_t, uint16_t
 
 class CRC_ {
  public:

--- a/plugins/Kaleidoscope-Escape-OneShot/src/Kaleidoscope-Escape-OneShot.h
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/Kaleidoscope-Escape-OneShot.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/Escape-OneShot.h>
+#include "kaleidoscope/plugin/Escape-OneShot.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot-Config.cpp
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot-Config.cpp
@@ -15,12 +15,17 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/plugin/Escape-OneShot.h"
+#include "kaleidoscope/plugin/Escape-OneShot.h"  // IWYU pragma: associated
 
-#include <Kaleidoscope-EEPROM-Settings.h>
-#include <Kaleidoscope-FocusSerial.h>
+#include <Arduino.h>                            // for PSTR, F, __FlashStrin...
+#include <Kaleidoscope-EEPROM-Settings.h>       // for EEPROMSettings
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <stdint.h>                             // for uint16_t
 
-#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for VirtualProps::Storage
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.cpp
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.cpp
@@ -15,11 +15,14 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-OneShot.h>
-#include <Kaleidoscope-Escape-OneShot.h>
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/layers.h"
+#include "kaleidoscope/plugin/Escape-OneShot.h"
+
+#include <Kaleidoscope-OneShot.h>               // for OneShot
+
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_Escape, Key_...
+#include "kaleidoscope/keyswitch_state.h"       // for keyIsInjected, keyTog...
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.h
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.h
@@ -17,8 +17,13 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-Ranges.h>
+#include <Kaleidoscope-Ranges.h>                // for OS_CANCEL
+#include <stdint.h>                             // for uint16_t
+
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 // DEPRECATED: `OneShotCancelKey` doesn't match our normal naming, and should
 // eventually be removed.

--- a/plugins/Kaleidoscope-FingerPainter/src/Kaleidoscope-FingerPainter.h
+++ b/plugins/Kaleidoscope-FingerPainter/src/Kaleidoscope-FingerPainter.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/FingerPainter.h>
+#include "kaleidoscope/plugin/FingerPainter.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
+++ b/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
@@ -15,13 +15,20 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-FingerPainter.h>
+#include "kaleidoscope/plugin/FingerPainter.h"
 
-#include <Kaleidoscope-EEPROM-Settings.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include <Kaleidoscope-LEDControl.h>
-#include <Kaleidoscope-LED-Palette-Theme.h>
-#include "kaleidoscope/keyswitch_state.h"
+#include <Arduino.h>                            // for PSTR, strcmp_P, F
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <Kaleidoscope-LED-Palette-Theme.h>     // for LEDPaletteTheme
+#include <stdint.h>                             // for uint16_t, uint8_t
+#include <string.h>                             // for memcmp
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for Device, cRGB, Virtual...
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/keyswitch_state.h"       // for keyToggledOff
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.h
+++ b/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.h
@@ -17,7 +17,12 @@
 
 #pragma once
 
-#include <Kaleidoscope-LEDControl.h>
+#include <stdint.h>                             // for uint16_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin/LEDMode.h"        // for LEDMode
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-FirmwareDump/src/Kaleidoscope-FirmwareDump.h
+++ b/plugins/Kaleidoscope-FirmwareDump/src/Kaleidoscope-FirmwareDump.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/FirmwareDump.h>
+#include "kaleidoscope/plugin/FirmwareDump.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-FirmwareDump/src/kaleidoscope/plugin/FirmwareDump.cpp
+++ b/plugins/Kaleidoscope-FirmwareDump/src/kaleidoscope/plugin/FirmwareDump.cpp
@@ -18,7 +18,9 @@
 #ifdef __AVR__
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
-#include <Kaleidoscope-FirmwareDump.h>
+#include "kaleidoscope/plugin/FirmwareDump.h"
+
+#include <Arduino.h>
 #include <Kaleidoscope-FocusSerial.h>
 #include <avr/boot.h>
 

--- a/plugins/Kaleidoscope-FirmwareDump/src/kaleidoscope/plugin/FirmwareDump.h
+++ b/plugins/Kaleidoscope-FirmwareDump/src/kaleidoscope/plugin/FirmwareDump.h
@@ -23,7 +23,10 @@
 
 #ifdef __AVR__
 
-#include "kaleidoscope/Runtime.h"
+#include <stdint.h>                             // for uint16_t
+
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-FocusSerial/src/Kaleidoscope-FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/Kaleidoscope-FocusSerial.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/FocusSerial.h>
+#include "kaleidoscope/plugin/FocusSerial.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -15,7 +15,16 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-FocusSerial.h>
+#include "kaleidoscope/plugin/FocusSerial.h"
+
+#include <Arduino.h>                            // for __FlashStringHelper, F
+#include <HardwareSerial.h>                     // for HardwareSerial
+#include <stdint.h>                             // for uint8_t
+#include <string.h>                             // for memset
+
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/hooks.h"                 // for Hooks
 
 #ifdef __AVR__
 #include <avr/pgmspace.h>

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -17,7 +17,15 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include <Arduino.h>                            // for __FlashStringHelper
+#include <HardwareSerial.h>                     // for HardwareSerial
+#include <stdint.h>                             // for uint8_t, uint16_t
+
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for cRGB
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-GhostInTheFirmware/src/Kaleidoscope-GhostInTheFirmware.h
+++ b/plugins/Kaleidoscope-GhostInTheFirmware/src/Kaleidoscope-GhostInTheFirmware.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/GhostInTheFirmware.h>
+#include "kaleidoscope/plugin/GhostInTheFirmware.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-GhostInTheFirmware/src/kaleidoscope/plugin/GhostInTheFirmware.cpp
+++ b/plugins/Kaleidoscope-GhostInTheFirmware/src/kaleidoscope/plugin/GhostInTheFirmware.cpp
@@ -15,10 +15,16 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-GhostInTheFirmware.h>
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/progmem_helpers.h"
+#include "kaleidoscope/plugin/GhostInTheFirmware.h"
+
+#include <stdint.h>                             // for uint16_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/keyswitch_state.h"       // for IS_PRESSED, WAS_PRESSED
+#include "kaleidoscope/progmem_helpers.h"       // for loadFromProgmem
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-GhostInTheFirmware/src/kaleidoscope/plugin/GhostInTheFirmware.h
+++ b/plugins/Kaleidoscope-GhostInTheFirmware/src/kaleidoscope/plugin/GhostInTheFirmware.h
@@ -17,7 +17,11 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include <stdint.h>                             // for uint16_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/Kaleidoscope-Hardware-Dygma-Raise.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/Kaleidoscope-Hardware-Dygma-Raise.h
@@ -18,4 +18,4 @@
 
 #pragma once
 
-#include "kaleidoscope/device/dygma/Raise.h"
+#include "kaleidoscope/device/dygma/Raise.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/Raise.cpp
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/Raise.cpp
@@ -18,15 +18,15 @@
 
 #ifdef ARDUINO_SAMD_RAISE
 
-#include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-EEPROM-Settings.h>
 #include <Kaleidoscope-LEDControl.h>
 #include <KeyboardioHID.h>
 #include <Wire.h>
 
-#include "kaleidoscope/util/crc16.h"
+#include "kaleidoscope/Runtime.h"
 #include "kaleidoscope/driver/color/GammaCorrection.h"
 #include "kaleidoscope/driver/keyscanner/Base_Impl.h"
+#include "kaleidoscope/util/crc16.h"
 
 #define I2C_CLOCK_KHZ 100
 #define I2C_FLASH_CLOCK_KHZ 100 // flashing doesn't work reliably at higher clock speeds

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/Raise.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/Raise.h
@@ -25,12 +25,12 @@
 
 #define CRGB(r,g,b) (cRGB){b, g, r}
 
-#include "kaleidoscope/driver/keyscanner/Base.h"
-#include "kaleidoscope/driver/hid/Keyboardio.h"
-#include "kaleidoscope/driver/led/Base.h"
-#include "kaleidoscope/driver/bootloader/samd/Bossac.h"
-#include "kaleidoscope/driver/storage/Flash.h"
 #include "kaleidoscope/device/Base.h"
+#include "kaleidoscope/driver/bootloader/samd/Bossac.h"
+#include "kaleidoscope/driver/hid/Keyboardio.h"
+#include "kaleidoscope/driver/keyscanner/Base.h"
+#include "kaleidoscope/driver/led/Base.h"
+#include "kaleidoscope/driver/storage/Flash.h"
 #include "kaleidoscope/util/flasher/KeyboardioI2CBootloader.h"
 
 namespace kaleidoscope {

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
@@ -18,9 +18,11 @@
 
 #ifdef ARDUINO_SAMD_RAISE
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-FocusSerial.h>
 #include "kaleidoscope/device/dygma/raise/Focus.h"
+
+#include <Kaleidoscope-FocusSerial.h>
+
+#include "kaleidoscope/Runtime.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/RaiseSide.cpp
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/RaiseSide.cpp
@@ -18,8 +18,9 @@
 
 #ifdef ARDUINO_SAMD_RAISE
 
+#include "kaleidoscope/device/dygma/raise/RaiseSide.h"
+
 #include <Arduino.h>
-#include "RaiseSide.h"
 
 #include "kaleidoscope/driver/color/GammaCorrection.h"
 

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/RaiseSide.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/RaiseSide.h
@@ -21,6 +21,7 @@
 #ifdef ARDUINO_SAMD_RAISE
 
 #include <Arduino.h>
+
 #include "TWI.h"
 
 struct cRGB {

--- a/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/Kaleidoscope-Hardware-EZ-ErgoDox.h
+++ b/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/Kaleidoscope-Hardware-EZ-ErgoDox.h
@@ -17,4 +17,4 @@
  */
 
 #pragma once
-#include "kaleidoscope/device/ez/ErgoDox.h"
+#include "kaleidoscope/device/ez/ErgoDox.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox.cpp
+++ b/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox.cpp
@@ -29,10 +29,10 @@
 
 #include <avr/wdt.h>
 
-#include "kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.h"
-#include "kaleidoscope/keyswitch_state.h"
 #include "kaleidoscope/KeyEvent.h"
 #include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.h"
+#include "kaleidoscope/keyswitch_state.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox.h
+++ b/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox.h
@@ -35,9 +35,9 @@ struct cRGB {
 
 #define CRGB(r,g,b) (cRGB){b, g, r}
 
-#include "kaleidoscope/driver/keyscanner/Base.h"
-#include "kaleidoscope/driver/bootloader/avr/HalfKay.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/bootloader/avr/HalfKay.h"
+#include "kaleidoscope/driver/keyscanner/Base.h"
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #include "kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.h"
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.cpp
+++ b/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.cpp
@@ -27,7 +27,10 @@
 #ifdef ARDUINO_AVR_ERGODOX
 
 #include "kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.h"
+
+#include <Arduino.h>
 #include <avr/wdt.h>
+
 #include "kaleidoscope/device/avr/pins_and_ports.h"
 #include "kaleidoscope/device/ez/ErgoDox/i2cmaster.h"
 

--- a/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.h
+++ b/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.h
@@ -27,7 +27,7 @@
 
 #ifdef ARDUINO_AVR_ERGODOX
 
-#include <Arduino.h>
+#include <stdint.h>
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox/i2cmaster.cpp
+++ b/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox/i2cmaster.cpp
@@ -10,11 +10,10 @@
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #ifdef ARDUINO_AVR_ERGODOX
 
-#include <inttypes.h>
-#include <compat/twi.h>
-
 #include "kaleidoscope/device/ez/ErgoDox/i2cmaster.h"
 
+#include <compat/twi.h>
+#include <inttypes.h>
 
 /* define CPU frequency in Mhz here if not defined in Makefile */
 #ifndef F_CPU

--- a/plugins/Kaleidoscope-Hardware-GD32-Eval/src/Kaleidoscope-Hardware-GD32-Eval.h
+++ b/plugins/Kaleidoscope-Hardware-GD32-Eval/src/Kaleidoscope-Hardware-GD32-Eval.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include "kaleidoscope/device/gd32/Eval.h"
+#include "kaleidoscope/device/gd32/Eval.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Hardware-GD32-Eval/src/kaleidoscope/device/gd32/Eval.h
+++ b/plugins/Kaleidoscope-Hardware-GD32-Eval/src/kaleidoscope/device/gd32/Eval.h
@@ -22,10 +22,9 @@
 #include <Arduino.h>
 
 #include "kaleidoscope/device/Base.h"
-#include "kaleidoscope/driver/storage/GD32Flash.h"
-#include "kaleidoscope/driver/bootloader/gd32/Base.h"
-
 #include "kaleidoscope/device/gd32/eval/KeyScanner.h"
+#include "kaleidoscope/driver/bootloader/gd32/Base.h"
+#include "kaleidoscope/driver/storage/GD32Flash.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-GD32-Eval/src/kaleidoscope/device/gd32/eval/KeyScanner.cpp
+++ b/plugins/Kaleidoscope-Hardware-GD32-Eval/src/kaleidoscope/device/gd32/eval/KeyScanner.cpp
@@ -17,8 +17,9 @@
 
 #ifdef ARDUINO_GD32F303ZE_EVAL
 
-#include "Arduino.h"
-#include "HardwareTimer.h"
+#include <Arduino.h>
+#include <HardwareTimer.h>
+
 #include "kaleidoscope/Runtime.h"
 #include "kaleidoscope/device/gd32/eval/KeyScanner.h"
 

--- a/plugins/Kaleidoscope-Hardware-GD32-Eval/src/kaleidoscope/device/gd32/eval/KeyScanner.h
+++ b/plugins/Kaleidoscope-Hardware-GD32-Eval/src/kaleidoscope/device/gd32/eval/KeyScanner.h
@@ -19,9 +19,9 @@
 
 #ifdef ARDUINO_GD32F303ZE_EVAL
 
-#include <Arduino.h>
-
 #include "kaleidoscope/device/gd32/eval/KeyScanner.h"
+
+#include <Arduino.h>
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-KBDFans-KBD4x/src/Kaleidoscope-Hardware-KBDFans-KBD4x.h
+++ b/plugins/Kaleidoscope-Hardware-KBDFans-KBD4x/src/Kaleidoscope-Hardware-KBDFans-KBD4x.h
@@ -18,4 +18,4 @@
 
 #pragma once
 
-#include "kaleidoscope/device/kbdfans/KBD4x.h"
+#include "kaleidoscope/device/kbdfans/KBD4x.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Hardware-KBDFans-KBD4x/src/kaleidoscope/device/kbdfans/KBD4x.h
+++ b/plugins/Kaleidoscope-Hardware-KBDFans-KBD4x/src/kaleidoscope/device/kbdfans/KBD4x.h
@@ -23,9 +23,9 @@
 
 #include <Arduino.h>
 
-#include "kaleidoscope/driver/keyscanner/ATmega.h"
-#include "kaleidoscope/driver/bootloader/avr/FLIP.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/bootloader/avr/FLIP.h"
+#include "kaleidoscope/driver/keyscanner/ATmega.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Atreus/src/Kaleidoscope-Hardware-Keyboardio-Atreus.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Atreus/src/Kaleidoscope-Hardware-Keyboardio-Atreus.h
@@ -18,4 +18,4 @@
 
 #pragma once
 
-#include "kaleidoscope/device/keyboardio/Atreus2.h"
+#include "kaleidoscope/device/keyboardio/Atreus2.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Atreus/src/kaleidoscope/device/keyboardio/Atreus2.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Atreus/src/kaleidoscope/device/keyboardio/Atreus2.h
@@ -22,8 +22,9 @@
 
 #include <Arduino.h>
 
-#include "kaleidoscope/driver/bootloader/avr/Caterina.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/bootloader/avr/Caterina.h"
+#include "kaleidoscope/driver/keyscanner/ATmega.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Imago/src/Kaleidoscope-Hardware-Keyboardio-Imago.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Imago/src/Kaleidoscope-Hardware-Keyboardio-Imago.h
@@ -18,4 +18,4 @@
 
 #pragma once
 
-#include "kaleidoscope/device/keyboardio/Imago.h"
+#include "kaleidoscope/device/keyboardio/Imago.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Imago/src/kaleidoscope/device/keyboardio/Imago.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Imago/src/kaleidoscope/device/keyboardio/Imago.h
@@ -29,10 +29,10 @@ struct cRGB {
 
 #define CRGB(r,g,b) (cRGB){b, g, r}
 
+#include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/bootloader/avr/Caterina.h"
 #include "kaleidoscope/driver/keyscanner/ATmega.h"
 #include "kaleidoscope/driver/led/Base.h"
-#include "kaleidoscope/driver/bootloader/avr/Caterina.h"
-#include "kaleidoscope/device/ATmega32U4Keyboard.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/Kaleidoscope-Hardware-Keyboardio-Model01.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/Kaleidoscope-Hardware-Keyboardio-Model01.h
@@ -15,6 +15,8 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// IWYU pragma: private, include "kaleidoscope/device/device.h"
+
 #pragma once
 
-#include "kaleidoscope/device/keyboardio/Model01.h"
+#include "kaleidoscope/device/keyboardio/Model01.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/kaleidoscope/device/keyboardio/Model01.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/kaleidoscope/device/keyboardio/Model01.cpp
@@ -17,14 +17,24 @@
 
 #ifdef ARDUINO_AVR_MODEL01
 
-#include "Arduino.h"                                 // for PROGMEM
-#include "kaleidoscope/device/keyboardio/Model01.h"  // for Model01LEDDriver...
-#include "kaleidoscope/driver/keyscanner/Base_Impl.h"
+#include "kaleidoscope/device/keyboardio/Model01.h"
+
+// System headers
+#include <stdint.h>                                  // for uint8_t
+
+// Arduino headers
+#include <Arduino.h>                                 // for PROGMEM
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #include <KeyboardioHID.h>
 #include <avr/wdt.h>
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+
+// Kaleidoscope headers
+#include "kaleidoscope/driver/keyscanner/Base_Impl.h"  // IWYU pragma: keep
+
+// Kaleidoscope-Hardware-Keyboardio-Model01 headers
+#include "kaleidoscope/driver/keyboardio/Model01Side.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/kaleidoscope/device/keyboardio/Model01.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/kaleidoscope/device/keyboardio/Model01.h
@@ -15,11 +15,20 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// IWYU pragma: private, include "kaleidoscope/device/device.h"
+
 #pragma once
 
 #ifdef ARDUINO_AVR_MODEL01
 
-#include <Arduino.h>
+// System headers
+#include <stdint.h>                                       // for uint8_t
+// Arduino headers
+#include <Arduino.h>                                      // for PROGMEM
+
+// Kaleidoscope headers
+#include "kaleidoscope/MatrixAddr.h"                      // for MatrixAddr
+#include "kaleidoscope/macro_helpers.h"                   // for RESTRICT_AR...
 
 #define CRGB(r,g,b) (cRGB){b, g, r}
 
@@ -29,12 +38,13 @@ struct cRGB {
   uint8_t r;
 };
 
-#include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/device/ATmega32U4Keyboard.h"       // for ATmega32U4K...
+#include "kaleidoscope/driver/bootloader/avr/Caterina.h"  // for Caterina
+#include "kaleidoscope/driver/keyscanner/Base.h"          // for BaseProps
+#include "kaleidoscope/driver/led/Base.h"                 // for BaseProps
 
-#include "kaleidoscope/driver/keyscanner/Base.h"
-#include "kaleidoscope/driver/keyboardio/Model01Side.h"
-#include "kaleidoscope/driver/led/Base.h"
-#include "kaleidoscope/driver/bootloader/avr/Caterina.h"
+// Kaleidoscope-Hardware-Keyboardio-Model01 headers
+#include "kaleidoscope/driver/keyboardio/Model01Side.h"   // for keydata_t
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/kaleidoscope/driver/keyboardio/Model01Side.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/kaleidoscope/driver/keyboardio/Model01Side.cpp
@@ -22,14 +22,18 @@
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
+#include "kaleidoscope/driver/keyboardio/Model01Side.h"
+
 #include <Arduino.h>
-#include "Model01Side.h"
 
 extern "C" {
 #include "kaleidoscope/device/keyboardio/twi.h"
 }
 
+// Kaleidoscope headers
 #include "kaleidoscope/driver/color/GammaCorrection.h"
+// Kaleidoscope-Hardware-Keyboardio-Model01 headers
+#include "kaleidoscope/driver/keyboardio/wire-protocol-constants.h"
 
 namespace kaleidoscope {
 namespace driver {

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/kaleidoscope/driver/keyboardio/Model01Side.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/kaleidoscope/driver/keyboardio/Model01Side.h
@@ -23,8 +23,8 @@
 
 #pragma once
 
-#include <Arduino.h>
-#include "wire-protocol-constants.h"
+// System headers
+#include <stdint.h>  // for uint8_t, uint32_t
 
 // We allow cRGB/CRGB to be defined already when this is included.
 //
@@ -97,8 +97,6 @@ class Model01Side {
   void sendLEDBank(uint8_t bank);
   int readRegister(uint8_t cmd);
 };
-#else // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-class Model01Side;
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
 } // namespace keyboardio

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/Kaleidoscope-Hardware-Keyboardio-Model100.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/Kaleidoscope-Hardware-Keyboardio-Model100.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include "kaleidoscope/device/keyboardio/Model100.h"
+#include "kaleidoscope/device/keyboardio/Model100.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.cpp
@@ -17,14 +17,12 @@
 
 #ifdef ARDUINO_keyboardio_model_100
 
-#include "Arduino.h"                                 // for PROGMEM
-#include "kaleidoscope/device/keyboardio/Model100.h"  // for Model100LEDDriver...
-#include "kaleidoscope/driver/keyscanner/Base_Impl.h"
+#include "kaleidoscope/device/keyboardio/Model100.h"
 
-#include "Wire.h"
+#include <Arduino.h>                                   // for PROGMEM
+#include <Wire.h>                                      // for Wire
 
-#ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-#endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+#include "kaleidoscope/driver/keyscanner/Base_Impl.h"  // For Base<>
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.h
@@ -34,14 +34,14 @@ struct cRGB {
 };
 
 
-#include "kaleidoscope/driver/keyscanner/Base.h"
-#include "kaleidoscope/driver/storage/GD32Flash.h"
-#include "kaleidoscope/driver/keyboardio/Model100Side.h"
-#include "kaleidoscope/driver/led/Base.h"
 #include "kaleidoscope/device/Base.h"
-#include "kaleidoscope/driver/hid/Keyboardio.h"
-#include "kaleidoscope/driver/hid/Base.h"
 #include "kaleidoscope/driver/bootloader/gd32/Base.h"
+#include "kaleidoscope/driver/hid/Base.h"
+#include "kaleidoscope/driver/hid/Keyboardio.h"
+#include "kaleidoscope/driver/keyboardio/Model100Side.h"
+#include "kaleidoscope/driver/keyscanner/Base.h"
+#include "kaleidoscope/driver/led/Base.h"
+#include "kaleidoscope/driver/storage/GD32Flash.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/driver/keyboardio/Model100Side.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/driver/keyboardio/Model100Side.cpp
@@ -22,12 +22,14 @@
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
+#include "kaleidoscope/driver/keyboardio/Model100Side.h"
+
 #include <Arduino.h>
-#include "Model100Side.h"
 #include <Wire.h>
 #include <utility/twi.h>
 
 #include "kaleidoscope/driver/color/GammaCorrection.h"
+#include "kaleidoscope/driver/keyboardio/wire-protocol-constants.h"
 
 namespace kaleidoscope {
 namespace driver {

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/driver/keyboardio/Model100Side.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/driver/keyboardio/Model100Side.h
@@ -23,8 +23,8 @@
 
 #pragma once
 
-#include <Arduino.h>
-#include "wire-protocol-constants.h"
+#include <Arduino.h>  // for byte
+#include <stdint.h>   // for uint8_t, uint32_t
 
 // We allow cRGB/CRGB to be defined already when this is included.
 //
@@ -105,8 +105,6 @@ class Model100Side {
   int readRegister(uint8_t cmd);
   uint8_t writeData(uint8_t* data, uint8_t length);
 };
-#else // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-class Model100Side;
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
 } // namespace keyboardio

--- a/plugins/Kaleidoscope-Hardware-OLKB-Planck/src/Kaleidoscope-Hardware-OLKB-Planck.h
+++ b/plugins/Kaleidoscope-Hardware-OLKB-Planck/src/Kaleidoscope-Hardware-OLKB-Planck.h
@@ -18,4 +18,4 @@
 
 #pragma once
 
-#include "kaleidoscope/device/olkb/Planck.h"
+#include "kaleidoscope/device/olkb/Planck.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Hardware-OLKB-Planck/src/kaleidoscope/device/olkb/Planck.cpp
+++ b/plugins/Kaleidoscope-Hardware-OLKB-Planck/src/kaleidoscope/device/olkb/Planck.cpp
@@ -18,6 +18,8 @@
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #ifdef ARDUINO_AVR_PLANCK
 
+#include "kaleidoscope/device/olkb/Planck.h"
+
 #include "kaleidoscope/Runtime.h"
 #include "kaleidoscope/driver/keyscanner/Base_Impl.h"
 

--- a/plugins/Kaleidoscope-Hardware-OLKB-Planck/src/kaleidoscope/device/olkb/Planck.h
+++ b/plugins/Kaleidoscope-Hardware-OLKB-Planck/src/kaleidoscope/device/olkb/Planck.h
@@ -21,8 +21,9 @@
 
 #include <Arduino.h>
 
-#include "kaleidoscope/driver/bootloader/avr/HalfKay.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/bootloader/avr/HalfKay.h"
+#include "kaleidoscope/driver/keyscanner/ATmega.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-SOFTHRUF-Splitography/src/Kaleidoscope-Hardware-SOFTHRUF-Splitography.h
+++ b/plugins/Kaleidoscope-Hardware-SOFTHRUF-Splitography/src/Kaleidoscope-Hardware-SOFTHRUF-Splitography.h
@@ -18,4 +18,4 @@
 
 #pragma once
 
-#include "kaleidoscope/device/softhruf/Splitography.h"
+#include "kaleidoscope/device/softhruf/Splitography.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Hardware-SOFTHRUF-Splitography/src/kaleidoscope/device/softhruf/Splitography.cpp
+++ b/plugins/Kaleidoscope-Hardware-SOFTHRUF-Splitography/src/kaleidoscope/device/softhruf/Splitography.cpp
@@ -25,6 +25,8 @@
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #ifdef ARDUINO_AVR_SPLITOGRAPHY
 
+#include "kaleidoscope/device/softhruf/Splitography.h"
+
 #include "kaleidoscope/Runtime.h"
 #include "kaleidoscope/driver/keyscanner/Base_Impl.h"
 

--- a/plugins/Kaleidoscope-Hardware-SOFTHRUF-Splitography/src/kaleidoscope/device/softhruf/Splitography.h
+++ b/plugins/Kaleidoscope-Hardware-SOFTHRUF-Splitography/src/kaleidoscope/device/softhruf/Splitography.h
@@ -30,9 +30,9 @@
 
 #include <Arduino.h>
 
-#include "kaleidoscope/driver/keyscanner/ATmega.h"
-#include "kaleidoscope/driver/bootloader/avr/FLIP.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/bootloader/avr/FLIP.h"
+#include "kaleidoscope/driver/keyscanner/ATmega.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-Technomancy-Atreus/src/Kaleidoscope-Hardware-Technomancy-Atreus.h
+++ b/plugins/Kaleidoscope-Hardware-Technomancy-Atreus/src/Kaleidoscope-Hardware-Technomancy-Atreus.h
@@ -24,4 +24,4 @@
 #define KALEIDOSCOPE_HARDWARE_ATREUS_PINOUT_ASTAR 1
 #endif
 
-#include "kaleidoscope/device/technomancy/Atreus.h"
+#include "kaleidoscope/device/technomancy/Atreus.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Hardware-Technomancy-Atreus/src/kaleidoscope/device/technomancy/Atreus.cpp
+++ b/plugins/Kaleidoscope-Hardware-Technomancy-Atreus/src/kaleidoscope/device/technomancy/Atreus.cpp
@@ -27,6 +27,8 @@
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #ifdef ARDUINO_AVR_ATREUS
 
+#include "kaleidoscope/device/technomancy/Atreus.h"
+
 #include "kaleidoscope/Runtime.h"
 #include "kaleidoscope/driver/keyscanner/Base_Impl.h"
 

--- a/plugins/Kaleidoscope-Hardware-Technomancy-Atreus/src/kaleidoscope/device/technomancy/Atreus.h
+++ b/plugins/Kaleidoscope-Hardware-Technomancy-Atreus/src/kaleidoscope/device/technomancy/Atreus.h
@@ -28,9 +28,10 @@
 
 #include <Arduino.h>
 
-#include "kaleidoscope/driver/bootloader/avr/HalfKay.h"
-#include "kaleidoscope/driver/bootloader/avr/Caterina.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/bootloader/avr/Caterina.h"
+#include "kaleidoscope/driver/bootloader/avr/HalfKay.h"
+#include "kaleidoscope/driver/keyscanner/ATmega.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-gHeavy-ButterStick/src/Kaleidoscope-Hardware-gHeavy-ButterStick.h
+++ b/plugins/Kaleidoscope-Hardware-gHeavy-ButterStick/src/Kaleidoscope-Hardware-gHeavy-ButterStick.h
@@ -18,4 +18,4 @@
 
 #pragma once
 
-#include "kaleidoscope/device/gheavy/ButterStick.h"
+#include "kaleidoscope/device/gheavy/ButterStick.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Hardware-gHeavy-ButterStick/src/kaleidoscope/device/gheavy/ButterStick.cpp
+++ b/plugins/Kaleidoscope-Hardware-gHeavy-ButterStick/src/kaleidoscope/device/gheavy/ButterStick.cpp
@@ -18,6 +18,8 @@
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #ifdef ARDUINO_AVR_GHEAVY_BUTTERSTICK
 
+#include "kaleidoscope/device/gheavy/ButterStick.h"
+
 #include "kaleidoscope/Runtime.h"
 #include "kaleidoscope/driver/keyscanner/Base_Impl.h"
 

--- a/plugins/Kaleidoscope-Hardware-gHeavy-ButterStick/src/kaleidoscope/device/gheavy/ButterStick.h
+++ b/plugins/Kaleidoscope-Hardware-gHeavy-ButterStick/src/kaleidoscope/device/gheavy/ButterStick.h
@@ -23,9 +23,9 @@
 
 #include <Arduino.h>
 
-#include "kaleidoscope/driver/keyscanner/ATmega.h"
-#include "kaleidoscope/driver/bootloader/avr/FLIP.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/bootloader/avr/FLIP.h"
+#include "kaleidoscope/driver/keyscanner/ATmega.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-Hardware-gHeavy-FaunchPad/src/Kaleidoscope-Hardware-gHeavy-FaunchPad.h
+++ b/plugins/Kaleidoscope-Hardware-gHeavy-FaunchPad/src/Kaleidoscope-Hardware-gHeavy-FaunchPad.h
@@ -18,4 +18,4 @@
 
 #pragma once
 
-#include "kaleidoscope/device/gheavy/FaunchPad.h"
+#include "kaleidoscope/device/gheavy/FaunchPad.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Hardware-gHeavy-FaunchPad/src/kaleidoscope/device/gheavy/FaunchPad.cpp
+++ b/plugins/Kaleidoscope-Hardware-gHeavy-FaunchPad/src/kaleidoscope/device/gheavy/FaunchPad.cpp
@@ -18,6 +18,8 @@
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #ifdef ARDUINO_AVR_GHEAVY_FAUNCHPAD
 
+#include "kaleidoscope/device/gheavy/FaunchPad.h"
+
 #include "kaleidoscope/Runtime.h"
 #include "kaleidoscope/driver/keyscanner/Base_Impl.h"
 

--- a/plugins/Kaleidoscope-Hardware-gHeavy-FaunchPad/src/kaleidoscope/device/gheavy/FaunchPad.h
+++ b/plugins/Kaleidoscope-Hardware-gHeavy-FaunchPad/src/kaleidoscope/device/gheavy/FaunchPad.h
@@ -23,9 +23,9 @@
 
 #include <Arduino.h>
 
-#include "kaleidoscope/driver/keyscanner/ATmega.h"
-#include "kaleidoscope/driver/bootloader/avr/FLIP.h"
 #include "kaleidoscope/device/ATmega32U4Keyboard.h"
+#include "kaleidoscope/driver/bootloader/avr/FLIP.h"
+#include "kaleidoscope/driver/keyscanner/ATmega.h"
 
 namespace kaleidoscope {
 namespace device {

--- a/plugins/Kaleidoscope-HardwareTestMode/src/Kaleidoscope-HardwareTestMode.h
+++ b/plugins/Kaleidoscope-HardwareTestMode/src/Kaleidoscope-HardwareTestMode.h
@@ -16,4 +16,4 @@
 
 #pragma once
 
-#include "kaleidoscope/plugin/HardwareTestMode.h"
+#include "kaleidoscope/plugin/HardwareTestMode.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-HardwareTestMode/src/kaleidoscope/plugin/HardwareTestMode.cpp
+++ b/plugins/Kaleidoscope-HardwareTestMode/src/kaleidoscope/plugin/HardwareTestMode.cpp
@@ -14,9 +14,16 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/Runtime.h"
-#include "Kaleidoscope-HardwareTestMode.h"
-#include "Kaleidoscope-LEDEffect-Rainbow.h"
+#include "kaleidoscope/plugin/HardwareTestMode.h"
+
+#include <stdint.h>                                       // for uint8_t
+
+#include "kaleidoscope/KeyAddr.h"                         // for MatrixAddr
+#include "kaleidoscope/Runtime.h"                         // for Runtime
+#include "kaleidoscope/device/device.h"                   // for Device, cRGB
+#include "kaleidoscope/driver/hid/keyboardio/Keyboard.h"  // for Keyboard
+#include "kaleidoscope/plugin/LEDControl.h"               // for LEDControl
+#include "kaleidoscope/plugin/LEDControl/LEDUtils.h"      // for hsvToRgb
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-HardwareTestMode/src/kaleidoscope/plugin/HardwareTestMode.h
+++ b/plugins/Kaleidoscope-HardwareTestMode/src/kaleidoscope/plugin/HardwareTestMode.h
@@ -16,8 +16,10 @@
 
 #pragma once
 
-#include <Arduino.h>
-#include "kaleidoscope/Runtime.h"
+#include <stdint.h>                      // for uint8_t
+
+#include "kaleidoscope/device/device.h"  // for cRGB
+#include "kaleidoscope/plugin.h"         // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Heatmap/src/Kaleidoscope-Heatmap.h
+++ b/plugins/Kaleidoscope-Heatmap/src/Kaleidoscope-Heatmap.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/Heatmap.h>
+#include "kaleidoscope/plugin/Heatmap.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Heatmap/src/kaleidoscope/plugin/Heatmap.cpp
+++ b/plugins/Kaleidoscope-Heatmap/src/kaleidoscope/plugin/Heatmap.cpp
@@ -15,10 +15,18 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-Heatmap.h>
-#include <Kaleidoscope-LEDControl.h>
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/plugin/Heatmap.h"
+
+#include <Arduino.h>                            // for pgm_read_byte, PROGMEM
+#include <stdint.h>                             // for uint16_t, uint8_t
+
+#include "kaleidoscope/KeyAddr.h"               // for MatrixAddr, MatrixAdd...
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for cRGB
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/keyswitch_state.h"       // for keyIsInjected, keyTog...
+#include "kaleidoscope/plugin/LEDControl.h"     // for LEDControl
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Heatmap/src/kaleidoscope/plugin/Heatmap.h
+++ b/plugins/Kaleidoscope-Heatmap/src/kaleidoscope/plugin/Heatmap.h
@@ -17,8 +17,16 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-LEDControl.h>
+#include <stdint.h>                                      // for uint16_t
+
+#include "kaleidoscope/KeyEvent.h"                       // for KeyEvent
+#include "kaleidoscope/Runtime.h"                        // for Runtime, Run...
+#include "kaleidoscope/device/device.h"                  // for cRGB, Device
+#include "kaleidoscope/event_handler_result.h"           // for EventHandler...
+#include "kaleidoscope/plugin.h"                         // for Plugin
+#include "kaleidoscope/plugin/AccessTransientLEDMode.h"  // for AccessTransi...
+#include "kaleidoscope/plugin/LEDMode.h"                 // for LEDMode
+#include "kaleidoscope/plugin/LEDModeInterface.h"        // for LEDModeInter...
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-HostOS/src/Kaleidoscope-HostOS.h
+++ b/plugins/Kaleidoscope-HostOS/src/Kaleidoscope-HostOS.h
@@ -17,5 +17,5 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/HostOS.h>
-#include <kaleidoscope/plugin/HostOS-Focus.h>
+#include "kaleidoscope/plugin/HostOS-Focus.h"  // IWYU pragma: export
+#include "kaleidoscope/plugin/HostOS.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.cpp
+++ b/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.cpp
@@ -15,8 +15,14 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-HostOS.h>
-#include <Kaleidoscope-FocusSerial.h>
+#include "kaleidoscope/plugin/HostOS-Focus.h"
+
+#include <Arduino.h>                            // for PSTR, strcmp_P
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <stdint.h>                             // for uint8_t
+
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin/HostOS.h"         // for HostOS, Type
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.h
+++ b/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.h
@@ -17,7 +17,8 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS.cpp
+++ b/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS.cpp
@@ -15,8 +15,13 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <kaleidoscope/plugin/HostOS.h>
-#include <Kaleidoscope-EEPROM-Settings.h>
+#include "kaleidoscope/plugin/HostOS.h"
+
+#include <Kaleidoscope-EEPROM-Settings.h>       // for EEPROMSettings
+
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for VirtualProps::Storage
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS.h
+++ b/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS.h
@@ -17,7 +17,10 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include <stdint.h>                             // for uint16_t
+
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-HostPowerManagement/src/Kaleidoscope-HostPowerManagement.h
+++ b/plugins/Kaleidoscope-HostPowerManagement/src/Kaleidoscope-HostPowerManagement.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/HostPowerManagement.h>
+#include "kaleidoscope/plugin/HostPowerManagement.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.cpp
+++ b/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.cpp
@@ -15,9 +15,12 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-HostPowerManagement.h>
-#include <Kaleidoscope-LEDControl.h>
+#include "kaleidoscope/plugin/HostPowerManagement.h"
+
+#include <Arduino.h>  // IWYU pragma: keep
+#include <stdint.h>                             // for uint8_t
+
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
 
 // This is a terrible hack until Arduino#6964 gets implemented.
 // It makes the `_usbSuspendState` symbol available to us.

--- a/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.h
+++ b/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.h
@@ -17,7 +17,8 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-IdleLEDs/src/Kaleidoscope-IdleLEDs.h
+++ b/plugins/Kaleidoscope-IdleLEDs/src/Kaleidoscope-IdleLEDs.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/IdleLEDs.h>
+#include "kaleidoscope/plugin/IdleLEDs.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -16,10 +16,18 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-IdleLEDs.h>
-#include <Kaleidoscope-LEDControl.h>
-#include <Kaleidoscope-EEPROM-Settings.h>
-#include <Kaleidoscope-FocusSerial.h>
+#include "kaleidoscope/plugin/IdleLEDs.h"
+
+#include <Arduino.h>                            // for F, PSTR, __FlashStrin...
+#include <Kaleidoscope-EEPROM-Settings.h>       // for EEPROMSettings
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <stdint.h>                             // for uint32_t, uint16_t
+
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for VirtualProps::Storage
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin/LEDControl.h"     // for LEDControl
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.h
+++ b/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.h
@@ -18,7 +18,11 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include <stdint.h>                             // for uint32_t, uint16_t
+
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LED-ActiveLayerColor/src/Kaleidoscope-LED-ActiveLayerColor.h
+++ b/plugins/Kaleidoscope-LED-ActiveLayerColor/src/Kaleidoscope-LED-ActiveLayerColor.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/LED-ActiveLayerColor.h>
+#include "kaleidoscope/plugin/LED-ActiveLayerColor.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LED-ActiveLayerColor/src/kaleidoscope/plugin/LED-ActiveLayerColor.cpp
+++ b/plugins/Kaleidoscope-LED-ActiveLayerColor/src/kaleidoscope/plugin/LED-ActiveLayerColor.cpp
@@ -15,8 +15,16 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-LED-ActiveLayerColor.h>
-#include "kaleidoscope/layers.h"
+#include "kaleidoscope/plugin/LED-ActiveLayerColor.h"
+
+#include <Arduino.h>                            // for pgm_read_byte
+#include <stdint.h>                             // for uint8_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/layers.h"                // for Layer, Layer_
+#include "kaleidoscope/plugin/LEDControl.h"     // for LEDControl
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LED-ActiveLayerColor/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
+++ b/plugins/Kaleidoscope-LED-ActiveLayerColor/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
@@ -17,7 +17,13 @@
 
 #pragma once
 
-#include <Kaleidoscope-LEDControl.h>
+#include "kaleidoscope/KeyAddr.h"                        // for KeyAddr
+#include "kaleidoscope/device/device.h"                  // for cRGB
+#include "kaleidoscope/event_handler_result.h"           // for EventHandler...
+#include "kaleidoscope/plugin.h"                         // for Plugin
+#include "kaleidoscope/plugin/AccessTransientLEDMode.h"  // for AccessTransi...
+#include "kaleidoscope/plugin/LEDMode.h"                 // for LEDMode
+#include "kaleidoscope/plugin/LEDModeInterface.h"        // for LEDModeInter...
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LED-ActiveModColor/src/Kaleidoscope-LED-ActiveModColor.h
+++ b/plugins/Kaleidoscope-LED-ActiveModColor/src/Kaleidoscope-LED-ActiveModColor.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/LED-ActiveModColor.h>
+#include "kaleidoscope/plugin/LED-ActiveModColor.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LED-ActiveModColor/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
+++ b/plugins/Kaleidoscope-LED-ActiveModColor/src/kaleidoscope/plugin/LED-ActiveModColor.cpp
@@ -15,12 +15,20 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-LED-ActiveModColor.h>
-#include <Kaleidoscope-OneShot.h>
-#include <Kaleidoscope-OneShotMetaKeys.h>
-#include "kaleidoscope/LiveKeys.h"
-#include "kaleidoscope/layers.h"
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/plugin/LED-ActiveModColor.h"
+
+#include <Kaleidoscope-OneShot.h>               // for OneShot
+#include <Kaleidoscope-OneShotMetaKeys.h>       // for OneShot_ActiveStickyKey
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr, MatrixAddr
+#include "kaleidoscope/KeyAddrBitfield.h"       // for KeyAddrBitfield, KeyA...
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/LiveKeys.h"              // for LiveKeys, live_keys
+#include "kaleidoscope/device/device.h"         // for CRGB, cRGB
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_Inactive
+#include "kaleidoscope/keyswitch_state.h"       // for keyToggledOn
+#include "kaleidoscope/plugin/LEDControl.h"     // for LEDControl
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LED-ActiveModColor/src/kaleidoscope/plugin/LED-ActiveModColor.h
+++ b/plugins/Kaleidoscope-LED-ActiveModColor/src/kaleidoscope/plugin/LED-ActiveModColor.h
@@ -17,9 +17,11 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include "kaleidoscope/KeyAddrBitfield.h"
-#include <Kaleidoscope-LEDControl.h>
+#include "kaleidoscope/KeyAddrBitfield.h"       // for KeyAddrBitfield
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/device/device.h"         // for cRGB
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 #define MAX_MODS_PER_LAYER 16
 

--- a/plugins/Kaleidoscope-LED-AlphaSquare/src/Kaleidoscope-LED-AlphaSquare.h
+++ b/plugins/Kaleidoscope-LED-AlphaSquare/src/Kaleidoscope-LED-AlphaSquare.h
@@ -17,6 +17,6 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/LED-AlphaSquare.h>
-#include <kaleidoscope/plugin/LED-AlphaSquare/Effect.h>
-#include <kaleidoscope/plugin/LED-AlphaSquare/Symbols.h>
+#include "kaleidoscope/plugin/LED-AlphaSquare.h"  // IWYU pragma: export
+#include "kaleidoscope/plugin/LED-AlphaSquare/Effect.h"  // IWYU pragma: export
+#include "kaleidoscope/plugin/LED-AlphaSquare/Symbols.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
+++ b/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
@@ -15,8 +15,18 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-LED-AlphaSquare.h>
-#include <kaleidoscope/plugin/LED-AlphaSquare/Font-4x4.h>
+#include "kaleidoscope/plugin/LED-AlphaSquare.h"
+
+#include <Arduino.h>                                       // for bitRead
+#include <stdint.h>                                        // for uint16_t
+
+#include "kaleidoscope/KeyAddr.h"                          // for KeyAddr
+#include "kaleidoscope/Runtime.h"                          // for Runtime
+#include "kaleidoscope/device/device.h"                    // for cRGB
+#include "kaleidoscope/key_defs.h"                         // for Key, Key_A
+#include "kaleidoscope/plugin/LEDControl.h"                // for LEDControl
+
+#include "kaleidoscope/plugin/LED-AlphaSquare/Font-4x4.h"  // for ALPHASQUAR...
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare.h
+++ b/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare.h
@@ -17,8 +17,13 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-LEDControl.h>
+#include <stdint.h>                 // for uint16_t, uint8_t
+
+#include "kaleidoscope/KeyAddr.h"   // for KeyAddr
+#include "kaleidoscope/key_defs.h"  // for Key
+#include "kaleidoscope/plugin.h"    // for Plugin
+
+struct cRGB;
 
 #define SYM4x4(                                                   \
                p00, p01, p02, p03,                                \

--- a/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
+++ b/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
@@ -15,8 +15,20 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-LED-AlphaSquare.h>
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/plugin/LED-AlphaSquare/Effect.h"
+
+#include <stdint.h>                               // for uint16_t, uint8_t
+
+#include "kaleidoscope/KeyAddr.h"                 // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"                // for KeyEvent
+#include "kaleidoscope/Runtime.h"                 // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"           // for Device, CRGB
+#include "kaleidoscope/event_handler_result.h"    // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"                // for Key, Key_NoKey, Key_0
+#include "kaleidoscope/keyswitch_state.h"         // for keyIsInjected
+#include "kaleidoscope/plugin/LEDControl.h"       // for LEDControl
+
+#include "kaleidoscope/plugin/LED-AlphaSquare.h"  // for AlphaSquare
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
+++ b/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
@@ -17,8 +17,16 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-LEDControl.h>
+#include <stdint.h>                                      // for uint16_t
+
+#include "kaleidoscope/KeyAddr.h"                        // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"                       // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"           // for EventHandler...
+#include "kaleidoscope/key_defs.h"                       // for Key
+#include "kaleidoscope/plugin.h"                         // for Plugin
+#include "kaleidoscope/plugin/AccessTransientLEDMode.h"  // for AccessTransi...
+#include "kaleidoscope/plugin/LEDMode.h"                 // for LEDMode
+#include "kaleidoscope/plugin/LEDModeInterface.h"        // for LEDModeInter...
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare/Symbols.h
+++ b/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare/Symbols.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/LED-AlphaSquare.h>
+#include <stdint.h>                               // for uint16_t
+
+#include "kaleidoscope/plugin/LED-AlphaSquare.h"  // for SYM4x4
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/Kaleidoscope-LED-Palette-Theme.h
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/Kaleidoscope-LED-Palette-Theme.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/LED-Palette-Theme.h>
+#include "kaleidoscope/plugin/LED-Palette-Theme.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -15,9 +15,19 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-LED-Palette-Theme.h>
-#include <Kaleidoscope-EEPROM-Settings.h>
-#include <Kaleidoscope-FocusSerial.h>
+#include "kaleidoscope/plugin/LED-Palette-Theme.h"
+
+#include <Arduino.h>                            // for strcmp_P, PSTR
+#include <Kaleidoscope-EEPROM-Settings.h>       // for EEPROMSettings
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <stdint.h>                             // for uint8_t, uint16_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/Base.h"           // for Base<>::Storage
+#include "kaleidoscope/device/device.h"         // for cRGB, VirtualProps::S...
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin/LEDControl.h"     // for LEDControl
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.h
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.h
@@ -17,8 +17,12 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-LEDControl.h>
+#include <stdint.h>                             // for uint16_t, uint8_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/device/device.h"         // for cRGB
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LED-Stalker/src/Kaleidoscope-LED-Stalker.h
+++ b/plugins/Kaleidoscope-LED-Stalker/src/Kaleidoscope-LED-Stalker.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/LED-Stalker.h>
+#include "kaleidoscope/plugin/LED-Stalker.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LED-Stalker/src/kaleidoscope/plugin/LED-Stalker.cpp
+++ b/plugins/Kaleidoscope-LED-Stalker/src/kaleidoscope/plugin/LED-Stalker.cpp
@@ -15,9 +15,18 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-LED-Stalker.h>
-#include <Kaleidoscope-LEDControl.h>
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/plugin/LED-Stalker.h"
+
+#include <Arduino.h>                                  // for min
+#include <stdint.h>                                   // for uint8_t, uint16_t
+
+#include "kaleidoscope/KeyAddr.h"                     // for MatrixAddr, Key...
+#include "kaleidoscope/KeyEvent.h"                    // for KeyEvent
+#include "kaleidoscope/Runtime.h"                     // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"               // for cRGB, CRGB
+#include "kaleidoscope/event_handler_result.h"        // for EventHandlerResult
+#include "kaleidoscope/plugin/LEDControl.h"           // for LEDControl
+#include "kaleidoscope/plugin/LEDControl/LEDUtils.h"  // for hsvToRgb
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LED-Stalker/src/kaleidoscope/plugin/LED-Stalker.h
+++ b/plugins/Kaleidoscope-LED-Stalker/src/kaleidoscope/plugin/LED-Stalker.h
@@ -17,8 +17,16 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-LEDControl.h>
+#include <stdint.h>                                      // for uint8_t, uin...
+
+#include "kaleidoscope/KeyEvent.h"                       // for KeyEvent
+#include "kaleidoscope/Runtime.h"                        // for Runtime, Run...
+#include "kaleidoscope/device/device.h"                  // for cRGB, CRGB
+#include "kaleidoscope/event_handler_result.h"           // for EventHandler...
+#include "kaleidoscope/plugin.h"                         // for Plugin
+#include "kaleidoscope/plugin/AccessTransientLEDMode.h"  // for AccessTransi...
+#include "kaleidoscope/plugin/LEDMode.h"                 // for LEDMode
+#include "kaleidoscope/plugin/LEDModeInterface.h"        // for LEDModeInter...
 
 #define STALKER(v, ...) ({static kaleidoscope::plugin::stalker::v _effect __VA_ARGS__; &_effect;})
 

--- a/plugins/Kaleidoscope-LED-Wavepool/src/Kaleidoscope-LED-Wavepool.h
+++ b/plugins/Kaleidoscope-LED-Wavepool/src/Kaleidoscope-LED-Wavepool.h
@@ -18,4 +18,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/LED-Wavepool.h>
+#include "kaleidoscope/plugin/LED-Wavepool.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LED-Wavepool/src/kaleidoscope/plugin/LED-Wavepool.cpp
+++ b/plugins/Kaleidoscope-LED-Wavepool/src/kaleidoscope/plugin/LED-Wavepool.cpp
@@ -18,8 +18,19 @@
 
 #ifdef ARDUINO_AVR_MODEL01
 
-#include <Kaleidoscope-LED-Wavepool.h>
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/plugin/LED-Wavepool.h"
+
+#include <Arduino.h>                                  // for pgm_read_byte
+#include <stdint.h>                                   // for int8_t, uint8_t
+
+#include "kaleidoscope/KeyAddr.h"                     // for MatrixAddr, Key...
+#include "kaleidoscope/KeyEvent.h"                    // for KeyEvent
+#include "kaleidoscope/Runtime.h"                     // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"               // for Device, cRGB
+#include "kaleidoscope/event_handler_result.h"        // for EventHandlerResult
+#include "kaleidoscope/keyswitch_state.h"             // for keyIsPressed
+#include "kaleidoscope/plugin/LEDControl.h"           // for LEDControl
+#include "kaleidoscope/plugin/LEDControl/LEDUtils.h"  // for hsvToRgb
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LED-Wavepool/src/kaleidoscope/plugin/LED-Wavepool.h
+++ b/plugins/Kaleidoscope-LED-Wavepool/src/kaleidoscope/plugin/LED-Wavepool.h
@@ -20,8 +20,17 @@
 
 #ifdef ARDUINO_AVR_MODEL01
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-LEDControl.h>
+#include <Arduino.h>                                     // for PROGMEM
+#include <stdint.h>                                      // for uint8_t, int...
+
+#include "kaleidoscope/KeyEvent.h"                       // for KeyEvent
+#include "kaleidoscope/Runtime.h"                        // for Runtime, Run...
+#include "kaleidoscope/device/device.h"                  // for Device
+#include "kaleidoscope/event_handler_result.h"           // for EventHandler...
+#include "kaleidoscope/plugin.h"                         // for Plugin
+#include "kaleidoscope/plugin/AccessTransientLEDMode.h"  // for AccessTransi...
+#include "kaleidoscope/plugin/LEDMode.h"                 // for LEDMode
+#include "kaleidoscope/plugin/LEDModeInterface.h"        // for LEDModeInter...
 
 #define WP_WID 14
 #define WP_HGT 5

--- a/plugins/Kaleidoscope-LEDEffect-BootAnimation/src/Kaleidoscope-LEDEffect-BootAnimation.h
+++ b/plugins/Kaleidoscope-LEDEffect-BootAnimation/src/Kaleidoscope-LEDEffect-BootAnimation.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include "kaleidoscope/plugin/LEDEffect-BootAnimation.h"
+#include "kaleidoscope/plugin/LEDEffect-BootAnimation.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LEDEffect-BootAnimation/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
+++ b/plugins/Kaleidoscope-LEDEffect-BootAnimation/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
@@ -15,8 +15,18 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope-LEDEffect-BootAnimation.h"
-#include "kaleidoscope/layers.h"
+#include "Kaleidoscope/plugin/LEDEffect-BootAnimation.h"
+
+#include <Arduino.h>                            // for PROGMEM, pgm_read_byte
+#include <stdint.h>                             // for uint16_t, uint8_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr, MatrixAddr
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for CRGB, cRGB
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_O, Key_A, Key_B
+#include "kaleidoscope/layers.h"                // for Layer, Layer_
+#include "kaleidoscope/plugin/LEDControl.h"     // for LEDControl
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LEDEffect-BootAnimation/src/kaleidoscope/plugin/LEDEffect-BootAnimation.h
+++ b/plugins/Kaleidoscope-LEDEffect-BootAnimation/src/kaleidoscope/plugin/LEDEffect-BootAnimation.h
@@ -17,8 +17,12 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include "Kaleidoscope-LEDControl.h"
+#include <stdint.h>                             // for uint16_t, uint8_t
+
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
+
+struct cRGB;
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LEDEffect-BootGreeting/src/Kaleidoscope-LEDEffect-BootGreeting.h
+++ b/plugins/Kaleidoscope-LEDEffect-BootGreeting/src/Kaleidoscope-LEDEffect-BootGreeting.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include "kaleidoscope/plugin/LEDEffect-BootGreeting.h"
+#include "kaleidoscope/plugin/LEDEffect-BootGreeting.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LEDEffect-BootGreeting/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
+++ b/plugins/Kaleidoscope-LEDEffect-BootGreeting/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
@@ -15,8 +15,18 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope-LEDEffect-BootGreeting.h"
-#include "kaleidoscope/layers.h"
+#include "kaleidoscope/plugin/LEDEffect-BootGreeting.h"
+
+#include <stdint.h>                                   // for uint16_t, uint8_t
+
+#include "kaleidoscope/KeyAddr.h"                     // for KeyAddr, Matrix...
+#include "kaleidoscope/Runtime.h"                     // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"               // for cRGB
+#include "kaleidoscope/event_handler_result.h"        // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"                    // for Key
+#include "kaleidoscope/layers.h"                      // for Layer, Layer_
+#include "kaleidoscope/plugin/LEDControl.h"           // for LEDControl, Key...
+#include "kaleidoscope/plugin/LEDControl/LEDUtils.h"  // for breath_compute
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LEDEffect-BootGreeting/src/kaleidoscope/plugin/LEDEffect-BootGreeting.h
+++ b/plugins/Kaleidoscope-LEDEffect-BootGreeting/src/kaleidoscope/plugin/LEDEffect-BootGreeting.h
@@ -17,7 +17,12 @@
 
 #pragma once
 
-#include "Kaleidoscope-LEDControl.h"
+#include <stdint.h>                             // for uint16_t, uint8_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LEDEffect-Breathe/src/Kaleidoscope-LEDEffect-Breathe.h
+++ b/plugins/Kaleidoscope-LEDEffect-Breathe/src/Kaleidoscope-LEDEffect-Breathe.h
@@ -16,4 +16,4 @@
 
 #pragma once
 
-#include "kaleidoscope/plugin/LEDEffect-Breathe.h"
+#include "kaleidoscope/plugin/LEDEffect-Breathe.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LEDEffect-Breathe/src/kaleidoscope/plugin/LEDEffect-Breathe.cpp
+++ b/plugins/Kaleidoscope-LEDEffect-Breathe/src/kaleidoscope/plugin/LEDEffect-Breathe.cpp
@@ -14,7 +14,14 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope-LEDEffect-Breathe.h"
+#include "kaleidoscope/plugin/LEDEffect-Breathe.h"
+
+#include <stdint.h>                                   // for uint8_t
+
+#include "kaleidoscope/Runtime.h"                     // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"               // for cRGB
+#include "kaleidoscope/plugin/LEDControl.h"           // for LEDControl
+#include "kaleidoscope/plugin/LEDControl/LEDUtils.h"  // for breath_compute
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LEDEffect-Breathe/src/kaleidoscope/plugin/LEDEffect-Breathe.h
+++ b/plugins/Kaleidoscope-LEDEffect-Breathe/src/kaleidoscope/plugin/LEDEffect-Breathe.h
@@ -16,7 +16,11 @@
 
 #pragma once
 
-#include "Kaleidoscope-LEDControl.h"
+#include <stdint.h>                                // for uint8_t
+
+#include "kaleidoscope/plugin.h"                   // for Plugin
+#include "kaleidoscope/plugin/LEDMode.h"           // for LEDMode
+#include "kaleidoscope/plugin/LEDModeInterface.h"  // for LEDModeInterface
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LEDEffect-Chase/src/Kaleidoscope-LEDEffect-Chase.h
+++ b/plugins/Kaleidoscope-LEDEffect-Chase/src/Kaleidoscope-LEDEffect-Chase.h
@@ -16,4 +16,4 @@
 
 #pragma once
 
-#include "kaleidoscope/plugin/LEDEffect-Chase.h"
+#include "kaleidoscope/plugin/LEDEffect-Chase.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LEDEffect-Chase/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
+++ b/plugins/Kaleidoscope-LEDEffect-Chase/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
@@ -14,7 +14,13 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope-LEDEffect-Chase.h"
+#include "kaleidoscope/plugin/LEDEffect-Chase.h"
+
+#include <stdint.h>                          // for uint16_t, uint8_t
+
+#include "kaleidoscope/Runtime.h"            // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"      // for CRGB, Device, Base<>::LE...
+#include "kaleidoscope/plugin/LEDControl.h"  // for LEDControl
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LEDEffect-Chase/src/kaleidoscope/plugin/LEDEffect-Chase.h
+++ b/plugins/Kaleidoscope-LEDEffect-Chase/src/kaleidoscope/plugin/LEDEffect-Chase.h
@@ -16,7 +16,12 @@
 
 #pragma once
 
-#include "Kaleidoscope-LEDControl.h"
+#include <stdint.h>                                // for uint8_t, int8_t
+
+#include "kaleidoscope/Runtime.h"                  // for Runtime, Runtime_
+#include "kaleidoscope/plugin.h"                   // for Plugin
+#include "kaleidoscope/plugin/LEDMode.h"           // for LEDMode
+#include "kaleidoscope/plugin/LEDModeInterface.h"  // for LEDModeInterface
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LEDEffect-Rainbow/src/Kaleidoscope-LEDEffect-Rainbow.h
+++ b/plugins/Kaleidoscope-LEDEffect-Rainbow/src/Kaleidoscope-LEDEffect-Rainbow.h
@@ -16,4 +16,4 @@
 
 #pragma once
 
-#include "kaleidoscope/plugin/LEDEffect-Rainbow.h"
+#include "kaleidoscope/plugin/LEDEffect-Rainbow.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LEDEffect-Rainbow/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
+++ b/plugins/Kaleidoscope-LEDEffect-Rainbow/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
@@ -14,7 +14,15 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope-LEDEffect-Rainbow.h"
+#include "kaleidoscope/plugin/LEDEffect-Rainbow.h"
+
+#include <Arduino.h>                                  // for byte
+#include <stdint.h>                                   // for uint8_t, uint16_t
+
+#include "kaleidoscope/Runtime.h"                     // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"               // for Base<>::LEDRang...
+#include "kaleidoscope/plugin/LEDControl.h"           // for LEDControl
+#include "kaleidoscope/plugin/LEDControl/LEDUtils.h"  // for hsvToRgb
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LEDEffect-Rainbow/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
+++ b/plugins/Kaleidoscope-LEDEffect-Rainbow/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
@@ -16,7 +16,11 @@
 
 #pragma once
 
-#include "Kaleidoscope-LEDControl.h"
+#include <stdint.h>                                // for uint8_t, uint16_t
+
+#include "kaleidoscope/plugin.h"                   // for Plugin
+#include "kaleidoscope/plugin/LEDMode.h"           // for LEDMode
+#include "kaleidoscope/plugin/LEDModeInterface.h"  // for LEDModeInterface
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LEDEffect-SolidColor/src/Kaleidoscope-LEDEffect-SolidColor.h
+++ b/plugins/Kaleidoscope-LEDEffect-SolidColor/src/Kaleidoscope-LEDEffect-SolidColor.h
@@ -16,4 +16,4 @@
 
 #pragma once
 
-#include "kaleidoscope/plugin/LEDEffect-SolidColor.h"
+#include "kaleidoscope/plugin/LEDEffect-SolidColor.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LEDEffect-SolidColor/src/kaleidoscope/plugin/LEDEffect-SolidColor.cpp
+++ b/plugins/Kaleidoscope-LEDEffect-SolidColor/src/kaleidoscope/plugin/LEDEffect-SolidColor.cpp
@@ -14,7 +14,11 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope-LEDEffect-SolidColor.h"
+#include "kaleidoscope/plugin/LEDEffect-SolidColor.h"
+
+#include "kaleidoscope/KeyAddr.h"            // for KeyAddr
+#include "kaleidoscope/device/device.h"      // for CRGB
+#include "kaleidoscope/plugin/LEDControl.h"  // for LEDControl
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LEDEffect-SolidColor/src/kaleidoscope/plugin/LEDEffect-SolidColor.h
+++ b/plugins/Kaleidoscope-LEDEffect-SolidColor/src/kaleidoscope/plugin/LEDEffect-SolidColor.h
@@ -16,7 +16,12 @@
 
 #pragma once
 
-#include "Kaleidoscope-LEDControl.h"
+#include <stdint.h>                                // for uint8_t
+
+#include "kaleidoscope/KeyAddr.h"                  // for KeyAddr
+#include "kaleidoscope/plugin.h"                   // for Plugin
+#include "kaleidoscope/plugin/LEDMode.h"           // for LEDMode
+#include "kaleidoscope/plugin/LEDModeInterface.h"  // for LEDModeInterface
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LEDEffects/src/Kaleidoscope-LEDEffects.h
+++ b/plugins/Kaleidoscope-LEDEffects/src/Kaleidoscope-LEDEffects.h
@@ -17,6 +17,6 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/TriColor.h>
-#include <kaleidoscope/plugin/Miami.h>
-#include <kaleidoscope/plugin/Jukebox.h>
+#include "kaleidoscope/plugin/Jukebox.h"  // IWYU pragma: export
+#include "kaleidoscope/plugin/Miami.h"  // IWYU pragma: export
+#include "kaleidoscope/plugin/TriColor.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/Jukebox.cpp
+++ b/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/Jukebox.cpp
@@ -15,7 +15,10 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-LEDEffects.h>
+#include "kaleidoscope/plugin/Jukebox.h"
+
+#include "kaleidoscope/device/device.h"    // for CRGB
+#include "kaleidoscope/plugin/TriColor.h"  // for TriColor
 
 kaleidoscope::plugin::TriColor JukeboxEffect(CRGB(0xc8, 0xe8, 0xee),   /* TM */
                                              CRGB(0xc3, 0xee, 0x8c),   /* VCO */

--- a/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/Jukebox.h
+++ b/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/Jukebox.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/TriColor.h>
+#include "kaleidoscope/plugin/TriColor.h"  // for TriColor
 
 extern kaleidoscope::plugin::TriColor JukeboxEffect;
 extern kaleidoscope::plugin::TriColor JukeboxAlternateEffect;

--- a/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/Miami.cpp
+++ b/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/Miami.cpp
@@ -15,7 +15,10 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-LEDEffects.h>
+#include "kaleidoscope/plugin/Miami.h"
+
+#include "kaleidoscope/device/device.h"    // for CRGB
+#include "kaleidoscope/plugin/TriColor.h"  // for TriColor
 
 kaleidoscope::plugin::TriColor MiamiEffect(CRGB(0x4e, 0xd6, 0xd6),   /* Cyan */
                                            CRGB(0xaf, 0x67, 0xfa));  /* Magenta */

--- a/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/Miami.h
+++ b/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/Miami.h
@@ -17,6 +17,6 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/TriColor.h>
+#include "kaleidoscope/plugin/TriColor.h"  // for TriColor
 
 extern kaleidoscope::plugin::TriColor MiamiEffect;

--- a/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/TriColor.cpp
+++ b/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/TriColor.cpp
@@ -15,8 +15,13 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-LEDEffects.h>
-#include "kaleidoscope/layers.h"
+#include "kaleidoscope/plugin/TriColor.h"
+
+#include "kaleidoscope/KeyAddr.h"            // for KeyAddr, MatrixAddr, Mat...
+#include "kaleidoscope/device/device.h"      // for cRGB
+#include "kaleidoscope/key_defs.h"           // for Key, Key_0, Key_A, Key_E...
+#include "kaleidoscope/layers.h"             // for Layer, Layer_
+#include "kaleidoscope/plugin/LEDControl.h"  // for LEDControl
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/TriColor.h
+++ b/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/TriColor.h
@@ -17,8 +17,10 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-LEDControl.h>
+#include "kaleidoscope/device/device.h"            // for cRGB
+#include "kaleidoscope/plugin.h"                   // for Plugin
+#include "kaleidoscope/plugin/LEDMode.h"           // for LEDMode
+#include "kaleidoscope/plugin/LEDModeInterface.h"  // for LEDModeInterface
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LayerFocus/src/Kaleidoscope-LayerFocus.h
+++ b/plugins/Kaleidoscope-LayerFocus/src/Kaleidoscope-LayerFocus.h
@@ -18,4 +18,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/LayerFocus.h>
+#include "kaleidoscope/plugin/LayerFocus.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
+++ b/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
@@ -16,10 +16,14 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope-LayerFocus.h"
-#include "Kaleidoscope-FocusSerial.h"
+#include "kaleidoscope/plugin/LayerFocus.h"
 
-#include "kaleidoscope/layers.h"
+#include <Arduino.h>                            // for PSTR, strcmp_P, F
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <stdint.h>                             // for uint8_t
+
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/layers.h"                // for Layer, Layer_
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.h
+++ b/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.h
@@ -18,7 +18,8 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Leader/src/Kaleidoscope-Leader.h
+++ b/plugins/Kaleidoscope-Leader/src/Kaleidoscope-Leader.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/Leader.h>
+#include "kaleidoscope/plugin/Leader.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Leader/src/kaleidoscope/plugin/Leader.cpp
+++ b/plugins/Kaleidoscope-Leader/src/kaleidoscope/plugin/Leader.cpp
@@ -15,11 +15,20 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-Leader.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/KeyEventTracker.h"
+#include "kaleidoscope/plugin/Leader.h"
+
+#include <Arduino.h>                            // for F, __FlashStringHelper
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <Kaleidoscope-Ranges.h>                // for LEAD_FIRST, LEAD_LAST
+#include <stdint.h>                             // for uint16_t, uint8_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/KeyEventTracker.h"       // for KeyEventTracker
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_NoKey
+#include "kaleidoscope/keyswitch_state.h"       // for INJECTED, keyToggledOff
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Leader/src/kaleidoscope/plugin/Leader.h
+++ b/plugins/Kaleidoscope-Leader/src/kaleidoscope/plugin/Leader.h
@@ -17,12 +17,20 @@
 
 #pragma once
 
-#include <Kaleidoscope-Ranges.h>
-#include "kaleidoscope/KeyEventTracker.h"
-#include "kaleidoscope/plugin.h"
+#include <Kaleidoscope-Ranges.h>                 // for LEAD_FIRST
+#include <stddef.h>                              // for NULL
+#include <stdint.h>                              // for uint16_t, uint8_t
+
+#include "kaleidoscope/KeyEvent.h"               // for KeyEvent
+#include "kaleidoscope/KeyEventTracker.h"        // for KeyEventTracker
+#include "kaleidoscope/event_handler_result.h"   // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"               // for Key, Key_NoKey
+#include "kaleidoscope/plugin.h"                 // for Plugin
 
 // -----------------------------------------------------------------------------
 // Deprecation warning messages
+#include "kaleidoscope_internal/deprecations.h"  // for DEPRECATED
+
 #define _DEPRECATED_MESSAGE_LEADER_INJECT                               \
   "The `Leader.inject()` function is deprecated. Please call\n"         \
   "`kaleidoscope::Runtime.handleKeyEvent()` directly instead.\n"        \

--- a/plugins/Kaleidoscope-Macros/src/Kaleidoscope-Macros.h
+++ b/plugins/Kaleidoscope-Macros/src/Kaleidoscope-Macros.h
@@ -16,4 +16,5 @@
 
 #pragma once
 
-#include "kaleidoscope/plugin/Macros.h"
+#include "kaleidoscope/plugin/Macros.h"  // IWYU pragma: export
+#include "kaleidoscope/plugin/Macros/MacroKeyDefs.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros.cpp
+++ b/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros.cpp
@@ -14,9 +14,20 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope-Macros.h"
-#include "Kaleidoscope-FocusSerial.h"
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/plugin/Macros.h"
+
+#include <Arduino.h>                                // for pgm_read_byte, delay
+#include <Kaleidoscope-FocusSerial.h>               // for Focus, FocusSerial
+#include <Kaleidoscope-Ranges.h>                    // for MACRO_FIRST
+#include <stdint.h>                                 // for uint8_t
+
+#include "kaleidoscope/KeyAddr.h"                   // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"                  // for KeyEvent
+#include "kaleidoscope/Runtime.h"                   // for Runtime, Runtime_
+#include "kaleidoscope/event_handler_result.h"      // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"                  // for Key, LSHIFT, Key_...
+#include "kaleidoscope/keyswitch_state.h"           // for INJECTED, IS_PRESSED
+#include "kaleidoscope/plugin/Macros/MacroSteps.h"  // for macro_t, MACRO_NONE
 
 // =============================================================================
 // Default `macroAction()` function definitions

--- a/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros.h
+++ b/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros.h
@@ -16,11 +16,14 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include <stdint.h>                                 // for uint8_t
 
-#include "kaleidoscope/plugin/Macros/MacroKeyDefs.h"
-#include "kaleidoscope/plugin/Macros/MacroSteps.h"
-#include "kaleidoscope/keyswitch_state.h"
+#include "Kaleidoscope-Ranges.h"                    // for MACRO_FIRST, MACR...
+#include "kaleidoscope/KeyEvent.h"                  // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"      // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"                  // for Key
+#include "kaleidoscope/plugin.h"                    // for Plugin
+#include "kaleidoscope/plugin/Macros/MacroSteps.h"  // for macro_t, MACRO_NONE
 
 // =============================================================================
 // Define this function in a Kaleidoscope sketch in order to trigger Macros.

--- a/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros/MacroKeyDefs.h
+++ b/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros/MacroKeyDefs.h
@@ -17,7 +17,10 @@
 
 #pragma once
 
-#include "Kaleidoscope-Ranges.h"
+#include <Kaleidoscope-Ranges.h>    // for MACRO_FIRST
+#include <stdint.h>                 // for uint8_t
+
+#include "kaleidoscope/key_defs.h"  // for Key
 
 constexpr Key M(uint8_t n) {
   return Key(kaleidoscope::ranges::MACRO_FIRST + n);

--- a/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros/MacroSteps.h
+++ b/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros/MacroSteps.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <stdint.h>  // for uint8_t
+
 typedef enum {
   MACRO_ACTION_END,
 

--- a/plugins/Kaleidoscope-MagicCombo/src/Kaleidoscope-MagicCombo.h
+++ b/plugins/Kaleidoscope-MagicCombo/src/Kaleidoscope-MagicCombo.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/MagicCombo.h>
+#include "kaleidoscope/plugin/MagicCombo.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-MagicCombo/src/kaleidoscope/plugin/MagicCombo.cpp
+++ b/plugins/Kaleidoscope-MagicCombo/src/kaleidoscope/plugin/MagicCombo.cpp
@@ -15,8 +15,15 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-MagicCombo.h>
-#include <Kaleidoscope-FocusSerial.h>
+#include "kaleidoscope/plugin/MagicCombo.h"
+
+#include <Arduino.h>                            // for F, __FlashStringHelper
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <stdint.h>                             // for uint16_t, int8_t, uin...
+
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for Device
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-MagicCombo/src/kaleidoscope/plugin/MagicCombo.h
+++ b/plugins/Kaleidoscope-MagicCombo/src/kaleidoscope/plugin/MagicCombo.h
@@ -17,7 +17,11 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include <Arduino.h>                            // for PROGMEM
+#include <stdint.h>                             // for uint16_t, uint8_t
+
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 #define MAX_COMBO_LENGTH 5
 

--- a/plugins/Kaleidoscope-MouseKeys/src/Kaleidoscope-MouseKeys.h
+++ b/plugins/Kaleidoscope-MouseKeys/src/Kaleidoscope-MouseKeys.h
@@ -16,4 +16,5 @@
 
 #pragma once
 
-#include "kaleidoscope/plugin/MouseKeys.h"
+#include "kaleidoscope/plugin/MouseKeys.h"  // IWYU pragma: export
+#include "kaleidoscope/plugin/mousekeys/MouseKeyDefs.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.cpp
+++ b/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.cpp
@@ -14,14 +14,22 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Arduino.h>
+#include "kaleidoscope/plugin/MouseKeys.h"
 
-#include "MouseKeys.h"
-#include "kaleidoscope/plugin/mousekeys/MouseWrapper.h"
+#include <Arduino.h>                                           // for F, __F...
+#include <Kaleidoscope-FocusSerial.h>                          // for Focus
+#include <stdint.h>                                            // for uint8_t
 
-#include "kaleidoscope/Runtime.h"
-#include "Kaleidoscope-FocusSerial.h"
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/KeyEvent.h"                             // for KeyEvent
+#include "kaleidoscope/Runtime.h"                              // for Runtime
+#include "kaleidoscope/device/device.h"                        // for Base<>...
+#include "kaleidoscope/driver/hid/keyboardio/AbsoluteMouse.h"  // for Absolu...
+#include "kaleidoscope/driver/hid/keyboardio/Mouse.h"          // for Mouse
+#include "kaleidoscope/event_handler_result.h"                 // for EventH...
+#include "kaleidoscope/key_defs.h"                             // for Key
+#include "kaleidoscope/keyswitch_state.h"                      // for keyTog...
+#include "kaleidoscope/plugin/mousekeys/MouseKeyDefs.h"        // for KEY_MO...
+#include "kaleidoscope/plugin/mousekeys/MouseWrapper.h"        // for MouseW...
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.h
+++ b/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.h
@@ -16,9 +16,12 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include "kaleidoscope/plugin/mousekeys/MouseKeyDefs.h"
-#include "kaleidoscope/plugin/mousekeys/MouseWarpModes.h"
+#include <stdint.h>                             // for uint8_t, uint16_t
+
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/mousekeys/MouseWrapper.cpp
+++ b/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/mousekeys/MouseWrapper.cpp
@@ -14,12 +14,15 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-// Mouse-related methods
-//
-//
-#include <Kaleidoscope.h>
 #include "kaleidoscope/plugin/mousekeys/MouseWrapper.h"
+
+#include <stdint.h>                                            // for uint16_t
+
+#include "kaleidoscope/Runtime.h"                              // for Runtime
+#include "kaleidoscope/device/device.h"                        // for Base<>...
+#include "kaleidoscope/driver/hid/keyboardio/AbsoluteMouse.h"  // for Absolu...
+#include "kaleidoscope/driver/hid/keyboardio/Mouse.h"          // for Mouse
+#include "kaleidoscope/plugin/mousekeys/MouseWarpModes.h"      // for MOUSE_...
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/mousekeys/MouseWrapper.h
+++ b/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/mousekeys/MouseWrapper.h
@@ -16,8 +16,7 @@
 
 #pragma once
 
-#include "Arduino.h"
-#include "kaleidoscope/plugin/mousekeys/MouseWarpModes.h"
+#include <stdint.h>  // for uint16_t, uint8_t, int8_t
 
 // Warping commands
 

--- a/plugins/Kaleidoscope-NumPad/src/Kaleidoscope-NumPad.h
+++ b/plugins/Kaleidoscope-NumPad/src/Kaleidoscope-NumPad.h
@@ -16,4 +16,4 @@
 
 #pragma once
 
-#include "kaleidoscope/plugin/NumPad.h"
+#include "kaleidoscope/plugin/NumPad.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-NumPad/src/kaleidoscope/plugin/NumPad.cpp
+++ b/plugins/Kaleidoscope-NumPad/src/kaleidoscope/plugin/NumPad.cpp
@@ -14,8 +14,17 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope-NumPad.h"
-#include "kaleidoscope/layers.h"
+#include "kaleidoscope/plugin/NumPad.h"
+
+#include <stdint.h>                                   // for uint8_t
+
+#include "kaleidoscope/KeyAddr.h"                     // for KeyAddr, Matrix...
+#include "kaleidoscope/device/device.h"               // for cRGB, CRGB
+#include "kaleidoscope/event_handler_result.h"        // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"                    // for Key, KEY_FLAGS
+#include "kaleidoscope/layers.h"                      // for Layer, Layer_
+#include "kaleidoscope/plugin/LEDControl.h"           // for LEDControl
+#include "kaleidoscope/plugin/LEDControl/LEDUtils.h"  // for breath_compute
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-NumPad/src/kaleidoscope/plugin/NumPad.h
+++ b/plugins/Kaleidoscope-NumPad/src/kaleidoscope/plugin/NumPad.h
@@ -16,7 +16,13 @@
 
 #pragma once
 
-#include "Kaleidoscope-LEDControl.h"
+#include <stdint.h>                             // for uint8_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
+
+struct cRGB;
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-OneShot/src/Kaleidoscope-OneShot.h
+++ b/plugins/Kaleidoscope-OneShot/src/Kaleidoscope-OneShot.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/OneShot.h>
+#include "kaleidoscope/plugin/OneShot.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.cpp
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.cpp
@@ -15,10 +15,20 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-OneShot.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/layers.h"
+#include "kaleidoscope/plugin/OneShot.h"
+
+#include <Arduino.h>                            // for bitRead, F, __FlashSt...
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <Kaleidoscope-Ranges.h>                // for OS_FIRST
+#include <stdint.h>                             // for uint8_t, int8_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr, MatrixAddr
+#include "kaleidoscope/KeyAddrBitfield.h"       // for KeyAddrBitfield, KeyA...
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_LeftControl
+#include "kaleidoscope/keyswitch_state.h"       // for INJECTED, IS_PRESSED
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.h
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.h
@@ -17,9 +17,16 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-Ranges.h>
-#include "kaleidoscope/KeyAddrBitfield.h"
+#include <Kaleidoscope-Ranges.h>                // for OS_FIRST, OS_LAST
+#include <stdint.h>                             // for uint16_t, uint8_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/KeyAddrBitfield.h"       // for KeyAddrBitfield
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_LeftControl
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 // ----------------------------------------------------------------------------
 // Keymap macros

--- a/plugins/Kaleidoscope-OneShotMetaKeys/src/Kaleidoscope-OneShotMetaKeys.h
+++ b/plugins/Kaleidoscope-OneShotMetaKeys/src/Kaleidoscope-OneShotMetaKeys.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/OneShotMetaKeys.h>
+#include "kaleidoscope/plugin/OneShotMetaKeys.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-OneShotMetaKeys/src/kaleidoscope/plugin/OneShotMetaKeys.cpp
+++ b/plugins/Kaleidoscope-OneShotMetaKeys/src/kaleidoscope/plugin/OneShotMetaKeys.cpp
@@ -15,16 +15,20 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-OneShotMetaKeys.h>
+#include "kaleidoscope/plugin/OneShotMetaKeys.h"
 
-#include <Kaleidoscope-FocusSerial.h>
-#include <Kaleidoscope-OneShot.h>
+#include <Arduino.h>                            // for F, __FlashStringHelper
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <Kaleidoscope-OneShot.h>               // for OneShot
 
-#include "kaleidoscope/KeyAddr.h"
-#include "kaleidoscope/key_defs.h"
-#include "kaleidoscope/KeyEvent.h"
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/LiveKeys.h"
+#include "kaleidoscope/KeyAddr.h"               // for MatrixAddr, MatrixAdd...
+#include "kaleidoscope/KeyAddrMap.h"            // for KeyAddrMap<>::Iterator
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/KeyMap.h"                // for KeyMap
+#include "kaleidoscope/LiveKeys.h"              // for LiveKeys, live_keys
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_Inactive
+#include "kaleidoscope/keyswitch_state.h"       // for INJECTED, keyToggledOff
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-OneShotMetaKeys/src/kaleidoscope/plugin/OneShotMetaKeys.h
+++ b/plugins/Kaleidoscope-OneShotMetaKeys/src/kaleidoscope/plugin/OneShotMetaKeys.h
@@ -17,13 +17,12 @@
 
 #pragma once
 
-#include <Kaleidoscope-OneShot.h>
-#include <Kaleidoscope-Ranges.h>
+#include <Kaleidoscope-Ranges.h>                // for OS_ACTIVE_STICKY, OS_...
 
-#include "kaleidoscope/event_handler_result.h"
-#include "kaleidoscope/key_defs.h"
-#include "kaleidoscope/KeyEvent.h"
-#include "kaleidoscope/plugin.h"
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 // ----------------------------------------------------------------------------
 // Key constants

--- a/plugins/Kaleidoscope-PersistentLEDMode/src/Kaleidoscope-PersistentLEDMode.h
+++ b/plugins/Kaleidoscope-PersistentLEDMode/src/Kaleidoscope-PersistentLEDMode.h
@@ -18,4 +18,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/PersistentLEDMode.h>
+#include "kaleidoscope/plugin/PersistentLEDMode.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-PersistentLEDMode/src/kaleidoscope/plugin/PersistentLEDMode.cpp
+++ b/plugins/Kaleidoscope-PersistentLEDMode/src/kaleidoscope/plugin/PersistentLEDMode.cpp
@@ -16,10 +16,15 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-PersistentLEDMode.h>
-#include <Kaleidoscope-LEDControl.h>
-#include <Kaleidoscope-EEPROM-Settings.h>
+#include "kaleidoscope/plugin/PersistentLEDMode.h"
+
+#include <Kaleidoscope-EEPROM-Settings.h>       // for EEPROMSettings
+#include <stdint.h>                             // for uint8_t, uint16_t
+
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for VirtualProps::Storage
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin/LEDControl.h"     // for LEDControl
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-PersistentLEDMode/src/kaleidoscope/plugin/PersistentLEDMode.h
+++ b/plugins/Kaleidoscope-PersistentLEDMode/src/kaleidoscope/plugin/PersistentLEDMode.h
@@ -18,7 +18,10 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include <stdint.h>                             // for uint16_t, uint8_t
+
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Qukeys/src/Kaleidoscope-Qukeys.h
+++ b/plugins/Kaleidoscope-Qukeys/src/Kaleidoscope-Qukeys.h
@@ -18,4 +18,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/Qukeys.h>
+#include "kaleidoscope/plugin/Qukeys.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.cpp
+++ b/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.cpp
@@ -18,14 +18,17 @@
 
 #include "kaleidoscope/plugin/Qukeys.h"
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-Ranges.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/progmem_helpers.h"
-#include "kaleidoscope/layers.h"
-#include "kaleidoscope/KeyEvent.h"
-#include "kaleidoscope/KeyEventTracker.h"
-#include "kaleidoscope/KeyAddrEventQueue.h"
+#include <Arduino.h>                         // for F, __FlashStringHelper
+#include <Kaleidoscope-FocusSerial.h>        // for Focus, FocusSerial
+#include <Kaleidoscope-Ranges.h>             // for DUL_FIRST, DUM_FIRST
+
+#include "kaleidoscope/KeyAddrEventQueue.h"  // for KeyAddrEventQueue
+#include "kaleidoscope/KeyEvent.h"           // for KeyEvent
+#include "kaleidoscope/KeyEventTracker.h"    // for KeyEventTracker
+#include "kaleidoscope/Runtime.h"            // for Runtime, Runtime_
+#include "kaleidoscope/keyswitch_state.h"    // for IS_PRESSED, WAS_PRESSED
+#include "kaleidoscope/layers.h"             // for Layer, Layer_
+#include "kaleidoscope/progmem_helpers.h"    // for cloneFromProgmem
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.h
+++ b/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.h
@@ -18,10 +18,17 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-Ranges.h>
-#include "kaleidoscope/KeyAddrEventQueue.h"
-#include "kaleidoscope/KeyEventTracker.h"
+#include <Arduino.h>                            // for PROGMEM
+#include <Kaleidoscope-Ranges.h>                // for DUM_FIRST
+#include <stdint.h>                             // for uint8_t, uint16_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/KeyAddrEventQueue.h"     // for KeyAddrEventQueue
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/KeyEventTracker.h"       // for KeyEventTracker
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_Transparent
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 // DualUse Key definitions for Qukeys in the keymap
 #define MT(mod, key) kaleidoscope::plugin::ModTapKey(Key_ ## mod, Key_ ## key)

--- a/plugins/Kaleidoscope-Ranges/src/Kaleidoscope-Ranges.h
+++ b/plugins/Kaleidoscope-Ranges/src/Kaleidoscope-Ranges.h
@@ -17,10 +17,10 @@
 
 #pragma once
 
-#include <stdint.h>  // for uint16_t
+#include <stdint.h>                 // for uint16_t, uint8_t
 
 // Included for definition of legacy Macros plugin key range:
-#include "kaleidoscope/key_defs.h"
+#include "kaleidoscope/key_defs.h"  // for SYNTHETIC
 
 namespace kaleidoscope {
 namespace ranges {

--- a/plugins/Kaleidoscope-Redial/src/Kaleidoscope-Redial.h
+++ b/plugins/Kaleidoscope-Redial/src/Kaleidoscope-Redial.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/Redial.h>
+#include "kaleidoscope/plugin/Redial.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.cpp
+++ b/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.cpp
@@ -15,9 +15,15 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-Redial.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/plugin/Redial.h"
+
+#include <Arduino.h>                            // for F, __FlashStringHelper
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_0, Key_1, Key_A
+#include "kaleidoscope/keyswitch_state.h"       // for keyToggledOn
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.h
+++ b/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.h
@@ -17,8 +17,12 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-Ranges.h>
+#include <Kaleidoscope-Ranges.h>                // for REDIAL
+
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 constexpr Key Key_Redial = Key(kaleidoscope::ranges::REDIAL);
 

--- a/plugins/Kaleidoscope-ShapeShifter/src/Kaleidoscope-ShapeShifter.h
+++ b/plugins/Kaleidoscope-ShapeShifter/src/Kaleidoscope-ShapeShifter.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/ShapeShifter.h>
+#include "kaleidoscope/plugin/ShapeShifter.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-ShapeShifter/src/kaleidoscope/plugin/ShapeShifter.cpp
+++ b/plugins/Kaleidoscope-ShapeShifter/src/kaleidoscope/plugin/ShapeShifter.cpp
@@ -15,9 +15,15 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-ShapeShifter.h>
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/LiveKeys.h"
+#include "kaleidoscope/plugin/ShapeShifter.h"
+
+#include <stdint.h>                             // for uint8_t
+
+#include "kaleidoscope/KeyAddr.h"               // for MatrixAddr, MatrixAdd...
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/LiveKeys.h"              // for LiveKeys, live_keys
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_NoKey
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-ShapeShifter/src/kaleidoscope/plugin/ShapeShifter.h
+++ b/plugins/Kaleidoscope-ShapeShifter/src/kaleidoscope/plugin/ShapeShifter.h
@@ -17,7 +17,10 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-SpaceCadet/src/Kaleidoscope-SpaceCadet.h
+++ b/plugins/Kaleidoscope-SpaceCadet/src/Kaleidoscope-SpaceCadet.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/SpaceCadet.h>
+#include "kaleidoscope/plugin/SpaceCadet.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadet.cpp
+++ b/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadet.cpp
@@ -16,11 +16,20 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-SpaceCadet.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/plugin/SpaceCadet.h"
 
-//#include <Kaleidoscope-Devel-ArduinoTrace.h>
+#include <Arduino.h>                            // for F, __FlashStringHelper
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <stdint.h>                             // for uint16_t, int8_t, uin...
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr, MatrixAddr
+#include "kaleidoscope/KeyAddrEventQueue.h"     // for KeyAddrEventQueue
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/KeyEventTracker.h"       // for KeyEventTracker
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_LeftParen
+#include "kaleidoscope/keyswitch_state.h"       // for keyToggledOn, WAS_PRE...
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadet.h
+++ b/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadet.h
@@ -18,10 +18,15 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include "kaleidoscope/KeyEventTracker.h"
-#include "kaleidoscope/KeyAddrEventQueue.h"
-#include <Kaleidoscope-Ranges.h>
+#include <Kaleidoscope-Ranges.h>                // for SC_FIRST, SC_LAST
+#include <stdint.h>                             // for uint16_t, uint8_t
+
+#include "kaleidoscope/KeyAddrEventQueue.h"     // for KeyAddrEventQueue
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/KeyEventTracker.h"       // for KeyEventTracker
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_NoKey
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 #ifndef SPACECADET_MAP_END
 #define SPACECADET_MAP_END (kaleidoscope::plugin::SpaceCadet::KeyBinding) { Key_NoKey, Key_NoKey, 0 }

--- a/plugins/Kaleidoscope-Steno/src/Kaleidoscope-Steno.h
+++ b/plugins/Kaleidoscope-Steno/src/Kaleidoscope-Steno.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/GeminiPR.h>
+#include "kaleidoscope/plugin/GeminiPR.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Steno/src/kaleidoscope/plugin/GeminiPR.cpp
+++ b/plugins/Kaleidoscope-Steno/src/kaleidoscope/plugin/GeminiPR.cpp
@@ -15,9 +15,19 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-Steno.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/plugin/GeminiPR.h"
+
+#include <Arduino.h>                            // for F, __FlashStringHelper
+#include <HardwareSerial.h>                     // for HardwareSerial
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <stdint.h>                             // for uint8_t
+#include <string.h>                             // for memset
+
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/keyswitch_state.h"       // for keyToggledOn
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Steno/src/kaleidoscope/plugin/GeminiPR.h
+++ b/plugins/Kaleidoscope-Steno/src/kaleidoscope/plugin/GeminiPR.h
@@ -17,10 +17,14 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-Ranges.h>
+#include <Kaleidoscope-Ranges.h>                // for STENO_FIRST
+#include <stdint.h>                             // for uint8_t
 
 #define S(n) Key(kaleidoscope::plugin::steno::geminipr::n)
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
+
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Syster/src/Kaleidoscope-Syster.h
+++ b/plugins/Kaleidoscope-Syster/src/Kaleidoscope-Syster.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/Syster.h>
+#include "kaleidoscope/plugin/Syster.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Syster/src/kaleidoscope/plugin/Syster.cpp
+++ b/plugins/Kaleidoscope-Syster/src/kaleidoscope/plugin/Syster.cpp
@@ -15,11 +15,18 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-Syster.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/plugin/Syster.h"
 
-#undef SYSTER
+#include <Arduino.h>                            // for F, __FlashStringHelper
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <stdint.h>                             // for int8_t, uint8_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_Backspace
+#include "kaleidoscope/keyswitch_state.h"       // for INJECTED, WAS_PRESSED
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Syster/src/kaleidoscope/plugin/Syster.h
+++ b/plugins/Kaleidoscope-Syster/src/kaleidoscope/plugin/Syster.h
@@ -17,8 +17,13 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-Ranges.h>
+#include <Kaleidoscope-Ranges.h>                // for SYSTER
+#include <stdint.h>                             // for int8_t, uint8_t
+
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 #define SYSTER_MAX_SYMBOL_LENGTH 32
 

--- a/plugins/Kaleidoscope-TapDance/src/Kaleidoscope-TapDance.h
+++ b/plugins/Kaleidoscope-TapDance/src/Kaleidoscope-TapDance.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/TapDance.h>
+#include "kaleidoscope/plugin/TapDance.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.cpp
+++ b/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.cpp
@@ -15,11 +15,22 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-TapDance.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/layers.h"
-#include "kaleidoscope/KeyEventTracker.h"
+#include "kaleidoscope/plugin/TapDance.h"
+
+#include <Arduino.h>                            // for F, __FlashStringHelper
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <Kaleidoscope-Ranges.h>                // for TD_FIRST
+#include <stdint.h>                             // for uint8_t, uint16_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr, MatrixAddr
+#include "kaleidoscope/KeyAddrEventQueue.h"     // for KeyAddrEventQueue
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/KeyEventTracker.h"       // for KeyEventTracker
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/keyswitch_state.h"       // for keyIsInjected, keyTog...
+#include "kaleidoscope/layers.h"                // for Layer, Layer_
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.h
+++ b/plugins/Kaleidoscope-TapDance/src/kaleidoscope/plugin/TapDance.h
@@ -17,12 +17,17 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include "kaleidoscope/LiveKeys.h"
-#include <Kaleidoscope-Ranges.h>
-#include "kaleidoscope/KeyAddr.h"
-#include "kaleidoscope/KeyAddrEventQueue.h"
-#include "kaleidoscope/KeyEventTracker.h"
+#include <Arduino.h>                            // for PROGMEM
+#include <Kaleidoscope-Ranges.h>                // for TD_FIRST, TD_LAST
+#include <stdint.h>                             // for uint8_t, uint16_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/KeyAddrEventQueue.h"     // for KeyAddrEventQueue
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/KeyEventTracker.h"       // for KeyEventTracker
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 #define TD(n) kaleidoscope::plugin::TapDanceKey(n)
 

--- a/plugins/Kaleidoscope-TopsyTurvy/src/Kaleidoscope-TopsyTurvy.h
+++ b/plugins/Kaleidoscope-TopsyTurvy/src/Kaleidoscope-TopsyTurvy.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/TopsyTurvy.h>
+#include "kaleidoscope/plugin/TopsyTurvy.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-TopsyTurvy/src/kaleidoscope/plugin/TopsyTurvy.cpp
+++ b/plugins/Kaleidoscope-TopsyTurvy/src/kaleidoscope/plugin/TopsyTurvy.cpp
@@ -15,9 +15,19 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-TopsyTurvy.h>
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/LiveKeys.h"
+#include "kaleidoscope/plugin/TopsyTurvy.h"
+
+#include <Kaleidoscope-Ranges.h>                          // for TT_FIRST
+
+#include "kaleidoscope/KeyAddr.h"                         // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"                        // for KeyEvent
+#include "kaleidoscope/LiveKeys.h"                        // for LiveKeys
+#include "kaleidoscope/Runtime.h"                         // for Runtime
+#include "kaleidoscope/device/device.h"                   // for Base<>::HID
+#include "kaleidoscope/driver/hid/keyboardio/Keyboard.h"  // for Keyboard
+#include "kaleidoscope/event_handler_result.h"            // for EventHandle...
+#include "kaleidoscope/key_defs.h"                        // for Key, Key_Le...
+#include "kaleidoscope/keyswitch_state.h"                 // for keyToggledOff
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-TopsyTurvy/src/kaleidoscope/plugin/TopsyTurvy.h
+++ b/plugins/Kaleidoscope-TopsyTurvy/src/kaleidoscope/plugin/TopsyTurvy.h
@@ -17,8 +17,13 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-Ranges.h>
+#include <Kaleidoscope-Ranges.h>                // for TT_FIRST, TT_LAST
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 #define TOPSY(k) ::kaleidoscope::plugin::TopsyTurvyKey(Key_ ## k)
 

--- a/plugins/Kaleidoscope-Turbo/src/Kaleidoscope-Turbo.h
+++ b/plugins/Kaleidoscope-Turbo/src/Kaleidoscope-Turbo.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/Turbo.h>
+#include "kaleidoscope/plugin/Turbo.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Turbo/src/kaleidoscope/plugin/Turbo.cpp
+++ b/plugins/Kaleidoscope-Turbo/src/kaleidoscope/plugin/Turbo.cpp
@@ -15,11 +15,23 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-Turbo.h>
-#include <Kaleidoscope-LEDControl.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/layers.h"
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/plugin/Turbo.h"
+
+#include <Arduino.h>                                      // for F, __FlashS...
+#include <Kaleidoscope-FocusSerial.h>                     // for Focus, Focu...
+#include <stdint.h>                                       // for uint16_t
+
+#include "kaleidoscope/KeyAddr.h"                         // for MatrixAddr
+#include "kaleidoscope/KeyAddrMap.h"                      // for KeyAddrMap<...
+#include "kaleidoscope/KeyEvent.h"                        // for KeyEvent
+#include "kaleidoscope/KeyMap.h"                          // for KeyMap
+#include "kaleidoscope/LiveKeys.h"                        // for LiveKeys
+#include "kaleidoscope/Runtime.h"                         // for Runtime
+#include "kaleidoscope/driver/hid/keyboardio/Keyboard.h"  // for Keyboard
+#include "kaleidoscope/event_handler_result.h"            // for EventHandle...
+#include "kaleidoscope/key_defs.h"                        // for Key
+#include "kaleidoscope/keyswitch_state.h"                 // for keyToggledOff
+#include "kaleidoscope/plugin/LEDControl.h"               // for LEDControl
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Turbo/src/kaleidoscope/plugin/Turbo.h
+++ b/plugins/Kaleidoscope-Turbo/src/kaleidoscope/plugin/Turbo.h
@@ -15,11 +15,16 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdint.h>
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-Ranges.h>
-
 #pragma once
+
+#include <Kaleidoscope-Ranges.h>                // for TURBO
+#include <stdint.h>                             // for uint16_t, uint32_t
+
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/device/device.h"         // for cRGB
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 constexpr Key Key_Turbo = Key(kaleidoscope::ranges::TURBO);
 

--- a/plugins/Kaleidoscope-TypingBreaks/src/Kaleidoscope-TypingBreaks.h
+++ b/plugins/Kaleidoscope-TypingBreaks/src/Kaleidoscope-TypingBreaks.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/TypingBreaks.h>
+#include "kaleidoscope/plugin/TypingBreaks.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
+++ b/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
@@ -15,10 +15,19 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-TypingBreaks.h>
-#include <Kaleidoscope-EEPROM-Settings.h>
-#include <Kaleidoscope-FocusSerial.h>
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/plugin/TypingBreaks.h"
+
+#include <Arduino.h>                            // for PSTR, strcmp_P, F
+#include <Kaleidoscope-EEPROM-Settings.h>       // for EEPROMSettings
+#include <Kaleidoscope-FocusSerial.h>           // for Focus, FocusSerial
+#include <stdint.h>                             // for uint32_t, uint16_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for VirtualProps::Storage
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/keyswitch_state.h"       // for keyToggledOff
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.h
+++ b/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.h
@@ -17,7 +17,11 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include <stdint.h>                             // for uint16_t, uint32_t
+
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-USB-Quirks/src/Kaleidoscope-USB-Quirks.h
+++ b/plugins/Kaleidoscope-USB-Quirks/src/Kaleidoscope-USB-Quirks.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/USB-Quirks.h>
+#include "kaleidoscope/plugin/USB-Quirks.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-USB-Quirks/src/kaleidoscope/plugin/USB-Quirks.cpp
+++ b/plugins/Kaleidoscope-USB-Quirks/src/kaleidoscope/plugin/USB-Quirks.cpp
@@ -15,7 +15,14 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-USB-Quirks.h>
+#include "kaleidoscope/plugin/USB-Quirks.h"
+
+#include <Arduino.h>                                      // for delay
+#include <stdint.h>                                       // for uint8_t
+
+#include "kaleidoscope/Runtime.h"                         // for Runtime
+#include "kaleidoscope/device/device.h"                   // for Base<>::HID
+#include "kaleidoscope/driver/hid/keyboardio/Keyboard.h"  // for Keyboard
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-USB-Quirks/src/kaleidoscope/plugin/USB-Quirks.h
+++ b/plugins/Kaleidoscope-USB-Quirks/src/kaleidoscope/plugin/USB-Quirks.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/plugin.h"  // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Unicode/src/Kaleidoscope-Unicode.h
+++ b/plugins/Kaleidoscope-Unicode/src/Kaleidoscope-Unicode.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/Unicode.h>
+#include "kaleidoscope/plugin/Unicode.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.cpp
+++ b/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.cpp
@@ -15,7 +15,16 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Kaleidoscope-Unicode.h>
+#include "kaleidoscope/plugin/Unicode.h"
+
+#include <Arduino.h>                                      // for delay
+#include <Kaleidoscope-HostOS.h>                          // for HostOS, LINUX
+#include <stdint.h>                                       // for uint8_t
+
+#include "kaleidoscope/Runtime.h"                         // for Runtime
+#include "kaleidoscope/device/device.h"                   // for Base<>::HID
+#include "kaleidoscope/driver/hid/keyboardio/Keyboard.h"  // for Keyboard
+#include "kaleidoscope/key_defs.h"                        // for Key, Key_Le...
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.h
+++ b/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.h
@@ -17,8 +17,10 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-HostOS.h>
+#include <stdint.h>                 // for uint8_t, uint32_t
+
+#include "kaleidoscope/key_defs.h"  // for Key
+#include "kaleidoscope/plugin.h"    // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-WinKeyToggle/src/Kaleidoscope-WinKeyToggle.h
+++ b/plugins/Kaleidoscope-WinKeyToggle/src/Kaleidoscope-WinKeyToggle.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/WinKeyToggle.h>
+#include "kaleidoscope/plugin/WinKeyToggle.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-WinKeyToggle/src/kaleidoscope/plugin/WinKeyToggle.cpp
+++ b/plugins/Kaleidoscope-WinKeyToggle/src/kaleidoscope/plugin/WinKeyToggle.cpp
@@ -15,8 +15,11 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/Runtime.h"
-#include <Kaleidoscope-WinKeyToggle.h>
+#include "kaleidoscope/plugin/WinKeyToggle.h"
+
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"              // for Key, Key_LeftGui, Key...
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-WinKeyToggle/src/kaleidoscope/plugin/WinKeyToggle.h
+++ b/plugins/Kaleidoscope-WinKeyToggle/src/kaleidoscope/plugin/WinKeyToggle.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/Kaleidoscope-LEDControl.h
+++ b/src/Kaleidoscope-LEDControl.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <kaleidoscope/plugin/LEDMode.h>
-#include <kaleidoscope/plugin/LEDControl.h>
-#include <kaleidoscope/plugin/LEDControl/LEDUtils.h>
-#include <kaleidoscope/plugin/LEDControl/LED-Off.h>
+#include "kaleidoscope/plugin/LEDMode.h"
+#include "kaleidoscope/plugin/LEDControl.h"
+#include "kaleidoscope/plugin/LEDControl/LEDUtils.h"
+#include "kaleidoscope/plugin/LEDControl/LED-Off.h"

--- a/src/Kaleidoscope.h
+++ b/src/Kaleidoscope.h
@@ -86,7 +86,7 @@ void setup();
 #include "kaleidoscope/layers.h"
 #include "kaleidoscope_internal/sketch_exploration/sketch_exploration.h"
 #include "kaleidoscope/macro_map.h"
-#include "kaleidoscope_internal/event_dispatch.h"
+#include "kaleidoscope/hooks.h"
 #include "kaleidoscope_internal/LEDModeManager.h"
 #include "kaleidoscope/macro_helpers.h"
 #include "kaleidoscope/plugin.h"

--- a/src/kaleidoscope/KeyAddr.h
+++ b/src/kaleidoscope/KeyAddr.h
@@ -16,6 +16,6 @@
 
 #pragma once
 
-#include "kaleidoscope/device/device.h"
+#include "kaleidoscope/device/device.h"  // for Device
 
 typedef kaleidoscope::Device::KeyAddr KeyAddr;

--- a/src/kaleidoscope/KeyAddrBitfield.h
+++ b/src/kaleidoscope/KeyAddrBitfield.h
@@ -16,10 +16,11 @@
 
 #pragma once
 
-#include <Arduino.h>
+#include <Arduino.h>               // for bitClear, bitRead, bitSet, bitWrite
+#include <stdint.h>                // for uint8_t
+#include <string.h>                // for memset
 
-#include "kaleidoscope/KeyAddr.h"
-
+#include "kaleidoscope/KeyAddr.h"  // for KeyAddr
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/KeyAddrEventQueue.h
+++ b/src/kaleidoscope/KeyAddrEventQueue.h
@@ -17,13 +17,15 @@
 
 #pragma once
 
-#include <Arduino.h>
+#include <Arduino.h>                       // for bitRead, bitWrite
+#include <stdint.h>                        // for uint8_t, uint16_t
 //#include <assert.h>
 
-#include "kaleidoscope/Runtime.h"
-#include "kaleidoscope/KeyEvent.h"
-#include "kaleidoscope/KeyAddr.h"
-#include "kaleidoscope/keyswitch_state.h"
+#include "kaleidoscope/KeyAddr.h"          // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"         // for KeyEvent, KeyEventId
+#include "kaleidoscope/Runtime.h"          // for Runtime, Runtime_
+#include "kaleidoscope/key_defs.h"         // for Key_Undefined
+#include "kaleidoscope/keyswitch_state.h"  // for IS_PRESSED, WAS_PRESSED
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/KeyAddrMap.h
+++ b/src/kaleidoscope/KeyAddrMap.h
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include "kaleidoscope_internal/device.h"
-#include "kaleidoscope/KeyAddr.h"
-#include "kaleidoscope/key_defs.h"
+#include <stdint.h>                // for uint8_t
+
+#include "kaleidoscope/KeyAddr.h"  // for KeyAddr
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/KeyEvent.h
+++ b/src/kaleidoscope/KeyEvent.h
@@ -18,8 +18,8 @@
 
 #include <stdint.h>                 // for uint8_t, int8_t
 
-#include "kaleidoscope/key_defs.h"  // for Key, Key_NoKey
 #include "kaleidoscope/KeyAddr.h"   // for KeyAddr
+#include "kaleidoscope/key_defs.h"  // for Key_Undefined, Key
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/KeyEventTracker.h
+++ b/src/kaleidoscope/KeyEventTracker.h
@@ -16,8 +16,7 @@
 
 #pragma once
 
-#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
-#include "kaleidoscope/KeyEvent.h"              // for KeyEvent, KeyEventId
+#include "kaleidoscope/KeyEvent.h"  // for KeyEvent, KeyEventId
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/KeyMap.h
+++ b/src/kaleidoscope/KeyMap.h
@@ -16,7 +16,9 @@
 
 #pragma once
 
-#include "kaleidoscope/KeyAddrMap.h"
+#include "kaleidoscope/KeyAddr.h"     // for KeyAddr
+#include "kaleidoscope/KeyAddrMap.h"  // for KeyAddrMap
+#include "kaleidoscope/key_defs.h"    // for Key
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/LiveKeys.h
+++ b/src/kaleidoscope/LiveKeys.h
@@ -16,9 +16,10 @@
 
 #pragma once
 
-#include "kaleidoscope/key_defs.h"    // for Key, Key_NoKey, Key_Transparent
 #include "kaleidoscope/KeyAddr.h"     // for KeyAddr
+#include "kaleidoscope/KeyAddrMap.h"  // for KeyAddrMap<>::Iterator, KeyAddrMap
 #include "kaleidoscope/KeyMap.h"      // for KeyMap
+#include "kaleidoscope/key_defs.h"    // for Key, Key_Masked, Key_Inactive
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/MatrixAddr.h
+++ b/src/kaleidoscope/MatrixAddr.h
@@ -14,10 +14,11 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// IWYU pragma: private, include "kaleidoscope/KeyAddr.h"
+
 #pragma once
 
-#include <limits.h>
-#include <stdint.h>
+#include <stdint.h>  // for uint8_t, int8_t
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/Runtime.cpp
+++ b/src/kaleidoscope/Runtime.cpp
@@ -15,9 +15,17 @@
  */
 
 #include "kaleidoscope/Runtime.h"
-#include "kaleidoscope/LiveKeys.h"
-#include "kaleidoscope/layers.h"
-#include "kaleidoscope/keyswitch_state.h"
+
+#include <Arduino.h>                                      // for millis
+#include <HardwareSerial.h>                               // for HardwareSerial
+
+#include "kaleidoscope/KeyAddr.h"                         // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"                        // for KeyEvent
+#include "kaleidoscope/LiveKeys.h"                        // for LiveKeys
+#include "kaleidoscope/device/device.h"                   // for Base<>::HID
+#include "kaleidoscope/driver/hid/keyboardio/Keyboard.h"  // for Keyboard
+#include "kaleidoscope/keyswitch_state.h"                 // for keyToggledOff
+#include "kaleidoscope/layers.h"                          // for Layer, Layer_
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/Runtime.h
+++ b/src/kaleidoscope/Runtime.h
@@ -16,12 +16,17 @@
 
 #pragma once
 
-#include "kaleidoscope_internal/device.h"
-#include "kaleidoscope/event_handler_result.h"
-#include "kaleidoscope/hooks.h"
-#include "kaleidoscope/KeyEvent.h"
-#include "kaleidoscope/LiveKeys.h"
-#include "kaleidoscope/layers.h"
+#include <stdint.h>                             // for uint32_t
+
+#include "kaleidoscope/KeyAddr.h"               // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"              // for KeyEvent
+#include "kaleidoscope/LiveKeys.h"              // for LiveKeys, live_keys
+#include "kaleidoscope/device/device.h"         // for Device
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/hooks.h"                 // for Hooks
+#include "kaleidoscope/key_defs.h"              // for Key, Key_Transparent
+#include "kaleidoscope/layers.h"                // for Layer, Layer_
+#include "kaleidoscope_internal/device.h"       // for device
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/bitfields.cpp
+++ b/src/kaleidoscope/bitfields.cpp
@@ -14,9 +14,10 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Arduino.h>
+#include "kaleidoscope/bitfields.h"
 
-#include "bitfields.h"
+#include <Arduino.h>  // for pgm_read_byte
+#include <stdint.h>   // for uint8_t
 
 namespace kaleidoscope {
 namespace bitfields {

--- a/src/kaleidoscope/bitfields.h
+++ b/src/kaleidoscope/bitfields.h
@@ -16,8 +16,9 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <stddef.h>
+#include <Arduino.h>  // for PROGMEM
+#include <stddef.h>   // for size_t
+#include <stdint.h>   // for uint8_t
 
 namespace kaleidoscope {
 namespace bitfields {

--- a/src/kaleidoscope/device/ATmega32U4Keyboard.h
+++ b/src/kaleidoscope/device/ATmega32U4Keyboard.h
@@ -19,14 +19,13 @@
 
 #if defined(__AVR__) || defined(KALEIDOSCOPE_VIRTUAL_BUILD)
 
-#include <Arduino.h>
-#include "kaleidoscope/device/Base.h"
-
-#include "kaleidoscope/driver/mcu/ATmega32U4.h"
-#include "kaleidoscope/driver/hid/Keyboardio.h"
-#include "kaleidoscope/driver/keyscanner/ATmega.h"
-#include "kaleidoscope/driver/storage/ATmega32U4EEPROMProps.h"
-#include "kaleidoscope/driver/storage/AVREEPROM.h"
+// IWYU pragma: begin_exports
+#include "kaleidoscope/device/Base.h"                           // for BaseP...
+#include "kaleidoscope/driver/hid/Keyboardio.h"                 // for Keybo...
+#include "kaleidoscope/driver/mcu/ATmega32U4.h"                 // for ATmeg...
+#include "kaleidoscope/driver/storage/ATmega32U4EEPROMProps.h"  // for ATmeg...
+#include "kaleidoscope/driver/storage/AVREEPROM.h"              // for AVREE...
+// IWYU pragma: end_exports
 
 namespace kaleidoscope {
 namespace device {

--- a/src/kaleidoscope/device/Base.h
+++ b/src/kaleidoscope/device/Base.h
@@ -15,22 +15,26 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// IWYU pragma: private, include "kaleidoscope/device/device.h"
+
 /** @file kaleidoscope/device/Base.h
  * Base class for Kaleidoscope device libraries.
  */
 
 #pragma once
 
-#include "kaleidoscope/MatrixAddr.h"
-#include "kaleidoscope_internal/deprecations.h"
-#include "kaleidoscope/macro_helpers.h"
+#include <stdint.h>                               // for uint8_t, int8_t
+#include <string.h>                               // for size_t, strlen, memcpy
 
-#include "kaleidoscope/driver/hid/Base.h"
-#include "kaleidoscope/driver/keyscanner/None.h"
-#include "kaleidoscope/driver/led/None.h"
-#include "kaleidoscope/driver/mcu/None.h"
-#include "kaleidoscope/driver/bootloader/None.h"
-#include "kaleidoscope/driver/storage/None.h"
+#include "kaleidoscope/driver/bootloader/None.h"  // for None
+#include "kaleidoscope/driver/hid/Base.h"         // for Base, BaseProps
+#include "kaleidoscope/driver/keyscanner/Base.h"  // for BaseProps
+#include "kaleidoscope/driver/keyscanner/None.h"  // for None
+#include "kaleidoscope/driver/led/None.h"         // for cRGB, BaseProps, CRGB
+#include "kaleidoscope/driver/mcu/Base.h"         // for BaseProps
+#include "kaleidoscope/driver/mcu/None.h"         // for None
+#include "kaleidoscope/driver/storage/Base.h"     // for BaseProps
+#include "kaleidoscope/driver/storage/None.h"     // for None
 
 #ifndef CRGB
 #error cRGB and CRGB *must* be defined before including this header!

--- a/src/kaleidoscope/device/device.h
+++ b/src/kaleidoscope/device/device.h
@@ -1,5 +1,6 @@
-/* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2019  Keyboard.io, Inc.
+/* -*- mode: c++ -*-
+ * Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2022  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -16,8 +17,42 @@
 
 #pragma once
 
+/** @file kaleidoscope/device/device.h
+ *
+ * Provider of the following types:
+ *  - `kaleidoscope::Device`
+ *  - `kaleidoscope::Device::KeyAddr`
+ *  - `kaleidoscope::DeviceProps`
+ *  - `kaleidoscope::device::HID`
+ *  - `kaleidoscope::device::Storage`
+ *  - `kaleidoscope::device::StorageProps`
+ */
+
+// This file includes whatever hardware plugin is specified during the build.
+// Depending on which device is targeted, you can find the sources in one of the
+// following files under the `plugins` directory:
+//
+// `Kaleidoscope-Hardware-<make>-<model>/src/kaleidoscope/device/<make>/<model>.h`
+//
+// Each hardware device header defines a types `kaleidoscope::Device` and
+// `kaleidoscope::DeviceProps` by using the `EXPORT_DEVICE()` preprocessor
+// macro, which then becomes available to client code by means of this header.
+// Client code should not include specific hardware device headers directly.
+//
+// `KALEIDOSCOPE_HARDWARE_H` gets defined during the build process like this:
+// The fully-qualified board name (fqbn) is read from the `sketch.json` file (in
+// the same directory as the sketch's *.ino file), and that tells Arduino which
+// core to use and which definition to read from `boards.txt`, which adds
+// compiler flags that set `KALEIDOSCOPE_HARDWARE_H` to the appropriate header
+// for the hardware plugin.
+//
+// For a description of the API for the `kaleidoscope::Device` class, see the
+// base device class definition in the following file:
+//
+// `kaleidoscope/device/Base.h`
+
 #ifdef KALEIDOSCOPE_VIRTUAL_BUILD
-#include "kaleidoscope/device/virtual/Virtual.h"
+#include "kaleidoscope/device/virtual/Virtual.h"  // IWYU pragma: export
 #else
 #include KALEIDOSCOPE_HARDWARE_H
 #endif

--- a/src/kaleidoscope/device/key_indexes.h
+++ b/src/kaleidoscope/device/key_indexes.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
-#include "kaleidoscope/KeyAddr.h"
+#include <stdint.h>                // for uint8_t
+
+#include "kaleidoscope/KeyAddr.h"  // for KeyAddr
 
 /* To be used by the hardware implementations, `keyIndex` tells us the index of
  * a key, from which we can figure out the row and column as needed. The index

--- a/src/kaleidoscope/device/virtual/DefaultHIDReportConsumer.cpp
+++ b/src/kaleidoscope/device/virtual/DefaultHIDReportConsumer.cpp
@@ -16,16 +16,24 @@
 
 #ifdef KALEIDOSCOPE_VIRTUAL_BUILD
 
-#include "DefaultHIDReportConsumer.h"
-#include "MultiReport/Keyboard.h"
-#include "Logging.h"
+#include "kaleidoscope/device/virtual/DefaultHIDReportConsumer.h"
 
-#include "virtual_io.h"
+// From KeyboardioHID:
+#include <HID-Settings.h>                         // for HID_REPORTID_NKRO_K...
+#include <MultiReport/Keyboard.h>                 // for HID_KeyboardReport_...
+// From system:
+#include <stdint.h>                               // for uint8_t
+// From Arduino core:
+#include <virtual_io.h>                           // for logUSBEvent_keyboard
+
+// From Kaleidoscope:
+#include "kaleidoscope/device/virtual/Logging.h"  // for log_info, logging
 
 #undef min
 #undef max
 
-#include <sstream>
+#include <sstream>                                // for operator<<, strings...
+#include <string>                                 // for char_traits, operator+
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/device/virtual/DefaultHIDReportConsumer.h
+++ b/src/kaleidoscope/device/virtual/DefaultHIDReportConsumer.h
@@ -18,7 +18,7 @@
 
 #ifdef KALEIDOSCOPE_VIRTUAL_BUILD
 
-#include <stdint.h>
+#include <stdint.h>  // for uint8_t
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/device/virtual/HID.cpp
+++ b/src/kaleidoscope/device/virtual/HID.cpp
@@ -22,11 +22,9 @@
 // library KeyboardioHID. It replaces all hardware related stuff
 // with stub implementations.
 
-// Include KeyboardioHID's HID.h header
-//
+// From KeyboardioHID:
 #include "HID.h"
-
-#include "HIDReportObserver.h"
+#include "HIDReportObserver.h"  // for HIDReportObserver
 
 #if defined(USBCON)
 

--- a/src/kaleidoscope/device/virtual/Logging.h
+++ b/src/kaleidoscope/device/virtual/Logging.h
@@ -18,8 +18,9 @@
 
 #ifdef KALEIDOSCOPE_VIRTUAL_BUILD
 
-#include "utility"
-#include "stdio.h"
+#include <stdio.h>  // for fprintf, stderr, stdout
+#include <utility>  // IWYU pragma: keep
+// IWYU pragma: no_include <__utility/forward.h>
 
 namespace kaleidoscope {
 namespace logging {

--- a/src/kaleidoscope/device/virtual/Virtual.cpp
+++ b/src/kaleidoscope/device/virtual/Virtual.cpp
@@ -18,20 +18,28 @@
 #ifdef KALEIDOSCOPE_VIRTUAL_BUILD
 
 #include "kaleidoscope/device/virtual/Virtual.h"
-#include "kaleidoscope/device/virtual/DefaultHIDReportConsumer.h"
-#include "kaleidoscope/device/virtual/Logging.h"
 
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/MatrixAddr.h"
-#include "kaleidoscope/key_defs.h"
+// From system:
+#include <stdint.h>                               // for uint8_t, uint16_t
+#include <stdlib.h>                               // for exit, size_t
 
+// From Arduino:
+#include <EEPROM.h>                               // for EEPROMClass, EERef
+#include <virtual_io.h>                           // for getLineOfInput, isI...
 
-#include "HIDReportObserver.h"
-#include "virtual_io.h"
-#include "EEPROM.h"
+// From KeyboardioHID:
+#include <HIDReportObserver.h>                    // for HIDReportObserver
 
-#include <sstream>
-#include <string>
+// From Kaleidoscope:
+#include "kaleidoscope/KeyAddr.h"                 // for MatrixAddr, MatrixA...
+#include "kaleidoscope/device/virtual/DefaultHIDReportConsumer.h"  // for DefaultHIDReportCon...
+#include "kaleidoscope/device/virtual/Logging.h"  // for log_error, logging
+#include "kaleidoscope/key_defs.h"                // for Key_NoKey
+#include "kaleidoscope/keyswitch_state.h"         // for IS_PRESSED, WAS_PRE...
+
+// These must come after other headers:
+#include <sstream>                                // for operator<<, string
+#include <string>                                 // for operator==, char_tr...
 
 // FIXME: This relates to virtual/cores/arduino/EEPROM.h.
 //        EEPROM static data must be defined here as only

--- a/src/kaleidoscope/device/virtual/Virtual.h
+++ b/src/kaleidoscope/device/virtual/Virtual.h
@@ -15,15 +15,25 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// IWYU pragma: private, include "kaleidoscope/device/device.h"
+
 #pragma once
 
 #ifdef KALEIDOSCOPE_VIRTUAL_BUILD
 
+// Compile-time (emulated) hardware header:
 #include KALEIDOSCOPE_HARDWARE_H
 
-#include "kaleidoscope/driver/bootloader/None.h"
-#include "kaleidoscope/driver/hid/Keyboardio.h"
-#include "kaleidoscope/driver/led/Base.h"
+// From system:
+#include <stdint.h>                                    // for uint8_t
+// From Arduino libraries:
+#include <HardwareSerial.h>                            // for Serial
+// From Kaleidoscope:
+#include "kaleidoscope/device/Base.h"                  // for Base
+#include "kaleidoscope/driver/bootloader/None.h"       // for None
+#include "kaleidoscope/driver/hid/Keyboardio.h"        // for Keyboardio
+#include "kaleidoscope/driver/keyscanner/Base.h"       // for Base
+#include "kaleidoscope/driver/mcu/None.h"              // for None
 
 namespace kaleidoscope {
 namespace device {

--- a/src/kaleidoscope/driver/bootloader/None.h
+++ b/src/kaleidoscope/driver/bootloader/None.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "kaleidoscope/driver/bootloader/Base.h"
+#include "kaleidoscope/driver/bootloader/Base.h"  // for Base
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/bootloader/avr/Caterina.h
+++ b/src/kaleidoscope/driver/bootloader/avr/Caterina.h
@@ -20,8 +20,8 @@
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #include <avr/wdt.h>
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-#include "kaleidoscope/driver/bootloader/None.h"
-#include "kaleidoscope/driver/bootloader/Base.h"
+#include "kaleidoscope/driver/bootloader/Base.h"  // IWYU pragma: keep
+#include "kaleidoscope/driver/bootloader/None.h"  // for None
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/bootloader/avr/FLIP.h
+++ b/src/kaleidoscope/driver/bootloader/avr/FLIP.h
@@ -25,8 +25,8 @@
 #endif
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
-#include "kaleidoscope/driver/bootloader/None.h"
-#include "kaleidoscope/driver/bootloader/Base.h"
+#include "kaleidoscope/driver/bootloader/Base.h"  // IWYU pragma: keep
+#include "kaleidoscope/driver/bootloader/None.h"  // for None
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/bootloader/avr/HalfKay.h
+++ b/src/kaleidoscope/driver/bootloader/avr/HalfKay.h
@@ -20,8 +20,8 @@
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #include <avr/wdt.h>
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
-#include "kaleidoscope/driver/bootloader/None.h"
-#include "kaleidoscope/driver/bootloader/Base.h"
+#include "kaleidoscope/driver/bootloader/Base.h"  // IWYU pragma: keep
+#include "kaleidoscope/driver/bootloader/None.h"  // for None
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/bootloader/gd32/Base.h
+++ b/src/kaleidoscope/driver/bootloader/gd32/Base.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <Arduino.h>  // IWYU pragma: keep
+
 #include "kaleidoscope/driver/bootloader/Base.h"
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/driver/bootloader/samd/Bossac.h
+++ b/src/kaleidoscope/driver/bootloader/samd/Bossac.h
@@ -20,6 +20,8 @@
 
 #ifdef ARDUINO_ARCH_SAMD
 
+#include <Arduino.h>
+
 #include "kaleidoscope/driver/bootloader/Base.h"
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/driver/color/GammaCorrection.h
+++ b/src/kaleidoscope/driver/color/GammaCorrection.h
@@ -17,7 +17,8 @@
 
 #pragma once
 
-#include <Arduino.h>
+#include <Arduino.h>  // for PROGMEM
+#include <stdint.h>   // for uint8_t
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/hid/Base.h
+++ b/src/kaleidoscope/driver/hid/Base.h
@@ -16,12 +16,10 @@
  */
 
 #pragma once
-#include <Arduino.h>
-#include "kaleidoscope/key_defs.h"
 
-#include "base/Keyboard.h"
-#include "base/Mouse.h"
-#include "base/AbsoluteMouse.h"
+#include "base/AbsoluteMouse.h"  // for AbsoluteMouse, AbsoluteMouseProps
+#include "base/Keyboard.h"       // for Keyboard, KeyboardProps
+#include "base/Mouse.h"          // for Mouse, MouseProps
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/hid/Keyboardio.h
+++ b/src/kaleidoscope/driver/hid/Keyboardio.h
@@ -16,15 +16,11 @@
  */
 
 #pragma once
-#include <Arduino.h>
-#include <KeyboardioHID.h>
-#include "kaleidoscope/key_defs.h"
 
-#include "kaleidoscope/driver/hid/Base.h"
-
-#include "keyboardio/Keyboard.h"
-#include "keyboardio/Mouse.h"
-#include "keyboardio/AbsoluteMouse.h"
+#include "kaleidoscope/driver/hid/Base.h"  // for Base, BaseProps
+#include "keyboardio/AbsoluteMouse.h"      // for AbsoluteMouse, AbsoluteMou...
+#include "keyboardio/Keyboard.h"           // for Keyboard, KeyboardProps
+#include "keyboardio/Mouse.h"              // for Mouse, MouseProps
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/hid/base/AbsoluteMouse.h
+++ b/src/kaleidoscope/driver/hid/base/AbsoluteMouse.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <Arduino.h>
+#include <stdint.h>  // for uint8_t, int8_t, uint16_t
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/hid/base/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/base/Keyboard.h
@@ -16,9 +16,10 @@
  */
 
 #pragma once
-#include <Arduino.h>
 
-#include "kaleidoscope/key_defs.h"
+#include <stdint.h>                 // for uint8_t
+
+#include "kaleidoscope/key_defs.h"  // for Key, Key_LeftAlt, Key_LeftControl
 
 #ifndef HID_BOOT_PROTOCOL
 #define HID_BOOT_PROTOCOL 0

--- a/src/kaleidoscope/driver/hid/base/Mouse.h
+++ b/src/kaleidoscope/driver/hid/base/Mouse.h
@@ -16,7 +16,8 @@
  */
 
 #pragma once
-#include <Arduino.h>
+
+#include <stdint.h>  // for int8_t, uint8_t
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/hid/keyboardio/AbsoluteMouse.h
+++ b/src/kaleidoscope/driver/hid/keyboardio/AbsoluteMouse.h
@@ -17,10 +17,14 @@
 
 #pragma once
 
-#include <Arduino.h>
-#include <KeyboardioHID.h>
+#include <stdint.h>                                      // for uint8_t, int8_t
 
-#include "kaleidoscope/driver/hid/base/AbsoluteMouse.h"
+#include <KeyboardioHID.h>
+// From KeyboardioHID:
+#include "DeviceAPIs/AbsoluteMouseAPI.hpp"               // for AbsoluteMous...
+#include "SingleReport/SingleAbsoluteMouse.h"            // for SingleAbsolu...
+// From Kaleidoscope:
+#include "kaleidoscope/driver/hid/base/AbsoluteMouse.h"  // for AbsoluteMouse
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/hid/keyboardio/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/keyboardio/Keyboard.h
@@ -16,10 +16,17 @@
  */
 
 #pragma once
-#include <Arduino.h>
-#include <KeyboardioHID.h>
 
-#include "kaleidoscope/driver/hid/base/Keyboard.h"
+#include <stdint.h>                                 // for uint8_t, uint16_t
+
+#include <KeyboardioHID.h>
+// From KeyboardioHID:
+#include "BootKeyboard/BootKeyboard.h"              // for BootKeyboard, Boo...
+#include "MultiReport/ConsumerControl.h"            // for ConsumerControl
+#include "MultiReport/Keyboard.h"                   // for Keyboard, Keyboard_
+#include "MultiReport/SystemControl.h"              // for SystemControl
+// From Kaleidoscope:
+#include "kaleidoscope/driver/hid/base/Keyboard.h"  // for Keyboard, Keyboar...
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/hid/keyboardio/Mouse.h
+++ b/src/kaleidoscope/driver/hid/keyboardio/Mouse.h
@@ -16,10 +16,14 @@
  */
 
 #pragma once
-#include <Arduino.h>
-#include <KeyboardioHID.h>
 
-#include "kaleidoscope/driver/hid/base/Mouse.h"
+#include <stdint.h>                              // for int8_t, uint8_t
+
+#include <KeyboardioHID.h>
+// From KeyboardioHID:
+#include "MultiReport/Mouse.h"                   // for HID_MouseReport_Data_t
+// From Kaleidoscope:
+#include "kaleidoscope/driver/hid/base/Mouse.h"  // for Mouse, MouseProps
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/keyscanner/ATmega.h
+++ b/src/kaleidoscope/driver/keyscanner/ATmega.h
@@ -17,13 +17,11 @@
 
 #pragma once
 
-#include <Arduino.h>
+#include <stdint.h>                               // for uint16_t, uint8_t
 
-#include "kaleidoscope/macro_helpers.h"
-#include "kaleidoscope/driver/keyscanner/Base.h"
-#include "kaleidoscope/driver/keyscanner/None.h"
-
-#include "kaleidoscope/device/avr/pins_and_ports.h"
+#include "kaleidoscope/device/avr/pins_and_ports.h"  // IWYU pragma: keep
+#include "kaleidoscope/driver/keyscanner/Base.h"  // for BaseProps
+#include "kaleidoscope/driver/keyscanner/None.h"  // for None
 
 #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 #include <avr/wdt.h>

--- a/src/kaleidoscope/driver/keyscanner/Base.h
+++ b/src/kaleidoscope/driver/keyscanner/Base.h
@@ -17,10 +17,10 @@
 
 #pragma once
 
-#include <Arduino.h>
+#include <stdint.h>                   // for uint8_t
 
-#include "kaleidoscope/key_defs.h"
-#include "kaleidoscope/MatrixAddr.h"
+#include "kaleidoscope/MatrixAddr.h"  // for MatrixAddr
+#include "kaleidoscope/key_defs.h"    // for Key
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/keyscanner/Base_Impl.h
+++ b/src/kaleidoscope/driver/keyscanner/Base_Impl.h
@@ -17,11 +17,14 @@
 
 #pragma once
 
-#include "kaleidoscope/driver/keyscanner/Base.h"
-#include "kaleidoscope/device/device.h"
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/KeyEvent.h"
-#include "kaleidoscope/Runtime.h"
+#include <stdint.h>                               // for uint8_t
+
+#include "kaleidoscope/KeyEvent.h"                // for KeyEvent
+#include "kaleidoscope/Runtime.h"                 // for Runtime, Runtime_
+#include "kaleidoscope/device/virtual/Virtual.h"  // for Device
+#include "kaleidoscope/driver/keyscanner/Base.h"  // for Base
+#include "kaleidoscope/key_defs.h"                // for Key
+#include "kaleidoscope/keyswitch_state.h"         // for keyToggledOff, keyT...
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/keyscanner/None.h
+++ b/src/kaleidoscope/driver/keyscanner/None.h
@@ -17,9 +17,7 @@
 
 #pragma once
 
-#include <Arduino.h>
-
-#include "kaleidoscope/driver/keyscanner/Base.h"
+#include "kaleidoscope/driver/keyscanner/Base.h"  // for BaseProps, Base
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/led/Base.h
+++ b/src/kaleidoscope/driver/led/Base.h
@@ -21,6 +21,9 @@
 #error cRGB and CRGB *must* be defined before including this header!
 #endif
 
+#include <Arduino.h>  // for PROGMEM, pgm_read_byte
+#include <stdint.h>   // for uint8_t
+
 namespace kaleidoscope {
 namespace driver {
 namespace led {

--- a/src/kaleidoscope/driver/led/Color.h
+++ b/src/kaleidoscope/driver/led/Color.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <stdint.h>  // for uint8_t
+
 namespace kaleidoscope {
 namespace driver {
 namespace led {

--- a/src/kaleidoscope/driver/led/None.h
+++ b/src/kaleidoscope/driver/led/None.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <stdint.h>                        // for uint8_t
+
 #ifndef CRGB
 
 struct cRGB {
@@ -27,7 +29,7 @@ struct cRGB {
 
 #endif
 
-#include "kaleidoscope/driver/led/Base.h"
+#include "kaleidoscope/driver/led/Base.h"  // for Base, BaseProps (ptr only)
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/led/WS2812.h
+++ b/src/kaleidoscope/driver/led/WS2812.h
@@ -33,8 +33,8 @@
 
 #pragma once
 
-#include "kaleidoscope/hardware/avr/pins_and_ports.h"
 #include "kaleidoscope/driver/led/Color.h"
+#include "kaleidoscope/hardware/avr/pins_and_ports.h"
 #include "ws2812/config.h"
 
 namespace kaleidoscope {

--- a/src/kaleidoscope/driver/mcu/ATmega32U4.h
+++ b/src/kaleidoscope/driver/mcu/ATmega32U4.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "kaleidoscope/driver/mcu/Base.h"
+#include "kaleidoscope/driver/mcu/Base.h"  // for Base, BaseProps
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/mcu/None.h
+++ b/src/kaleidoscope/driver/mcu/None.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "kaleidoscope/driver/mcu/Base.h"
+#include "kaleidoscope/driver/mcu/Base.h"  // for Base, BaseProps (ptr only)
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/storage/ATmega32U4EEPROMProps.h
+++ b/src/kaleidoscope/driver/storage/ATmega32U4EEPROMProps.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
-#include "kaleidoscope/driver/storage/AVREEPROM.h"
+#include <stdint.h>                                 // for uint16_t
+
+#include "kaleidoscope/driver/storage/AVREEPROM.h"  // for AVREEPROMProps
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/storage/AVREEPROM.h
+++ b/src/kaleidoscope/driver/storage/AVREEPROM.h
@@ -17,10 +17,12 @@
 
 #pragma once
 
+#include <stdint.h>                            // for uint16_t, uint8_t
 #if defined(__AVR__) || defined(KALEIDOSCOPE_VIRTUAL_BUILD)
 
-#include "kaleidoscope/driver/storage/Base.h"
-#include <EEPROM.h>
+#include <EEPROM.h>                            // for EEPROM, EEPROMClass
+
+#include "kaleidoscope/driver/storage/Base.h"  // for Base, BaseProps
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/storage/Base.h
+++ b/src/kaleidoscope/driver/storage/Base.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <stdint.h>  // for uint16_t, uint8_t
+
 namespace kaleidoscope {
 namespace driver {
 namespace storage {

--- a/src/kaleidoscope/driver/storage/Flash.h
+++ b/src/kaleidoscope/driver/storage/Flash.h
@@ -27,9 +27,10 @@
 
 #ifdef __SAMD21G18A__
 
-#include "kaleidoscope/driver/storage/Base.h"
-#include <FlashStorage.h>
 #include <FlashAsEEPROM.h>
+#include <FlashStorage.h>
+
+#include "kaleidoscope/driver/storage/Base.h"
 
 // We need to undefine Flash, because `FlashStorage` defines it as a macro, yet,
 // we want to use it as a class name.

--- a/src/kaleidoscope/driver/storage/GD32Flash.h
+++ b/src/kaleidoscope/driver/storage/GD32Flash.h
@@ -19,9 +19,10 @@
 
 #if defined(ARDUINO_ARCH_GD32) || defined(KALEIDOSCOPE_VIRTUAL_BUILD)
 
+#include <FlashAsEEPROM.h>
+#include <FlashStorage.h>
+
 #include "kaleidoscope/driver/storage/Base.h"
-#include "FlashStorage.h"
-#include "FlashAsEEPROM.h"
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/driver/storage/None.h
+++ b/src/kaleidoscope/driver/storage/None.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "kaleidoscope/driver/storage/Base.h"
+#include "kaleidoscope/driver/storage/Base.h"  // for Base, BaseProps (ptr o...
 
 namespace kaleidoscope {
 namespace driver {

--- a/src/kaleidoscope/event_handler_result.h
+++ b/src/kaleidoscope/event_handler_result.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <stdint.h>  // for uint8_t
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/hooks.cpp
+++ b/src/kaleidoscope/hooks.cpp
@@ -14,10 +14,10 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope/event_handler_result.h"
-#include "kaleidoscope/event_handlers.h"
-#include "kaleidoscope/macro_helpers.h"
-#include "kaleidoscope/hooks.h"
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/event_handlers.h"        // for _FOR_EACH_EVENT_HANDLER
+#include "kaleidoscope/hooks.h"                 // for Hooks
+#include "kaleidoscope/macro_helpers.h"         // for __NL__, MAKE_TEMPLATE...
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/hooks.h
+++ b/src/kaleidoscope/hooks.h
@@ -16,30 +16,22 @@
 
 #pragma once
 
-#include <Arduino.h>
+#include "kaleidoscope/KeyEvent.h"  // IWYU pragma: keep
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/event_handlers.h"        // for _FOR_EACH_EVENT_HANDLER
+#include "kaleidoscope/macro_helpers.h"         // for __NL__, MAKE_TEMPLATE...
+#include "kaleidoscope_internal/event_dispatch.h"  // IWYU pragma: keep
 
 namespace kaleidoscope {
-class Key;
-}
-
-#include "kaleidoscope/KeyAddr.h"
-#include "kaleidoscope/KeyEvent.h"
-#include "kaleidoscope/plugin.h"
-#include "kaleidoscope/event_handlers.h"
-
-// Forward declaration required to enable friend declarations
-// in class Hooks.
-class kaleidoscope_;
-
-namespace kaleidoscope {
-namespace plugin {
-// Forward declaration to enable friend declarations.
-class LEDControl;
-class FocusSerial;
-}
-
-// Forward declaration to enable friend declarations.
+// Forward declarations to enable friend declarations.
 class Layer_;
+class Runtime_;
+
+namespace plugin {
+// Forward declarations to enable friend declarations.
+class FocusSerial;
+class LEDControl;
+} // namespace plugin
 
 namespace sketch_exploration {
 void pluginsExploreSketch();
@@ -61,11 +53,11 @@ class Hooks {
 
   // Runtime_ calls Hooks::onSetup, Hooks::beforeReportingState
   // and Hooks::afterEachCycle.
+  friend class Layer_;
   friend class Runtime_;
-  friend class ::kaleidoscope::plugin::FocusSerial;
-  friend class ::kaleidoscope::Layer_;
-  friend class ::kaleidoscope::plugin::LEDControl;
-  friend void ::kaleidoscope::sketch_exploration::pluginsExploreSketch();
+  friend class plugin::FocusSerial;
+  friend class plugin::LEDControl;
+  friend void sketch_exploration::pluginsExploreSketch();
 
  private:
 

--- a/src/kaleidoscope/key_defs.h
+++ b/src/kaleidoscope/key_defs.h
@@ -16,16 +16,18 @@
 
 #pragma once
 
+#include <Arduino.h>                        // for pgm_read_byte, INPUT
 #include <stdint.h>                         // for uint8_t, uint16_t
 
-#include <Arduino.h>                        // for pgm_read_byte, INPUT
-
 #include "kaleidoscope/HIDTables.h"         // for HID_KEYBOARD_LEFT_CONTROL
-#include "kaleidoscope/key_defs/keyboard.h"
-#include "kaleidoscope/key_defs/sysctl.h"
-#include "kaleidoscope/key_defs/consumerctl.h"
-#include "kaleidoscope/key_defs/keymaps.h"  // for LAYER_SHIFT_OFFSET
+
+// IWYU pragma: begin_exports
 #include "kaleidoscope/key_defs/aliases.h"
+#include "kaleidoscope/key_defs/consumerctl.h"
+#include "kaleidoscope/key_defs/keyboard.h"
+#include "kaleidoscope/key_defs/keymaps.h"  // for LAYER_MOVE_OFFSET, LAYER_...
+#include "kaleidoscope/key_defs/sysctl.h"
+// IWYU pragma: end_exports
 
 // -----------------------------------------------------------------------------
 // Constant keycode values

--- a/src/kaleidoscope/key_defs/keymaps.h
+++ b/src/kaleidoscope/key_defs/keymaps.h
@@ -16,9 +16,7 @@
 
 #pragma once
 
-#include <stdint.h>
-
-#include "kaleidoscope_internal/deprecations.h"
+#include <stdint.h>  // for uint8_t
 
 static const uint8_t LAYER_OP_OFFSET = 42;
 static const uint8_t LAYER_SHIFT_OFFSET = LAYER_OP_OFFSET;

--- a/src/kaleidoscope/keymaps.h
+++ b/src/kaleidoscope/keymaps.h
@@ -16,9 +16,12 @@
 
 #pragma once
 
-#include "kaleidoscope/key_defs.h"
-#include "kaleidoscope/KeyAddr.h"
-#include "kaleidoscope_internal/device.h"
+#include <stdint.h>                        // for uint8_t
+
+#include "kaleidoscope/KeyAddr.h"          // for KeyAddr
+#include "kaleidoscope/device/device.h"    // for Device
+#include "kaleidoscope/key_defs.h"         // for Key
+#include "kaleidoscope_internal/device.h"  // for device
 
 extern const Key keymaps_linear[][kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns];
 

--- a/src/kaleidoscope/keyswitch_state.h
+++ b/src/kaleidoscope/keyswitch_state.h
@@ -17,8 +17,6 @@
 #pragma once
 // switch debouncing and status
 
-#include <Arduino.h>
-
 #define INJECTED    0b10000000
 #define IS_PRESSED  0b00000010
 #define WAS_PRESSED 0b00000001

--- a/src/kaleidoscope/layers.cpp
+++ b/src/kaleidoscope/layers.cpp
@@ -14,12 +14,22 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kaleidoscope_internal/device.h"
-#include "kaleidoscope/hooks.h"
-#include "kaleidoscope/layers.h"
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/KeyEvent.h"
-#include "kaleidoscope/LiveKeys.h"
+#include <stdint.h>                               // for uint8_t, int8_t
+#include <string.h>                               // for memmove, memset
+
+#include "kaleidoscope/KeyAddr.h"                 // for KeyAddr
+#include "kaleidoscope/KeyAddrMap.h"              // for KeyAddrMap<>::Iterator
+#include "kaleidoscope/KeyEvent.h"                // for KeyEvent
+#include "kaleidoscope/KeyMap.h"                  // for KeyMap
+#include "kaleidoscope/LiveKeys.h"                // for LiveKeys, live_keys
+#include "kaleidoscope/MatrixAddr.h"              // for MatrixAddr, MatrixA...
+#include "kaleidoscope/device/virtual/Virtual.h"  // for Device
+#include "kaleidoscope/hooks.h"                   // for Hooks
+#include "kaleidoscope/key_defs.h"                // for Key, LAYER_MOVE_OFFSET
+#include "kaleidoscope/keymaps.h"                 // for keyFromKeymap
+#include "kaleidoscope/keyswitch_state.h"         // for keyToggledOn
+#include "kaleidoscope/layers.h"                  // for Layer_, Layer, Laye...
+#include "kaleidoscope_internal/device.h"         // for device
 
 // The maximum number of layers allowed.
 #define MAX_LAYERS 32;

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -16,15 +16,18 @@
 
 #pragma once
 
-#include <Arduino.h>
-#include "kaleidoscope/key_defs.h"
-#include "kaleidoscope/keymaps.h"
-#include "kaleidoscope/KeyEvent.h"
-#include "kaleidoscope/device/device.h"
-#include "kaleidoscope_internal/device.h"
-#include "kaleidoscope_internal/sketch_exploration/sketch_exploration.h"
-#include "kaleidoscope_internal/shortname.h"
-#include "kaleidoscope_internal/deprecations.h"
+#include <Arduino.h>                                // for PROGMEM
+#include <stdint.h>                                 // for uint8_t, int8_t
+
+#include "kaleidoscope/KeyAddr.h"                   // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"                  // for KeyEvent
+#include "kaleidoscope/device/device.h"             // for Device
+#include "kaleidoscope/key_defs.h"                  // for Key
+#include "kaleidoscope/keymaps.h"                   // IWYU pragma: keep
+#include "kaleidoscope/macro_helpers.h"             // for __NL__
+#include "kaleidoscope_internal/device.h"           // for device
+#include "kaleidoscope_internal/shortname.h"        // for _INIT_HID_GETSHOR...
+#include "kaleidoscope_internal/sketch_exploration/sketch_exploration.h"  // for _INIT_SKETCH_EXPL...
 
 #define START_KEYMAPS                                                   __NL__ \
    constexpr Key keymaps_linear[][kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns] PROGMEM = {

--- a/src/kaleidoscope/plugin.h
+++ b/src/kaleidoscope/plugin.h
@@ -16,10 +16,6 @@
 
 #pragma once
 
-#include "kaleidoscope/event_handler_result.h"
-#include "kaleidoscope_internal/event_dispatch.h"
-#include "kaleidoscope/event_handlers.h"
-
 #if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API
 #error The V1 plugin API has been removed, please see UPGRADING.md.
 #endif

--- a/src/kaleidoscope/plugin/AccessTransientLEDMode.h
+++ b/src/kaleidoscope/plugin/AccessTransientLEDMode.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <stdint.h>  // for uint8_t
+
 namespace kaleidoscope {
 namespace plugin {
 

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -14,11 +14,18 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Kaleidoscope-LEDControl.h"
-#include "Kaleidoscope-FocusSerial.h"
-#include "kaleidoscope_internal/LEDModeManager.h"
-#include "kaleidoscope/keyswitch_state.h"
-#include "kaleidoscope/LiveKeys.h"
+#include "kaleidoscope/plugin/LEDControl.h"
+
+#include <Arduino.h>                               // for PSTR, strcmp_P
+#include <Kaleidoscope-FocusSerial.h>              // for Focus, FocusSerial
+
+#include "kaleidoscope/KeyAddrMap.h"               // for KeyAddrMap<>::Iter...
+#include "kaleidoscope/KeyEvent.h"                 // for KeyEvent
+#include "kaleidoscope/KeyMap.h"                   // for KeyMap
+#include "kaleidoscope/LiveKeys.h"                 // for LiveKeys, live_keys
+#include "kaleidoscope/hooks.h"                    // for Hooks
+#include "kaleidoscope/keyswitch_state.h"          // for keyToggledOn
+#include "kaleidoscope_internal/LEDModeManager.h"  // for LEDModeManager
 
 using namespace kaleidoscope::internal; // NOLINT(build/namespaces)
 

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -16,8 +16,17 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
-#include "kaleidoscope/plugin/LEDMode.h"
+#include <stdint.h>                                // for uint8_t, uint16_t
+
+#include "kaleidoscope/KeyAddr.h"                  // for KeyAddr
+#include "kaleidoscope/KeyEvent.h"                 // for KeyEvent
+#include "kaleidoscope/Runtime.h"                  // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"            // for cRGB, Device, Base...
+#include "kaleidoscope/event_handler_result.h"     // for EventHandlerResult
+#include "kaleidoscope/key_defs.h"                 // for Key, IS_INTERNAL
+#include "kaleidoscope/plugin.h"                   // for Plugin
+#include "kaleidoscope/plugin/LEDMode.h"           // for LEDMode
+#include "kaleidoscope/plugin/LEDModeInterface.h"  // for LEDModeInterface
 
 constexpr uint8_t LED_TOGGLE = 0b00000001;  // Synthetic, internal
 
@@ -27,8 +36,6 @@ constexpr Key Key_LEDToggle = Key(2, KEY_FLAGS | SYNTHETIC | IS_INTERNAL | LED_T
 
 namespace kaleidoscope {
 namespace plugin {
-
-class LEDMode;
 
 class LEDControl : public kaleidoscope::Plugin {
  public:

--- a/src/kaleidoscope/plugin/LEDControl/LED-Off.cpp
+++ b/src/kaleidoscope/plugin/LEDControl/LED-Off.cpp
@@ -16,6 +16,8 @@
 
 #include "kaleidoscope/plugin/LEDControl/LED-Off.h"
 
+#include "kaleidoscope/plugin/LEDControl.h"  // for LEDControl
+
 namespace kaleidoscope {
 namespace plugin {
 void LEDOff::onActivate(void) {

--- a/src/kaleidoscope/plugin/LEDControl/LED-Off.h
+++ b/src/kaleidoscope/plugin/LEDControl/LED-Off.h
@@ -16,7 +16,8 @@
 
 #pragma once
 
-#include "Kaleidoscope-LEDControl.h"
+#include "kaleidoscope/KeyAddr.h"         // for KeyAddr
+#include "kaleidoscope/plugin/LEDMode.h"  // for LEDMode
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/plugin/LEDControl/LEDUtils.cpp
+++ b/src/kaleidoscope/plugin/LEDControl/LEDUtils.cpp
@@ -16,6 +16,8 @@
 
 #include "kaleidoscope/plugin/LEDControl/LEDUtils.h"
 
+#include "kaleidoscope/Runtime.h"  // for Runtime, Runtime_
+
 cRGB
 breath_compute(uint8_t hue, uint8_t saturation, uint8_t phase_offset) {
 

--- a/src/kaleidoscope/plugin/LEDControl/LEDUtils.h
+++ b/src/kaleidoscope/plugin/LEDControl/LEDUtils.h
@@ -16,7 +16,9 @@
 
 #pragma once
 
-#include "kaleidoscope/Runtime.h"
+#include <stdint.h>                      // for uint16_t, uint8_t
+
+#include "kaleidoscope/device/device.h"  // for cRGB
 
 cRGB breath_compute(uint8_t hue = 170, uint8_t saturation = 255, uint8_t phase_offset = 0);
 cRGB hsvToRgb(uint16_t h, uint16_t s, uint16_t v);

--- a/src/kaleidoscope/plugin/LEDMode.h
+++ b/src/kaleidoscope/plugin/LEDMode.h
@@ -16,9 +16,11 @@
 
 #pragma once
 
-#include "kaleidoscope/plugin.h"
-#include "kaleidoscope/plugin/AccessTransientLEDMode.h"
-#include "kaleidoscope/plugin/LEDModeInterface.h"
+#include "kaleidoscope/KeyAddr.h"                  // for KeyAddr
+#include "kaleidoscope/event_handler_result.h"     // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                   // for Plugin
+#include "kaleidoscope/plugin/AccessTransientLEDMode.h"  // IWYU pragma: keep
+#include "kaleidoscope/plugin/LEDModeInterface.h"  // for LEDModeInterface
 
 namespace kaleidoscope {
 

--- a/src/kaleidoscope/plugin/LEDModeInterface.cpp
+++ b/src/kaleidoscope/plugin/LEDModeInterface.cpp
@@ -15,8 +15,8 @@
  */
 
 
-#include <kaleidoscope/plugin/LEDModeInterface.h>
-#include <kaleidoscope/plugin/LEDControl.h>
+#include <kaleidoscope/plugin/LEDControl.h>        // for LEDControl
+#include <kaleidoscope/plugin/LEDModeInterface.h>  // for LEDModeInterface
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/progmem_helpers.h
+++ b/src/kaleidoscope/progmem_helpers.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <Arduino.h>  // for memcpy_P
+
 // Load any intrinsic data type or trivial class stored in PROGMEM into an
 // object of that type in memory.
 template <typename _Type>

--- a/src/kaleidoscope/util/crc16.h
+++ b/src/kaleidoscope/util/crc16.h
@@ -33,7 +33,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <stdint.h>  // for uint16_t, uint8_t
 
 static inline uint16_t _crc16_update(uint16_t crc, uint8_t data) __attribute__((always_inline, unused));
 static inline uint16_t _crc16_update(uint16_t crc, uint8_t data) {

--- a/src/kaleidoscope/util/flasher/Base.h
+++ b/src/kaleidoscope/util/flasher/Base.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <stdint.h>  // for uint8_t
+
 namespace kaleidoscope {
 namespace util {
 namespace flasher {

--- a/src/kaleidoscope/util/flasher/KeyboardioI2CBootloader.h
+++ b/src/kaleidoscope/util/flasher/KeyboardioI2CBootloader.h
@@ -21,10 +21,11 @@
 // TODO(@algernon): We should support AVR here, too.
 #ifdef __SAMD21G18A__
 
+#include <stdint.h>
 #include <Wire.h>
 
-#include "kaleidoscope/util/flasher/Base.h"
 #include "kaleidoscope/util/crc16.h"
+#include "kaleidoscope/util/flasher/Base.h"
 
 namespace kaleidoscope {
 namespace util {

--- a/src/kaleidoscope/version.h
+++ b/src/kaleidoscope/version.h
@@ -1,4 +1,11 @@
+// -*- mode: c++ -*-
+
 #pragma once
+
+// We use `include-what-you-use`, which uses `clang` to help manage header
+// includes.  If we don't guard this file with an #ifdef, it will cause that to
+// fail on any file that includes this header.
+#ifndef __clang__
 
 #define KALEIDOSCOPE_AVR_GCC_MINIMAL_VERSION 5
 #define KALEIDOSCOPE_AVR_GCC_MINIMAL_MINOR 4
@@ -9,3 +16,5 @@
       )
 #error Kaleidoscope requires Arduino version >= 1.8.6 to build. Please upgrade.
 #endif
+
+#endif // #ifndef __clang__

--- a/src/kaleidoscope_internal/LEDModeManager.cpp
+++ b/src/kaleidoscope_internal/LEDModeManager.cpp
@@ -15,7 +15,8 @@
  */
 
 #include "kaleidoscope_internal/LEDModeManager.h"
-#include "kaleidoscope/plugin/LEDMode.h"
+
+#include "kaleidoscope/plugin/LEDMode.h"  // for LEDMode
 
 namespace kaleidoscope {
 namespace internal {

--- a/src/kaleidoscope_internal/LEDModeManager.h
+++ b/src/kaleidoscope_internal/LEDModeManager.h
@@ -16,12 +16,17 @@
 
 #pragma once
 
-#include "kaleidoscope_internal/array_like_storage.h"
-#include "kaleidoscope/plugin.h"
-#include "kaleidoscope/plugin/LEDMode.h"
-#include "kaleidoscope_internal/type_traits/has_method.h"
+#include <Arduino.h>                                       // for PROGMEM
+#include <stddef.h>                                        // for size_t
+#include <stdint.h>                                        // for uint8_t
+// IWYU pragma: no_include <new>
 
-#include <stddef.h>
+#include "kaleidoscope/macro_helpers.h"                    // for __NL__
+#include "kaleidoscope/plugin.h"                           // for Plugin
+#include "kaleidoscope/plugin/LEDMode.h"                   // for LEDMode
+#include "kaleidoscope/plugin/LEDModeInterface.h"          // for LEDModeInt...
+#include "kaleidoscope_internal/array_like_storage.h"  // IWYU pragma: keep
+#include "kaleidoscope_internal/type_traits/has_method.h"  // for DEFINE_HAS...
 
 #if defined(KALEIDOSCOPE_VIRTUAL_BUILD) || defined(ARDUINO_ARCH_STM32)
 #include <new>

--- a/src/kaleidoscope_internal/array_like_storage.h
+++ b/src/kaleidoscope_internal/array_like_storage.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <stdint.h>  // for uint8_t
 
 namespace kaleidoscope {
 namespace internal {

--- a/src/kaleidoscope_internal/event_dispatch.h
+++ b/src/kaleidoscope_internal/event_dispatch.h
@@ -33,11 +33,10 @@
 
 #pragma once
 
+#include "kaleidoscope/event_handlers.h"
 #include "kaleidoscope/macro_helpers.h"
 #include "kaleidoscope/plugin.h"
-#include "kaleidoscope/hooks.h"
 #include "kaleidoscope_internal/eventhandler_signature_check.h"
-#include "kaleidoscope/event_handlers.h"
 #include "kaleidoscope_internal/sketch_exploration/sketch_exploration.h"
 
 // Some words about the design of hook routing:

--- a/src/kaleidoscope_internal/eventhandler_signature_check.h
+++ b/src/kaleidoscope_internal/eventhandler_signature_check.h
@@ -16,10 +16,10 @@
 
 #pragma once
 
-#include "kaleidoscope/macro_helpers.h"
-#include "kaleidoscope/plugin.h"
-#include "kaleidoscope_internal/type_traits/has_member.h"
-#include "kaleidoscope_internal/type_traits/has_method.h"
+#include "kaleidoscope/event_handlers.h"                   // for _PROCESS_E...
+#include "kaleidoscope/macro_helpers.h"                    // for __NL__
+#include "kaleidoscope_internal/type_traits/has_member.h"  // for DEFINE_HAS...
+#include "kaleidoscope_internal/type_traits/has_method.h"  // for DEFINE_HAS...
 
 // *************************************************************************
 // *************************************************************************

--- a/src/kaleidoscope_internal/sketch_exploration/keymap_exploration.h
+++ b/src/kaleidoscope_internal/sketch_exploration/keymap_exploration.h
@@ -16,7 +16,10 @@
 
 #pragma once
 
-#include "kaleidoscope/key_defs.h"
+#include <stdint.h>                 // for uint8_t
+
+#include "kaleidoscope/KeyAddr.h"   // for KeyAddr
+#include "kaleidoscope/key_defs.h"  // for Key, Key_NoKey
 
 namespace kaleidoscope { // NOLINT(build/namespaces)
 namespace sketch_exploration { // NOLINT(build/namespaces)
@@ -174,11 +177,6 @@ struct HasKey {
 
   Key k_;
 };
-
-// This class is actually defined and implemented in _INIT_KEYMAP_EXPLORATION
-// which is invoked by KALEIDOSCOPE_INIT_PLUGINS
-//
-class KeymapInterface;
 
 extern void pluginsExploreSketch();
 

--- a/src/kaleidoscope_internal/sketch_exploration/plugin_exploration.h
+++ b/src/kaleidoscope_internal/sketch_exploration/plugin_exploration.h
@@ -16,7 +16,8 @@
 
 #pragma once
 
-#include "kaleidoscope_internal/type_traits/type_traits"
+#include "kaleidoscope_internal/type_traits/type_traits"  // IWYU pragma: keep
+// IWYU pragma: no_include <type_traits>
 
 namespace kaleidoscope {
 namespace sketch_exploration {

--- a/src/kaleidoscope_internal/sketch_exploration/sketch_exploration.cpp
+++ b/src/kaleidoscope_internal/sketch_exploration/sketch_exploration.cpp
@@ -15,7 +15,6 @@
  */
 
 namespace kaleidoscope {
-\
 namespace sketch_exploration {
 
 // This empty weak symbol is necessary if the KEYMAP(...) macro

--- a/src/kaleidoscope_internal/sketch_exploration/sketch_exploration.h
+++ b/src/kaleidoscope_internal/sketch_exploration/sketch_exploration.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "kaleidoscope_internal/sketch_exploration/keymap_exploration.h"
-#include "kaleidoscope_internal/sketch_exploration/plugin_exploration.h"
+#include "kaleidoscope_internal/sketch_exploration/plugin_exploration.h"  // IWYU pragma: keep
 
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // Read carefully

--- a/src/kaleidoscope_internal/type_traits/has_member.h
+++ b/src/kaleidoscope_internal/type_traits/has_member.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "kaleidoscope/macro_helpers.h"
+#include "kaleidoscope/macro_helpers.h"  // for __NL__
 
 // The following code has been stolen from
 //

--- a/src/kaleidoscope_internal/type_traits/has_method.h
+++ b/src/kaleidoscope_internal/type_traits/has_method.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "kaleidoscope/macro_helpers.h"
+#include "kaleidoscope/macro_helpers.h"  // for __NL__, UNWRAP, ADD_TEMPLATE...
 
 #define DEFINE_HAS_METHOD_TRAITS(PREFIX,                                       \
                                  TMPL_PARAM_TYPE_LIST, TMPL_PARAM_LIST,        \


### PR DESCRIPTION
This consists of a reorganization and standardization of the header includes for almost all Kaleidoscope source files.  I used [`include-what-you-use`](https://include-what-you-use.org/) via a wrapper script to do most of the work.  In some places I manually added `IWYU pragma` comments to keep headers that it would have discarded, or to mark header files as "private", with alternatives (e.g. including `KeyAddr.h` instead of `MatrixAddr.h` in most places, and including `device/device.h` instead of `Virtual.h` (the hardware header used when running iwyu).

There are some related changes bundled with the header reorg:
- I updated the code style guide with information about the header includes.
- I added the `iwyu.py` wrapper script that we can use on most source files (but unfortunately not all).
- I replaced some Arduino-specific type aliases that had been missed (`boolean` & `byte`), so that those files can include `stdint.h` instead of `Arduino.h`.
- I changed some plugin-specific `Key` constructors from preprocessor macros to `constexpr` functions or variables.
- I replaced some instances of `::Kaleidoscope` with the preferred `::kaleidoscope::Runtime`.
- I attempted to better document the `kaleidoscope/device/device.h` header file to make it clear how it is used.

Files that warrant particular attention:
- `src/kaleidoscope/device/device.h`
- `src/kaleidoscope/hooks.h`

Closes #762