### PR TITLE
FocusSerial: Implement a `device.reset` command

### DIFF
--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -90,9 +90,13 @@ bool FocusSerial::handleHelp(const char *command,
 }
 
 EventHandlerResult FocusSerial::onFocusEvent(const char *command) {
-  if (handleHelp(command, PSTR("help\nplugins")))
+  if (handleHelp(command, PSTR("help\ndevice.reset\nplugins")))
     return EventHandlerResult::OK;
 
+  if (strcmp_P(command, PSTR("device.reset")) == 0) {
+    Runtime.device().rebootBootloader();
+    return EventHandlerResult::EVENT_CONSUMED;
+  }
   if (strcmp_P(command, PSTR("plugins")) == 0) {
     kaleidoscope::Hooks::onNameQuery();
     return EventHandlerResult::EVENT_CONSUMED;


### PR DESCRIPTION
To make it easier - or in some cases, even possible - to put the keyboard into programmable mode, we need to be able to initiate a reset from the host side. For example, ynlike on AVR, where we can send a HUP to the serial port, on GD32, we need to do it a bit differently: by sending the keyboard a Focus request to reboot itself.

This implements the command itself.