### PR TITLE
Standardize namespace block closing comments

### DIFF
--- a/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/Colormap.cpp
+++ b/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/Colormap.cpp
@@ -72,7 +72,7 @@ EventHandlerResult ColormapEffect::onFocusEvent(const char *command) {
                                            map_base_, max_layers_);
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::ColormapEffect ColormapEffect;

--- a/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/Colormap.h
+++ b/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/Colormap.h
@@ -67,7 +67,8 @@ class ColormapEffect : public Plugin,
   static uint8_t max_layers_;
   static uint16_t map_base_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::ColormapEffect ColormapEffect;

--- a/plugins/Kaleidoscope-Cycle/src/kaleidoscope/plugin/Cycle.cpp
+++ b/plugins/Kaleidoscope-Cycle/src/kaleidoscope/plugin/Cycle.cpp
@@ -110,8 +110,8 @@ uint8_t Cycle::toModFlag(uint8_t keyCode) {
   }
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 __attribute__((weak))
 void cycleAction(Key previous_key, uint8_t cycle_count) {

--- a/plugins/Kaleidoscope-Cycle/src/kaleidoscope/plugin/Cycle.h
+++ b/plugins/Kaleidoscope-Cycle/src/kaleidoscope/plugin/Cycle.h
@@ -53,8 +53,9 @@ class Cycle : public kaleidoscope::Plugin {
   static uint8_t cycle_count_;
   static uint8_t current_modifier_flags_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 void cycleAction(Key previous_key, uint8_t cycle_count);
 

--- a/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.cpp
+++ b/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.cpp
@@ -58,8 +58,8 @@ EventHandlerResult CycleTimeReport::afterEachCycle() {
   return EventHandlerResult::OK;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 __attribute__((weak)) void cycleTimeReport(void) {
   Focus.send(Focus.COMMENT, F("average loop time:"), CycleTimeReport.average_loop_time,

--- a/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.h
+++ b/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.h
@@ -38,8 +38,9 @@ class CycleTimeReport : public kaleidoscope::Plugin {
   static uint16_t last_report_time_;
   static uint32_t loop_start_time_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 void cycleTimeReport(void);
 

--- a/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
+++ b/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
@@ -140,7 +140,7 @@ void DynamicTapDance::setup(uint8_t dynamic_offset, uint16_t size) {
   updateDynamicTapDanceCache();
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::DynamicTapDance DynamicTapDance;

--- a/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.h
+++ b/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.h
@@ -50,7 +50,7 @@ class DynamicTapDance: public kaleidoscope::Plugin {
   static void updateDynamicTapDanceCache();
 };
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::DynamicTapDance DynamicTapDance;

--- a/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
@@ -127,7 +127,7 @@ EventHandlerResult EEPROMKeymapProgrammer::onFocusEvent(const char *command) {
   return EventHandlerResult::EVENT_CONSUMED;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::EEPROMKeymapProgrammer EEPROMKeymapProgrammer;

--- a/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.h
+++ b/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.h
@@ -57,7 +57,8 @@ class EEPROMKeymapProgrammer : public kaleidoscope::Plugin {
   static uint16_t update_position_;  // layer, row, col
   static Key new_key_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::EEPROMKeymapProgrammer EEPROMKeymapProgrammer;

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -163,7 +163,7 @@ EventHandlerResult EEPROMKeymap::onFocusEvent(const char *command) {
   return EventHandlerResult::EVENT_CONSUMED;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::EEPROMKeymap EEPROMKeymap;

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.h
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.h
@@ -59,7 +59,8 @@ class EEPROMKeymap : public kaleidoscope::Plugin {
   static void printKey(Key key);
   static void dumpKeymap(uint8_t layers, Key(*getkey)(uint8_t, KeyAddr));
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::EEPROMKeymap EEPROMKeymap;

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -263,8 +263,8 @@ EventHandlerResult FocusEEPROMCommand::onFocusEvent(const char *command) {
   return EventHandlerResult::EVENT_CONSUMED;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::EEPROMSettings EEPROMSettings;
 kaleidoscope::plugin::FocusSettingsCommand FocusSettingsCommand;

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.h
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.h
@@ -94,8 +94,9 @@ class FocusEEPROMCommand : public kaleidoscope::Plugin {
 
   EventHandlerResult onFocusEvent(const char *command);
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::EEPROMSettings EEPROMSettings;
 extern kaleidoscope::plugin::FocusSettingsCommand FocusSettingsCommand;

--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.cpp
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.cpp
@@ -56,7 +56,7 @@ EventHandlerResult EscapeOneShot::onKeyEvent(KeyEvent &event) {
   return EventHandlerResult::OK;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::EscapeOneShot EscapeOneShot;

--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.h
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot.h
@@ -65,8 +65,8 @@ class EscapeOneShotConfig : public Plugin {
   static uint16_t settings_base_;
 };
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::EscapeOneShot EscapeOneShot;
 extern kaleidoscope::plugin::EscapeOneShotConfig EscapeOneShotConfig;

--- a/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
+++ b/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
@@ -129,7 +129,7 @@ EventHandlerResult FingerPainter::onFocusEvent(const char *command) {
   return EventHandlerResult::OK;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::FingerPainter FingerPainter;

--- a/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.h
+++ b/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.h
@@ -50,7 +50,8 @@ class FingerPainter : public LEDMode {
   static uint16_t color_base_;
   static bool edit_mode_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::FingerPainter FingerPainter;

--- a/plugins/Kaleidoscope-FirmwareDump/src/kaleidoscope/plugin/FirmwareDump.cpp
+++ b/plugins/Kaleidoscope-FirmwareDump/src/kaleidoscope/plugin/FirmwareDump.cpp
@@ -69,8 +69,8 @@ EventHandlerResult FirmwareDump::onFocusEvent(const char *command) {
   return EventHandlerResult::EVENT_CONSUMED;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::FirmwareDump FirmwareDump;
 

--- a/plugins/Kaleidoscope-FirmwareDump/src/kaleidoscope/plugin/FirmwareDump.h
+++ b/plugins/Kaleidoscope-FirmwareDump/src/kaleidoscope/plugin/FirmwareDump.h
@@ -41,8 +41,8 @@ class FirmwareDump : public kaleidoscope::Plugin {
   uint16_t bootloader_size_;
 };
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::FirmwareDump FirmwareDump;
 

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -118,7 +118,7 @@ void FocusSerial::printBool(bool b) {
   Runtime.serialPort().print((b) ? F("true") : F("false"));
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::FocusSerial Focus;

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -108,7 +108,8 @@ class FocusSerial : public kaleidoscope::Plugin {
   static uint8_t buf_cursor_;
   static void printBool(bool b);
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::FocusSerial Focus;

--- a/plugins/Kaleidoscope-GhostInTheFirmware/src/kaleidoscope/plugin/GhostInTheFirmware.cpp
+++ b/plugins/Kaleidoscope-GhostInTheFirmware/src/kaleidoscope/plugin/GhostInTheFirmware.cpp
@@ -86,7 +86,7 @@ EventHandlerResult GhostInTheFirmware::afterEachCycle() {
   return EventHandlerResult::OK;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::GhostInTheFirmware GhostInTheFirmware;

--- a/plugins/Kaleidoscope-GhostInTheFirmware/src/kaleidoscope/plugin/GhostInTheFirmware.h
+++ b/plugins/Kaleidoscope-GhostInTheFirmware/src/kaleidoscope/plugin/GhostInTheFirmware.h
@@ -45,7 +45,8 @@ class GhostInTheFirmware : public kaleidoscope::Plugin {
   static uint16_t current_pos_;
   static uint16_t start_time_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::GhostInTheFirmware GhostInTheFirmware;

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/Raise.cpp
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/Raise.cpp
@@ -475,8 +475,8 @@ void Raise::settings::keyscanInterval(uint16_t interval) {
   RaiseHands::keyscanInterval(interval);
 }
 
-}
-}
-}
+}  // namespace dygma
+}  // namespace device
+}  // namespace kaleidoscope
 
 #endif

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/Raise.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/Raise.h
@@ -223,13 +223,12 @@ class Raise: public kaleidoscope::device::Base<RaiseProps> {
   } settings;
 };
 
-
-}
-}
+}  // namespace dygma
+}  // namespace device
 
 typedef kaleidoscope::device::dygma::Raise Device;
 
-}
+}  // namespace kaleidoscope
 
 #define PER_KEY_DATA(dflt,                                                                                  \
   r0c0, r0c1, r0c2, r0c3, r0c4, r0c5, r0c6,                r0c9,  r0c10, r0c11, r0c12, r0c13, r0c14, r0c15, \

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
@@ -127,10 +127,10 @@ EventHandlerResult Focus::onFocusEvent(const char *command) {
   return EventHandlerResult::OK;
 }
 
-}
-}
-}
-}
+}  // namespace raise
+}  // namespace dygma
+}  // namespace device
+}  // namespace kaleidoscope
 
 kaleidoscope::device::dygma::raise::Focus RaiseFocus;
 

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.h
@@ -32,10 +32,10 @@ class Focus : public kaleidoscope::Plugin {
   EventHandlerResult onFocusEvent(const char *command);
 };
 
-}
-}
-}
-}
+}  // namespace raise
+}  // namespace dygma
+}  // namespace device
+}  // namespace kaleidoscope
 
 extern kaleidoscope::device::dygma::raise::Focus RaiseFocus;
 

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/RaiseSide.cpp
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/RaiseSide.cpp
@@ -244,8 +244,8 @@ void RaiseSide::sendLEDBank(uint8_t bank) {
   uint8_t result = twi_.writeTo(data, ELEMENTS(data));
 }
 
-}
-}
-}
-}
+}  // namespace raise
+}  // namespace dygma
+}  // namespace device
+}  // namespace kaleidoscope
 #endif

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/RaiseSide.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/RaiseSide.h
@@ -104,9 +104,9 @@ class RaiseSide {
   int readRegister(uint8_t cmd);
 };
 
-}
-}
-}
-}
+}  // namespace raise
+}  // namespace dygma
+}  // namespace device
+}  // namespace kaleidoscope
 
 #endif

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/SideFlash.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/SideFlash.h
@@ -77,9 +77,9 @@ class SideFlash : public kaleidoscope::Plugin {
   }
 };
 
-}
-}
-}
-}
+}  // namespace raise
+}  // namespace dygma
+}  // namespace device
+}  // namespace kaleidoscope
 
 #endif

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/TWI.cpp
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/TWI.cpp
@@ -90,10 +90,9 @@ void TWI::init(uint16_t clock_khz) {
   Wire.setClock(clock_khz * 1000);
 }
 
-
-}
-}
-}
-}
+}  // namespace raise
+}  // namespace dygma
+}  // namespace device
+}  // namespace kaleidoscope
 
 #endif

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/TWI.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/TWI.h
@@ -44,8 +44,9 @@ class TWI {
   uint8_t crc_errors_;
 };
 
-}
-}
-}
-}
+}  // namespace raise
+}  // namespace dygma
+}  // namespace device
+}  // namespace kaleidoscope
+
 #endif

--- a/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox.cpp
+++ b/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox.cpp
@@ -210,9 +210,9 @@ uint8_t ErgoDox::pressedKeyswitchCount() {
   return count;
 }
 
-}
-}
-}
+}  // namespace ez
+}  // namespace device
+}  // namespace kaleidoscope
 
 #endif
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox.h
+++ b/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox.h
@@ -134,11 +134,12 @@ class ErgoDox;
     r0c11, r1c11, r2c11, r3c11, r4c11, r5c11,                           \
     r0c12, r1c12, r2c12, r3c12, r4c12, r5c12,                           \
     r0c13, r1c13, r2c13, r3c13, r4c13, dflt
-}
-}
+
+}  // namespace ez
+}  // namespace device
 
 EXPORT_DEVICE(kaleidoscope::device::ez::ErgoDox)
 
-}
+}  // namespace kaleidoscope
 
 #endif

--- a/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.cpp
+++ b/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.cpp
@@ -170,9 +170,9 @@ ErgoDoxScanner::reattachExpanderOnError() {
   start_time = millis();
 }
 
-}
-}
-}
+}  // namespace ez
+}  // namespace device
+}  // namespace kaleidoscope
 
 #endif
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.h
+++ b/plugins/Kaleidoscope-Hardware-EZ-ErgoDox/src/kaleidoscope/device/ez/ErgoDox/ErgoDoxScanner.h
@@ -50,8 +50,8 @@ class ErgoDoxScanner {
   uint8_t initExpander();
 };
 
-}
-}
-}
+}  // namespace ez
+}  // namespace device
+}  // namespace kaleidoscope
 
 #endif

--- a/plugins/Kaleidoscope-Hardware-KBDFans-KBD4x/src/kaleidoscope/device/kbdfans/KBD4x.h
+++ b/plugins/Kaleidoscope-Hardware-KBDFans-KBD4x/src/kaleidoscope/device/kbdfans/KBD4x.h
@@ -73,11 +73,12 @@ class KBD4x;
          R1C0, R1C1, R1C2, R1C3, R1C4, R1C5, R1C6, R1C7, R1C8, R1C9, R1C10, R1C11, \
          R2C0, R2C1, R2C2, R2C3, R2C4, R2C5, R2C6, R2C7, R2C8, R2C9, R2C10, R2C11, \
          R3C0, R3C1, R3C2, R3C3, R3C4, R3C5, R3C5, R3C7, R3C8, R3C9, R3C10, R3C11
-}
-}
+
+}  // namespace kbdfans
+}  // namespace device
 
 EXPORT_DEVICE(kaleidoscope::device::kbdfans::KBD4x)
 
-}
+}  // namespace kaleidoscope
 
 #endif

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Atreus/src/kaleidoscope/device/keyboardio/Atreus2.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Atreus/src/kaleidoscope/device/keyboardio/Atreus2.cpp
@@ -59,9 +59,9 @@ ISR(TIMER1_OVF_vect) {
   Runtime.device().keyScanner().do_scan_ = true;
 }
 
-}
-}
-}
+}  // namespace keyboardio
+}  // namespace device
+}  // namespace kaleidoscope
 
 #endif
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Atreus/src/kaleidoscope/device/keyboardio/Atreus2.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Atreus/src/kaleidoscope/device/keyboardio/Atreus2.h
@@ -88,11 +88,12 @@ class Atreus;
   R1C0, R1C1, R1C2, R1C3, R1C4, XXX,  XXX,  R1C7, R1C8, R1C9, R1C10, R1C11, \
   R2C0, R2C1, R2C2, R2C3, R2C4, R2C5, R2C6, R2C7, R2C8, R2C9, R2C10, R2C11, \
   R3C0, R3C1, R3C2, R3C3, R3C4, R3C5, R3C6, R3C7, R3C8, R3C9, R3C10, R3C11
-}
-}
+
+}  // namespace keyboardio
+}  // namespace device
 
 EXPORT_DEVICE(kaleidoscope::device::keyboardio::Atreus)
 
-}
+}  // namespace kaleidoscope
 
 #endif

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Imago/src/kaleidoscope/device/keyboardio/Imago.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Imago/src/kaleidoscope/device/keyboardio/Imago.cpp
@@ -217,8 +217,8 @@ void Imago::setup() {
 
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
-}
-}
-}
+}  // namespace keyboardio
+}  // namespace device
+}  // namespace kaleidoscope
 
 #endif

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Imago/src/kaleidoscope/device/keyboardio/Imago.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Imago/src/kaleidoscope/device/keyboardio/Imago.h
@@ -120,11 +120,11 @@ class Imago: public kaleidoscope::device::ATmega32U4Keyboard<ImagoProps> {
          R3C0, R3C1, R3C2, R3C3, R3C4, R3C5, R3C6, R3C7, R3C8, R3C9, R3C10, R3C11, R3C12, R3C13, XXX,   R3C15, \
          R4C0, R4C1, R4C2, R4C3, XXX,  R4C5, R4C6, R4C7, R4C8, XXX,  R4C10, R4C11, R4C12, R4C13, XXX,   R4C15
 
-}
-}
+}  // namespace keyboardio
+}  // namespace device
 
 EXPORT_DEVICE(kaleidoscope::device::keyboardio::Imago)
 
-}
+}  // namespace kaleidoscope
 
 #endif

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/kaleidoscope/device/keyboardio/Model01.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/kaleidoscope/device/keyboardio/Model01.cpp
@@ -257,7 +257,8 @@ void Model01::enableHardwareTestMode() {
 
 #endif
 
-}
-}
-}
+}  // namespace keyboardio
+}  // namespace device
+}  // namespace kaleidoscope
+
 #endif

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/kaleidoscope/device/keyboardio/Model01.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/kaleidoscope/device/keyboardio/Model01.h
@@ -141,7 +141,7 @@ class Model01 : public kaleidoscope::device::ATmega32U4Keyboard<Model01Props> {
 
 EXPORT_DEVICE(kaleidoscope::device::keyboardio::Model01)
 
-}
+}  // namespace kaleidoscope
 
 #define PER_KEY_DATA_STACKED(dflt,                                    \
                r0c0, r0c1, r0c2, r0c3, r0c4, r0c5, r0c6,                \

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.cpp
@@ -242,7 +242,8 @@ void Model100::enableHardwareTestMode() {
 
 #endif
 
-}
-}
-}
+}  // namespace keyboardio
+}  // namespace device
+}  // namespace kaleidoscope
+
 #endif

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.h
@@ -163,7 +163,7 @@ class Model100 : public kaleidoscope::device::Base<Model100Props> {
 
 EXPORT_DEVICE(kaleidoscope::device::keyboardio::Model100)
 
-}
+}  // namespace kaleidoscope
 
 #define PER_KEY_DATA_STACKED(dflt,                                    \
                r0c0, r0c1, r0c2, r0c3, r0c4, r0c5, r0c6,                \

--- a/plugins/Kaleidoscope-Hardware-OLKB-Planck/src/kaleidoscope/device/olkb/Planck.h
+++ b/plugins/Kaleidoscope-Hardware-OLKB-Planck/src/kaleidoscope/device/olkb/Planck.h
@@ -67,11 +67,11 @@ class Planck;
          R2C0, R2C1, R2C2, R2C3, R2C4, R2C5, R2C6, R2C7, R2C8, R2C9, R2C10, R2C11, \
          R3C0, R3C1, R3C2, R3C3, R3C4, R3C5, R3C6, R3C7, R3C8, R3C9, R3C10, R3C11
 
-}
-}
+}  // namespace olkb
+}  // namespace device
 
 EXPORT_DEVICE(kaleidoscope::device::olkb::Planck)
 
-}
+}  // namespace kaleidoscope
 
 #endif

--- a/plugins/Kaleidoscope-Hardware-SOFTHRUF-Splitography/src/kaleidoscope/device/softhruf/Splitography.h
+++ b/plugins/Kaleidoscope-Hardware-SOFTHRUF-Splitography/src/kaleidoscope/device/softhruf/Splitography.h
@@ -96,11 +96,11 @@ class Splitography;
     r2c0 ,r2c1 ,r2c2 ,r2c3 ,r2c4 ,r2c5 ,r2c6 ,r2c7 ,r2c8 ,r2c9 ,r2c10 ,r2c11,  \
     dflt ,dflt ,dflt ,dflt ,r3c4 ,r3c5 ,r3c6 ,r3c7 ,dflt ,dflt ,dflt  ,dflt
 
-}
-}
+}  // namespace softhruf
+}  // namespace device
 
 EXPORT_DEVICE(kaleidoscope::device::softhruf::Splitography)
 
-}
+}  // namespace kaleidoscope
 
 #endif

--- a/plugins/Kaleidoscope-Hardware-Technomancy-Atreus/src/kaleidoscope/device/technomancy/Atreus.h
+++ b/plugins/Kaleidoscope-Hardware-Technomancy-Atreus/src/kaleidoscope/device/technomancy/Atreus.h
@@ -112,11 +112,12 @@ class Atreus;
     R1C0, R1C1, R1C2, R1C3, R1C4, dflt,   R1C7, R1C8, R1C9, R1C10, R1C11,     \
     R2C0, R2C1, R2C2, R2C3, R2C4, R3C5,   R2C7, R2C8, R2C9, R2C10, R2C11,     \
     R3C0, R3C1, R3C2, R3C3, R3C4, R3C6,   R3C7, R3C8, R3C9, R3C10, R3C11
-}
-}
+
+}  // namespace technomancy
+}  // namespace device
 
 EXPORT_DEVICE(kaleidoscope::device::technomancy::Atreus)
 
-}
+}  // namespace kaleidoscope
 
 #endif

--- a/plugins/Kaleidoscope-HardwareTestMode/src/kaleidoscope/plugin/HardwareTestMode.cpp
+++ b/plugins/Kaleidoscope-HardwareTestMode/src/kaleidoscope/plugin/HardwareTestMode.cpp
@@ -132,7 +132,7 @@ void HardwareTestMode::runTests() {
   testMatrix();
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::HardwareTestMode HardwareTestMode;

--- a/plugins/Kaleidoscope-HardwareTestMode/src/kaleidoscope/plugin/HardwareTestMode.h
+++ b/plugins/Kaleidoscope-HardwareTestMode/src/kaleidoscope/plugin/HardwareTestMode.h
@@ -45,7 +45,8 @@ class HardwareTestMode : public kaleidoscope::Plugin {
   static void waitForKeypress();
   static void setLeds(cRGB color);
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::HardwareTestMode HardwareTestMode;

--- a/plugins/Kaleidoscope-Heatmap/src/kaleidoscope/plugin/Heatmap.cpp
+++ b/plugins/Kaleidoscope-Heatmap/src/kaleidoscope/plugin/Heatmap.cpp
@@ -241,7 +241,7 @@ void Heatmap::TransientLEDMode::update(void) {
   }
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::Heatmap HeatmapEffect;

--- a/plugins/Kaleidoscope-Heatmap/src/kaleidoscope/plugin/Heatmap.h
+++ b/plugins/Kaleidoscope-Heatmap/src/kaleidoscope/plugin/Heatmap.h
@@ -75,7 +75,8 @@ class Heatmap : public Plugin,
     friend class Heatmap;
   };
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::Heatmap HeatmapEffect;

--- a/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.cpp
+++ b/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.cpp
@@ -46,7 +46,7 @@ EventHandlerResult FocusHostOSCommand::onFocusEvent(const char *command) {
   return EventHandlerResult::EVENT_CONSUMED;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::FocusHostOSCommand FocusHostOSCommand;

--- a/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.h
+++ b/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.h
@@ -28,7 +28,8 @@ class FocusHostOSCommand : public kaleidoscope::Plugin {
   FocusHostOSCommand() {}
   EventHandlerResult onFocusEvent(const char *command);
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::FocusHostOSCommand FocusHostOSCommand;

--- a/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS.cpp
+++ b/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS.cpp
@@ -49,7 +49,7 @@ void HostOS::os(hostos::Type new_os) {
   Runtime.storage().commit();
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::HostOS HostOS;

--- a/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS.h
+++ b/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS.h
@@ -54,9 +54,11 @@ class HostOS : public kaleidoscope::Plugin {
   uint16_t eeprom_slice_;
   bool is_configured_ = false;
 };
-}
+
+}  // namespace plugin
 
 namespace hostos = plugin::hostos;
-}
+
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::HostOS HostOS;

--- a/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.cpp
+++ b/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.cpp
@@ -57,8 +57,8 @@ EventHandlerResult HostPowerManagement::beforeEachCycle() {
   return EventHandlerResult::OK;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 __attribute__((weak)) void hostPowerManagementEventHandler(kaleidoscope::plugin::HostPowerManagement::Event event) {
 }

--- a/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.h
+++ b/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.h
@@ -38,12 +38,13 @@ class HostPowerManagement : public kaleidoscope::Plugin {
   static bool was_suspended_;
   static bool initial_suspend_;
 };
-}
+
+}  // namespace plugin
 
 // Backwards compatibility
 typedef plugin::HostPowerManagement HostPowerManagement;
 
-}
+}  // namespace kaleidoscope
 
 void hostPowerManagementEventHandler(kaleidoscope::plugin::HostPowerManagement::Event event);
 

--- a/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -116,8 +116,8 @@ EventHandlerResult PersistentIdleLEDs::onFocusEvent(const char *command) {
   return EventHandlerResult::EVENT_CONSUMED;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::IdleLEDs IdleLEDs;
 kaleidoscope::plugin::PersistentIdleLEDs PersistentIdleLEDs;

--- a/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.h
+++ b/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.h
@@ -55,8 +55,8 @@ class PersistentIdleLEDs : public IdleLEDs {
   static uint16_t settings_base_;
 };
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::IdleLEDs IdleLEDs;
 extern kaleidoscope::plugin::PersistentIdleLEDs PersistentIdleLEDs;

--- a/plugins/Kaleidoscope-LED-ActiveLayerColor/src/kaleidoscope/plugin/LED-ActiveLayerColor.cpp
+++ b/plugins/Kaleidoscope-LED-ActiveLayerColor/src/kaleidoscope/plugin/LED-ActiveLayerColor.cpp
@@ -72,7 +72,7 @@ EventHandlerResult LEDActiveLayerColorEffect::onLayerChange() {
   return EventHandlerResult::OK;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::LEDActiveLayerColorEffect LEDActiveLayerColorEffect;

--- a/plugins/Kaleidoscope-LED-ActiveLayerColor/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
+++ b/plugins/Kaleidoscope-LED-ActiveLayerColor/src/kaleidoscope/plugin/LED-ActiveLayerColor.h
@@ -67,7 +67,8 @@ class LEDActiveLayerColorEffect : public Plugin,
 
   static const cRGB *colormap_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::LEDActiveLayerColorEffect LEDActiveLayerColorEffect;

--- a/plugins/Kaleidoscope-LED-ActiveModColor/src/kaleidoscope/plugin/LED-ActiveModColor.h
+++ b/plugins/Kaleidoscope-LED-ActiveModColor/src/kaleidoscope/plugin/LED-ActiveModColor.h
@@ -56,7 +56,8 @@ class ActiveModColorEffect : public kaleidoscope::Plugin {
   static cRGB oneshot_color_;
   static cRGB sticky_color_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::ActiveModColorEffect ActiveModColorEffect;

--- a/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
+++ b/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare.cpp
@@ -147,7 +147,7 @@ bool AlphaSquare::isSymbolPart(uint16_t symbol,
   return false;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::AlphaSquare AlphaSquare;

--- a/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare.h
+++ b/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare.h
@@ -91,7 +91,7 @@ class AlphaSquare : public kaleidoscope::Plugin {
   static cRGB color;
 };
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::AlphaSquare AlphaSquare;

--- a/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
+++ b/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.cpp
@@ -111,7 +111,7 @@ EventHandlerResult AlphaSquareEffect::onKeyEvent(KeyEvent &event) {
   return EventHandlerResult::OK;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::AlphaSquareEffect AlphaSquareEffect;

--- a/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
+++ b/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare/Effect.h
@@ -57,7 +57,8 @@ class AlphaSquareEffect : public Plugin,
     friend class AlphaSquareEffect;
   };
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::AlphaSquareEffect AlphaSquareEffect;

--- a/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare/Symbols.h
+++ b/plugins/Kaleidoscope-LED-AlphaSquare/src/kaleidoscope/plugin/LED-AlphaSquare/Symbols.h
@@ -31,8 +31,8 @@ static constexpr uint16_t Lambda = SYM4x4(1, 0, 0, 0,
                                           0, 1, 0, 0,
                                           0, 1, 1, 0,
                                           1, 0, 0, 1);
-}
-}
-}
 
-}
+}  // namespace symbols
+}  // namespace alpha_square
+}  // namespace plugin
+}  // namespace kaleidoscope

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -193,7 +193,7 @@ EventHandlerResult LEDPaletteTheme::themeFocusEvent(const char *command,
   return EventHandlerResult::EVENT_CONSUMED;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::LEDPaletteTheme LEDPaletteTheme;

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.h
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.h
@@ -50,7 +50,7 @@ class LEDPaletteTheme : public kaleidoscope::Plugin {
   static uint16_t palette_base_;
 };
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::LEDPaletteTheme LEDPaletteTheme;

--- a/plugins/Kaleidoscope-LED-Stalker/src/kaleidoscope/plugin/LED-Stalker.cpp
+++ b/plugins/Kaleidoscope-LED-Stalker/src/kaleidoscope/plugin/LED-Stalker.cpp
@@ -158,9 +158,8 @@ cRGB Rainbow::compute(uint8_t *step) {
   return hsvToRgb(255 - *step, 255, *step);
 }
 
-}
-}
-
-}
+}  // namespace stalker
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::StalkerEffect StalkerEffect;

--- a/plugins/Kaleidoscope-LED-Stalker/src/kaleidoscope/plugin/LED-Stalker.h
+++ b/plugins/Kaleidoscope-LED-Stalker/src/kaleidoscope/plugin/LED-Stalker.h
@@ -101,8 +101,8 @@ class Rainbow : public StalkerEffect::ColorComputer {
   cRGB compute(uint8_t *step) final;
 };
 
-}
-}
-}
+}  // namespace stalker
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::StalkerEffect StalkerEffect;

--- a/plugins/Kaleidoscope-LED-Wavepool/src/kaleidoscope/plugin/LED-Wavepool.cpp
+++ b/plugins/Kaleidoscope-LED-Wavepool/src/kaleidoscope/plugin/LED-Wavepool.cpp
@@ -237,8 +237,8 @@ void WavepoolEffect::TransientLEDMode::update(void) {
 
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::WavepoolEffect WavepoolEffect;
 

--- a/plugins/Kaleidoscope-LED-Wavepool/src/kaleidoscope/plugin/LED-Wavepool.h
+++ b/plugins/Kaleidoscope-LED-Wavepool/src/kaleidoscope/plugin/LED-Wavepool.h
@@ -82,8 +82,8 @@ class WavepoolEffect : public Plugin,
   };
 };
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::WavepoolEffect WavepoolEffect;
 

--- a/plugins/Kaleidoscope-LEDEffect-BootAnimation/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
+++ b/plugins/Kaleidoscope-LEDEffect-BootAnimation/src/kaleidoscope/plugin/LEDEffect-BootAnimation.cpp
@@ -94,7 +94,7 @@ EventHandlerResult BootAnimationEffect::afterEachCycle() {
   return EventHandlerResult::OK;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::BootAnimationEffect BootAnimationEffect;

--- a/plugins/Kaleidoscope-LEDEffect-BootAnimation/src/kaleidoscope/plugin/LEDEffect-BootAnimation.h
+++ b/plugins/Kaleidoscope-LEDEffect-BootAnimation/src/kaleidoscope/plugin/LEDEffect-BootAnimation.h
@@ -43,7 +43,8 @@ class BootAnimationEffect : public kaleidoscope::Plugin {
   static uint16_t start_time_;
   static uint8_t current_index_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::BootAnimationEffect BootAnimationEffect;

--- a/plugins/Kaleidoscope-LEDEffect-BootGreeting/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
+++ b/plugins/Kaleidoscope-LEDEffect-BootGreeting/src/kaleidoscope/plugin/LEDEffect-BootGreeting.cpp
@@ -91,7 +91,7 @@ EventHandlerResult BootGreetingEffect::afterEachCycle() {
   return EventHandlerResult::OK;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::BootGreetingEffect BootGreetingEffect;

--- a/plugins/Kaleidoscope-LEDEffect-BootGreeting/src/kaleidoscope/plugin/LEDEffect-BootGreeting.h
+++ b/plugins/Kaleidoscope-LEDEffect-BootGreeting/src/kaleidoscope/plugin/LEDEffect-BootGreeting.h
@@ -45,7 +45,8 @@ class BootGreetingEffect : public kaleidoscope::Plugin {
   static KeyAddr key_addr_;
   static uint16_t start_time;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::BootGreetingEffect BootGreetingEffect;

--- a/plugins/Kaleidoscope-LEDEffect-Breathe/src/kaleidoscope/plugin/LEDEffect-Breathe.cpp
+++ b/plugins/Kaleidoscope-LEDEffect-Breathe/src/kaleidoscope/plugin/LEDEffect-Breathe.cpp
@@ -36,7 +36,8 @@ void LEDBreatheEffect::TransientLEDMode::update(void) {
   cRGB color = breath_compute(parent_->hue, parent_->saturation);
   ::LEDControl.set_all_leds_to(color);
 }
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::LEDBreatheEffect LEDBreatheEffect;

--- a/plugins/Kaleidoscope-LEDEffect-Breathe/src/kaleidoscope/plugin/LEDEffect-Breathe.h
+++ b/plugins/Kaleidoscope-LEDEffect-Breathe/src/kaleidoscope/plugin/LEDEffect-Breathe.h
@@ -55,7 +55,8 @@ class LEDBreatheEffect : public Plugin,
     uint8_t last_update_ = 0;
   };
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::LEDBreatheEffect LEDBreatheEffect;

--- a/plugins/Kaleidoscope-LEDEffect-Chase/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
+++ b/plugins/Kaleidoscope-LEDEffect-Chase/src/kaleidoscope/plugin/LEDEffect-Chase.cpp
@@ -69,7 +69,7 @@ void LEDChaseEffect::TransientLEDMode::update(void) {
     ::LEDControl.setCrgbAt(pos2, CRGB(0, 0, 255));
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::LEDChaseEffect LEDChaseEffect;

--- a/plugins/Kaleidoscope-LEDEffect-Chase/src/kaleidoscope/plugin/LEDEffect-Chase.h
+++ b/plugins/Kaleidoscope-LEDEffect-Chase/src/kaleidoscope/plugin/LEDEffect-Chase.h
@@ -72,7 +72,8 @@ class LEDChaseEffect : public Plugin,
   uint8_t distance_ = 5;
   uint8_t update_delay_ = 150;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::LEDChaseEffect LEDChaseEffect;

--- a/plugins/Kaleidoscope-LEDEffect-Rainbow/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
+++ b/plugins/Kaleidoscope-LEDEffect-Rainbow/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
@@ -96,8 +96,8 @@ void LEDRainbowWaveEffect::update_delay(byte delay) {
   rainbow_update_delay = delay;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::LEDRainbowEffect LEDRainbowEffect;
 kaleidoscope::plugin::LEDRainbowWaveEffect LEDRainbowWaveEffect;

--- a/plugins/Kaleidoscope-LEDEffect-Rainbow/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
+++ b/plugins/Kaleidoscope-LEDEffect-Rainbow/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
@@ -112,8 +112,9 @@ class LEDRainbowWaveEffect : public Plugin, public LEDModeInterface {
   uint8_t rainbow_update_delay = 40; // delay between updates (ms)
   uint8_t rainbow_value = 50;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::LEDRainbowEffect LEDRainbowEffect;
 extern kaleidoscope::plugin::LEDRainbowWaveEffect LEDRainbowWaveEffect;

--- a/plugins/Kaleidoscope-LEDEffect-SolidColor/src/kaleidoscope/plugin/LEDEffect-SolidColor.cpp
+++ b/plugins/Kaleidoscope-LEDEffect-SolidColor/src/kaleidoscope/plugin/LEDEffect-SolidColor.cpp
@@ -36,5 +36,5 @@ void LEDSolidColor::TransientLEDMode::refreshAt(KeyAddr key_addr) {
                               parent_->b_));
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope

--- a/plugins/Kaleidoscope-LEDEffect-SolidColor/src/kaleidoscope/plugin/LEDEffect-SolidColor.h
+++ b/plugins/Kaleidoscope-LEDEffect-SolidColor/src/kaleidoscope/plugin/LEDEffect-SolidColor.h
@@ -58,5 +58,6 @@ class LEDSolidColor : public Plugin,
 
   uint8_t r_, g_, b_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope

--- a/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/TriColor.cpp
+++ b/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/TriColor.cpp
@@ -62,5 +62,5 @@ void TriColor::TransientLEDMode::update(void) {
   }
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope

--- a/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/TriColor.h
+++ b/plugins/Kaleidoscope-LEDEffects/src/kaleidoscope/plugin/TriColor.h
@@ -56,5 +56,6 @@ class TriColor : public Plugin,
   cRGB mod_color_;
   cRGB esc_color_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope

--- a/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
+++ b/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
@@ -85,7 +85,7 @@ EventHandlerResult LayerFocus::onFocusEvent(const char *command) {
   return EventHandlerResult::EVENT_CONSUMED;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::LayerFocus LayerFocus;

--- a/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.h
+++ b/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.h
@@ -32,7 +32,7 @@ class LayerFocus: public kaleidoscope::Plugin {
   EventHandlerResult onFocusEvent(const char *command);
 };
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::LayerFocus LayerFocus;

--- a/plugins/Kaleidoscope-Leader/src/kaleidoscope/plugin/Leader.cpp
+++ b/plugins/Kaleidoscope-Leader/src/kaleidoscope/plugin/Leader.cpp
@@ -168,7 +168,7 @@ EventHandlerResult Leader::afterEachCycle() {
   return EventHandlerResult::OK;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::Leader Leader;

--- a/plugins/Kaleidoscope-Leader/src/kaleidoscope/plugin/Leader.h
+++ b/plugins/Kaleidoscope-Leader/src/kaleidoscope/plugin/Leader.h
@@ -100,8 +100,8 @@ class Leader : public kaleidoscope::Plugin {
 
   static int8_t lookup(void);
 };
-}
 
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::Leader Leader;

--- a/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros.h
+++ b/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros.h
@@ -108,7 +108,7 @@ class Macros : public kaleidoscope::Plugin {
 
 };
 
-} // namespace plugin
-} // namespace kaleidosocpe
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::Macros Macros;

--- a/plugins/Kaleidoscope-MagicCombo/src/kaleidoscope/plugin/MagicCombo.cpp
+++ b/plugins/Kaleidoscope-MagicCombo/src/kaleidoscope/plugin/MagicCombo.cpp
@@ -65,7 +65,7 @@ EventHandlerResult MagicCombo::afterEachCycle() {
   return EventHandlerResult::OK;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::MagicCombo MagicCombo;

--- a/plugins/Kaleidoscope-MagicCombo/src/kaleidoscope/plugin/MagicCombo.h
+++ b/plugins/Kaleidoscope-MagicCombo/src/kaleidoscope/plugin/MagicCombo.h
@@ -62,9 +62,9 @@ class MagicCombo : public kaleidoscope::Plugin {
 namespace magiccombo {
 extern const MagicCombo::Combo combos[];
 extern const uint8_t combos_length;
-}
 
-}
-}
+}  // namespace magiccombo
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::MagicCombo MagicCombo;

--- a/plugins/Kaleidoscope-NumPad/src/kaleidoscope/plugin/NumPad.cpp
+++ b/plugins/Kaleidoscope-NumPad/src/kaleidoscope/plugin/NumPad.cpp
@@ -81,7 +81,7 @@ EventHandlerResult NumPad::afterEachCycle() {
   return EventHandlerResult::OK;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::NumPad NumPad;

--- a/plugins/Kaleidoscope-NumPad/src/kaleidoscope/plugin/NumPad.h
+++ b/plugins/Kaleidoscope-NumPad/src/kaleidoscope/plugin/NumPad.h
@@ -45,7 +45,8 @@ class NumPad : public kaleidoscope::Plugin {
   static KeyAddr numpadLayerToggleKeyAddr;
   static bool numpadActive;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::NumPad NumPad;

--- a/plugins/Kaleidoscope-PersistentLEDMode/src/kaleidoscope/plugin/PersistentLEDMode.cpp
+++ b/plugins/Kaleidoscope-PersistentLEDMode/src/kaleidoscope/plugin/PersistentLEDMode.cpp
@@ -58,7 +58,7 @@ EventHandlerResult PersistentLEDMode::onLEDModeChange() {
   return EventHandlerResult::OK;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::PersistentLEDMode PersistentLEDMode;

--- a/plugins/Kaleidoscope-PersistentLEDMode/src/kaleidoscope/plugin/PersistentLEDMode.h
+++ b/plugins/Kaleidoscope-PersistentLEDMode/src/kaleidoscope/plugin/PersistentLEDMode.h
@@ -37,7 +37,7 @@ class PersistentLEDMode: public kaleidoscope::Plugin {
   static uint8_t cached_mode_index_;
 };
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::PersistentLEDMode PersistentLEDMode;

--- a/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.cpp
+++ b/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.cpp
@@ -500,7 +500,7 @@ bool isModifierKey(Key key) {
   return (key.isKeyboardModifier() || key.isLayerShift());
 }
 
-} // namespace plugin {
-} // namespace kaleidoscope {
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::Qukeys Qukeys;

--- a/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.h
+++ b/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.h
@@ -230,8 +230,8 @@ class Qukeys : public kaleidoscope::Plugin {
 // shift keys. Used for determining if a qukey is a SpaceCadet-type key.
 bool isModifierKey(Key key);
 
-} // namespace plugin {
-} // namespace kaleidoscope {
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::Qukeys Qukeys;
 

--- a/plugins/Kaleidoscope-Ranges/src/Kaleidoscope-Ranges.h
+++ b/plugins/Kaleidoscope-Ranges/src/Kaleidoscope-Ranges.h
@@ -92,5 +92,5 @@ enum : uint16_t {
   KALEIDOSCOPE_SAFE_START = SAFE_START
 };
 
-}
-}
+}  // namespace ranges
+}  // namespace kaleidoscope

--- a/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.cpp
+++ b/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.cpp
@@ -54,7 +54,7 @@ __attribute__((weak)) bool Redial::shouldRemember(Key mapped_key) {
   return false;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::Redial Redial;

--- a/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.h
+++ b/plugins/Kaleidoscope-Redial/src/kaleidoscope/plugin/Redial.h
@@ -42,7 +42,7 @@ class Redial : public kaleidoscope::Plugin {
   static Key last_key_;
 };
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::Redial Redial;

--- a/plugins/Kaleidoscope-ShapeShifter/src/kaleidoscope/plugin/ShapeShifter.cpp
+++ b/plugins/Kaleidoscope-ShapeShifter/src/kaleidoscope/plugin/ShapeShifter.cpp
@@ -68,7 +68,7 @@ EventHandlerResult ShapeShifter::onKeyEvent(KeyEvent &event) {
   return EventHandlerResult::OK;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::ShapeShifter ShapeShifter;

--- a/plugins/Kaleidoscope-ShapeShifter/src/kaleidoscope/plugin/ShapeShifter.h
+++ b/plugins/Kaleidoscope-ShapeShifter/src/kaleidoscope/plugin/ShapeShifter.h
@@ -37,8 +37,8 @@ class ShapeShifter : public kaleidoscope::Plugin {
 
   EventHandlerResult onKeyEvent(KeyEvent &event);
 };
-}
 
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::ShapeShifter ShapeShifter;

--- a/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadet.h
+++ b/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadet.h
@@ -109,8 +109,8 @@ class SpaceCadet : public kaleidoscope::Plugin {
   void flushEvent(bool is_tap = false);
   void flushQueue();
 };
-}
 
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::SpaceCadet SpaceCadet;

--- a/plugins/Kaleidoscope-Steno/src/kaleidoscope/plugin/GeminiPR.cpp
+++ b/plugins/Kaleidoscope-Steno/src/kaleidoscope/plugin/GeminiPR.cpp
@@ -62,8 +62,8 @@ EventHandlerResult GeminiPR::onKeyEvent(KeyEvent &event) {
   return EventHandlerResult::EVENT_CONSUMED;
 }
 
-}
-}
-}
+}  // namespace steno
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::steno::GeminiPR GeminiPR;

--- a/plugins/Kaleidoscope-TopsyTurvy/src/kaleidoscope/plugin/TopsyTurvy.h
+++ b/plugins/Kaleidoscope-TopsyTurvy/src/kaleidoscope/plugin/TopsyTurvy.h
@@ -50,7 +50,7 @@ class TopsyTurvy: public kaleidoscope::Plugin {
   static KeyAddr tt_addr_;
 };
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::TopsyTurvy TopsyTurvy;

--- a/plugins/Kaleidoscope-Turbo/src/kaleidoscope/plugin/Turbo.cpp
+++ b/plugins/Kaleidoscope-Turbo/src/kaleidoscope/plugin/Turbo.cpp
@@ -160,7 +160,7 @@ EventHandlerResult Turbo::onNameQuery() {
   return ::Focus.sendName(F("Turbo"));
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::Turbo Turbo;

--- a/plugins/Kaleidoscope-Turbo/src/kaleidoscope/plugin/Turbo.h
+++ b/plugins/Kaleidoscope-Turbo/src/kaleidoscope/plugin/Turbo.h
@@ -65,7 +65,8 @@ class Turbo : public kaleidoscope::Plugin {
   static uint32_t start_time_;
   static uint32_t flash_start_time_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::Turbo Turbo;

--- a/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
+++ b/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
@@ -215,8 +215,8 @@ EventHandlerResult TypingBreaks::onFocusEvent(const char *command) {
   return EventHandlerResult::EVENT_CONSUMED;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::TypingBreaks TypingBreaks;
 

--- a/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.h
+++ b/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.h
@@ -55,8 +55,9 @@ class TypingBreaks : public kaleidoscope::Plugin {
 
   static uint16_t settings_base_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::TypingBreaks TypingBreaks;
 

--- a/plugins/Kaleidoscope-USB-Quirks/src/kaleidoscope/plugin/USB-Quirks.cpp
+++ b/plugins/Kaleidoscope-USB-Quirks/src/kaleidoscope/plugin/USB-Quirks.cpp
@@ -36,7 +36,7 @@ void USBQuirks::toggleKeyboardProtocol() {
   Runtime.attachToHost();
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::USBQuirks USBQuirks;

--- a/plugins/Kaleidoscope-USB-Quirks/src/kaleidoscope/plugin/USB-Quirks.h
+++ b/plugins/Kaleidoscope-USB-Quirks/src/kaleidoscope/plugin/USB-Quirks.h
@@ -27,7 +27,8 @@ class USBQuirks: public kaleidoscope::Plugin {
 
   void toggleKeyboardProtocol();
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::USBQuirks USBQuirks;

--- a/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.cpp
+++ b/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.cpp
@@ -142,8 +142,8 @@ void Unicode::type(uint32_t unicode) {
   end();
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 __attribute__((weak)) Key hexToKey(uint8_t hex) {
   uint8_t m;

--- a/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.h
+++ b/plugins/Kaleidoscope-Unicode/src/kaleidoscope/plugin/Unicode.h
@@ -52,8 +52,9 @@ class Unicode : public kaleidoscope::Plugin {
   static Key linux_key_;
   static uint8_t input_delay_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 Key hexToKey(uint8_t hex);
 Key hexToKeysWithNumpad(uint8_t hex);

--- a/plugins/Kaleidoscope-WinKeyToggle/src/kaleidoscope/plugin/WinKeyToggle.cpp
+++ b/plugins/Kaleidoscope-WinKeyToggle/src/kaleidoscope/plugin/WinKeyToggle.cpp
@@ -36,7 +36,8 @@ EventHandlerResult WinKeyToggle::onKeyEvent(KeyEvent &event) {
 
   return EventHandlerResult::OK;
 }
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::WinKeyToggle WinKeyToggle;

--- a/plugins/Kaleidoscope-WinKeyToggle/src/kaleidoscope/plugin/WinKeyToggle.h
+++ b/plugins/Kaleidoscope-WinKeyToggle/src/kaleidoscope/plugin/WinKeyToggle.h
@@ -34,7 +34,8 @@ class WinKeyToggle: public kaleidoscope::Plugin {
  private:
   static bool enabled_;
 };
-}
-}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::WinKeyToggle WinKeyToggle;

--- a/src/kaleidoscope/MatrixAddr.h
+++ b/src/kaleidoscope/MatrixAddr.h
@@ -263,4 +263,4 @@ bool operator<=(const MatrixAddr1__ & a1, const MatrixAddr2__ & a2) {
 
 #endif
 
-} // end namespace kaleidoscope
+} // namespace kaleidoscope

--- a/src/kaleidoscope/bitfields.cpp
+++ b/src/kaleidoscope/bitfields.cpp
@@ -49,6 +49,6 @@ bool _BaseBitfield::isBitSetPROGMEM_P(const void *bit_field, uint8_t raw_pos) {
   return the_byte & (0x1 << bit_pos);
 }
 
-} // end namespace internal
-} // end namespace bitfields
-} // end namespace kaleidoscope
+} // namespace internal
+} // namespace bitfields
+} // namespace kaleidoscope

--- a/src/kaleidoscope/device/ATmega32U4Keyboard.h
+++ b/src/kaleidoscope/device/ATmega32U4Keyboard.h
@@ -52,7 +52,7 @@ template <typename _DeviceProps>
 class ATmega32U4Keyboard;
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
-}
-}
+}  // namespace device
+}  // namespace kaleidoscope
 
 #endif

--- a/src/kaleidoscope/device/Base.h
+++ b/src/kaleidoscope/device/Base.h
@@ -426,8 +426,8 @@ class Base {
   Storage storage_;
 };
 
-}
-}
+}  // namespace device
+}  // namespace kaleidoscope
 
 // EXPORT_DEVICE exports a device type from a specific namespace to
 // the 'kaleidoscope' namespace as type 'Device'. The corresponding

--- a/src/kaleidoscope/driver/bootloader/Base.h
+++ b/src/kaleidoscope/driver/bootloader/Base.h
@@ -29,6 +29,6 @@ class Base {
   static void rebootBootloader() {}
 };
 
-}
-}
-}
+}  // namespace bootloader
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/bootloader/None.h
+++ b/src/kaleidoscope/driver/bootloader/None.h
@@ -31,6 +31,6 @@ namespace bootloader {
  */
 class None : public kaleidoscope::driver::bootloader::Base {};
 
-}
-}
-}
+}  // namespace bootloader
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/bootloader/avr/Caterina.h
+++ b/src/kaleidoscope/driver/bootloader/avr/Caterina.h
@@ -57,7 +57,7 @@ class Caterina : public kaleidoscope::driver::bootloader::Base {
 typedef bootloader::None Caterina;
 #endif // #ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
-}
-}
-}
-}
+}  // namespace avr
+}  // namespace bootloader
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/bootloader/avr/FLIP.cpp
+++ b/src/kaleidoscope/driver/bootloader/avr/FLIP.cpp
@@ -69,10 +69,10 @@ void FLIP::rebootBootloader() {
   // happens before the watchdog reboots us
 }
 
-}
-}
-}
-}
+}  // namespace avr
+}  // namespace bootloader
+}  // namespace driver
+}  // namespace kaleidoscope
 
 #endif
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD

--- a/src/kaleidoscope/driver/bootloader/avr/FLIP.h
+++ b/src/kaleidoscope/driver/bootloader/avr/FLIP.h
@@ -42,7 +42,7 @@ class FLIP : public kaleidoscope::driver::bootloader::Base {
 typedef bootloader::None FLIP;
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
-}
-}
-}
-}
+}  // namespace avr
+}  // namespace bootloader
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/bootloader/avr/HalfKay.h
+++ b/src/kaleidoscope/driver/bootloader/avr/HalfKay.h
@@ -73,7 +73,7 @@ class HalfKay : public kaleidoscope::driver::bootloader::Base {
 typedef bootloader::None HalfKay;
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
-}
-}
-}
-}
+}  // namespace avr
+}  // namespace bootloader
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/bootloader/samd/Bossac.h
+++ b/src/kaleidoscope/driver/bootloader/samd/Bossac.h
@@ -41,9 +41,9 @@ class Bossac : public kaleidoscope::driver::bootloader::Base {
   }
 };
 
-}
-}
-}
-}
+}  // namespace samd
+}  // namespace bootloader
+}  // namespace driver
+}  // namespace kaleidoscope
 
 #endif

--- a/src/kaleidoscope/driver/color/GammaCorrection.h
+++ b/src/kaleidoscope/driver/color/GammaCorrection.h
@@ -44,5 +44,5 @@ const uint8_t PROGMEM gamma_correction[] = {
 };
 
 }
-}
-}
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/hid/Base.h
+++ b/src/kaleidoscope/driver/hid/Base.h
@@ -61,6 +61,6 @@ class Base {
   }
 };
 
-}
-}
-}
+}  // namespace hid
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/hid/Keyboardio.h
+++ b/src/kaleidoscope/driver/hid/Keyboardio.h
@@ -38,6 +38,6 @@ struct KeyboardioProps: public BaseProps {
 template <typename _Props>
 class Keyboardio: public Base<_Props> {};
 
-}
-}
-}
+}  // namespace hid
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/hid/base/AbsoluteMouse.h
+++ b/src/kaleidoscope/driver/hid/base/AbsoluteMouse.h
@@ -70,7 +70,7 @@ class AbsoluteMouse {
   }
 };
 
-}
-}
-}
-}
+}  // namespace base
+}  // namespace hid
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/hid/base/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/base/Keyboard.h
@@ -333,7 +333,7 @@ class Keyboard {
 
 };
 
-}
-}
-}
-}
+}  // namespace base
+}  // namespace hid
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/hid/base/Mouse.h
+++ b/src/kaleidoscope/driver/hid/base/Mouse.h
@@ -77,7 +77,7 @@ class Mouse {
   }
 };
 
-}
-}
-}
-}
+}  // namespace base
+}  // namespace hid
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/hid/keyboardio/AbsoluteMouse.h
+++ b/src/kaleidoscope/driver/hid/keyboardio/AbsoluteMouse.h
@@ -73,7 +73,7 @@ struct AbsoluteMouseProps: public base::AbsoluteMouseProps {
 template <typename _Props>
 class AbsoluteMouse: public base::AbsoluteMouse<_Props> {};
 
-}
-}
-}
-}
+}  // namespace keyboardio
+}  // namespace hid
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/hid/keyboardio/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/keyboardio/Keyboard.h
@@ -186,7 +186,7 @@ struct KeyboardProps: public base::KeyboardProps {
 template <typename _Props>
 class Keyboard: public base::Keyboard<_Props> {};
 
-}
-}
-}
-}
+}  // namespace keyboardio
+}  // namespace hid
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/hid/keyboardio/Mouse.h
+++ b/src/kaleidoscope/driver/hid/keyboardio/Mouse.h
@@ -89,7 +89,7 @@ struct MouseProps: public base::MouseProps {
 template <typename _Props>
 class Mouse: public base::Mouse<_Props> {};
 
-}
-}
-}
-}
+}  // namespace keyboardio
+}  // namespace hid
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/keyscanner/ATmega.h
+++ b/src/kaleidoscope/driver/keyscanner/ATmega.h
@@ -237,6 +237,6 @@ template <typename _KeyScannerProps>
 class ATmega : public keyscanner::None {};
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
-}
-}
-}
+}  // namespace keyscanner
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/keyscanner/Base.h
+++ b/src/kaleidoscope/driver/keyscanner/Base.h
@@ -62,6 +62,6 @@ class Base {
 
 };
 
-}
-}
-}
+}  // namespace keyscanner
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/keyscanner/None.h
+++ b/src/kaleidoscope/driver/keyscanner/None.h
@@ -31,6 +31,6 @@ namespace keyscanner {
  */
 class None : public kaleidoscope::driver::keyscanner::Base<BaseProps> {};
 
-}
-}
-}
+}  // namespace keyscanner
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/led/Base.h
+++ b/src/kaleidoscope/driver/led/Base.h
@@ -146,6 +146,6 @@ class Base {
   typedef _LEDDriverProps Props_;
 };
 
-}
-}
-}
+}  // namespace led
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/led/Color.h
+++ b/src/kaleidoscope/driver/led/Color.h
@@ -51,7 +51,7 @@ struct BGR {
   uint8_t r;
 };
 
-}
-}
-}
-}
+}  // namespace color
+}  // namespace led
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/led/None.h
+++ b/src/kaleidoscope/driver/led/None.h
@@ -43,6 +43,6 @@ namespace led {
  */
 class None : public kaleidoscope::driver::led::Base<BaseProps> {};
 
-}
-}
-}
+}  // namespace led
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/led/WS2812.h
+++ b/src/kaleidoscope/driver/led/WS2812.h
@@ -164,6 +164,6 @@ class WS2812 {
   }
 
 };
-}
-}
-}
+}  // namespace led
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/mcu/ATmega32U4.h
+++ b/src/kaleidoscope/driver/mcu/ATmega32U4.h
@@ -79,6 +79,6 @@ template <typename _Props>
 class ATmega32U4 : public kaleidoscope::driver::mcu::Base<_Props> {};
 #endif // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
 
-}
-}
-}
+}  // namespace mcu
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/mcu/Base.h
+++ b/src/kaleidoscope/driver/mcu/Base.h
@@ -45,6 +45,6 @@ class Base {
   void attachToHost() {}
 };
 
-}
-}
-}
+}  // namespace mcu
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/mcu/None.h
+++ b/src/kaleidoscope/driver/mcu/None.h
@@ -31,6 +31,6 @@ namespace mcu {
  */
 class None : public kaleidoscope::driver::mcu::Base<BaseProps> {};
 
-}
-}
-}
+}  // namespace mcu
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/mcu/SAMD.h
+++ b/src/kaleidoscope/driver/mcu/SAMD.h
@@ -36,8 +36,8 @@ class SAMD : public kaleidoscope::driver::mcu::Base<BaseProps> {
   }
 };
 
-}
-}
-}
+}  // namespace mcu
+}  // namespace driver
+}  // namespace kaleidoscope
 
 #endif

--- a/src/kaleidoscope/driver/storage/ATmega32U4EEPROMProps.h
+++ b/src/kaleidoscope/driver/storage/ATmega32U4EEPROMProps.h
@@ -29,6 +29,6 @@ struct ATmega32U4EEPROMProps : kaleidoscope::driver::storage::AVREEPROMProps {
   static constexpr uint16_t length = 1024;
 };
 
-}
-}
-}
+}  // namespace storage
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/storage/AVREEPROM.h
+++ b/src/kaleidoscope/driver/storage/AVREEPROM.h
@@ -58,8 +58,8 @@ class AVREEPROM : public kaleidoscope::driver::storage::Base<_StorageProps> {
   }
 };
 
-}
-}
-}
+}  // namespace storage
+}  // namespace driver
+}  // namespace kaleidoscope
 
 #endif

--- a/src/kaleidoscope/driver/storage/Base.h
+++ b/src/kaleidoscope/driver/storage/Base.h
@@ -56,6 +56,6 @@ class Base {
   void commit() {}
 };
 
-}
-}
-}
+}  // namespace storage
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/driver/storage/Flash.h
+++ b/src/kaleidoscope/driver/storage/Flash.h
@@ -74,8 +74,8 @@ class Flash: public kaleidoscope::driver::storage::Base<_StorageProps> {
   }
 };
 
-}
-}
-}
+}  // namespace storage
+}  // namespace driver
+}  // namespace kaleidoscope
 
 #endif

--- a/src/kaleidoscope/driver/storage/None.h
+++ b/src/kaleidoscope/driver/storage/None.h
@@ -31,6 +31,6 @@ namespace storage {
  */
 class None : public kaleidoscope::driver::storage::Base<BaseProps> {};
 
-}
-}
-}
+}  // namespace storage
+}  // namespace driver
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/event_handler_result.h
+++ b/src/kaleidoscope/event_handler_result.h
@@ -50,4 +50,4 @@ enum class EventHandlerResult : uint8_t {
   ERROR,
 };
 
-}
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/hooks.h
+++ b/src/kaleidoscope/hooks.h
@@ -78,4 +78,4 @@ class Hooks {
 #undef DEFINE_WEAK_HOOK_FUNCTION
 };
 
-}
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/keymaps.h
+++ b/src/kaleidoscope/keymaps.h
@@ -32,4 +32,4 @@ Key keyFromKeymap(uint8_t layer, KeyAddr key_addr) {
   return keymaps_linear[layer][key_addr.toInt()].readFromProgmem();
 }
 
-}
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/layers.cpp
+++ b/src/kaleidoscope/layers.cpp
@@ -256,6 +256,6 @@ void Layer_::forEachActiveLayer(forEachHandler h) {
   }
 }
 
-}
+}  // namespace kaleidoscope
 
 kaleidoscope::Layer_ Layer;

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -119,6 +119,6 @@ class Layer_ {
   static int8_t active_layers_[31];
   static uint8_t active_layer_keymap_[kaleidoscope_internal::device.numKeys()];
 };
-}
+}  // namespace kaleidoscope
 
 extern kaleidoscope::Layer_ Layer;

--- a/src/kaleidoscope/plugin/AccessTransientLEDMode.h
+++ b/src/kaleidoscope/plugin/AccessTransientLEDMode.h
@@ -38,5 +38,5 @@ class AccessTransientLEDMode {
   uint8_t led_mode_id_ = 255; /* 255 means uninitialized */
 };
 
-} // end namespace plugin
-} // end namespace kaleidoscope
+} // namespace plugin
+} // namespace kaleidoscope

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -330,8 +330,8 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
   return EventHandlerResult::EVENT_CONSUMED;
 }
 
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::LEDControl LEDControl;
 kaleidoscope::plugin::FocusLEDCommand FocusLEDCommand;

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -136,9 +136,9 @@ class FocusLEDCommand : public Plugin {
   EventHandlerResult onFocusEvent(const char *command);
 };
 
-}
+}  // namespace plugin
 
-}
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::LEDControl LEDControl;
 extern kaleidoscope::plugin::FocusLEDCommand FocusLEDCommand;

--- a/src/kaleidoscope/plugin/LEDControl/LED-Off.cpp
+++ b/src/kaleidoscope/plugin/LEDControl/LED-Off.cpp
@@ -27,7 +27,7 @@ void LEDOff::onActivate(void) {
 void LEDOff::refreshAt(KeyAddr key_addr) {
   ::LEDControl.setCrgbAt(key_addr, {0, 0, 0});
 }
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 kaleidoscope::plugin::LEDOff LEDOff;

--- a/src/kaleidoscope/plugin/LEDControl/LED-Off.h
+++ b/src/kaleidoscope/plugin/LEDControl/LED-Off.h
@@ -33,7 +33,7 @@ class LEDOff : public LEDMode {
   void onActivate(void) final;
   void refreshAt(KeyAddr key_addr) final;
 };
-}
-}
+}  // namespace plugin
+}  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::LEDOff LEDOff;

--- a/src/kaleidoscope/plugin/LEDMode.h
+++ b/src/kaleidoscope/plugin/LEDMode.h
@@ -27,7 +27,8 @@ namespace kaleidoscope {
 namespace internal {
 // Forward declaration
 class LEDModeManager;
-} // end namespace internal
+
+} // namespace internal
 
 namespace plugin {
 
@@ -108,5 +109,5 @@ class LEDMode : public kaleidoscope::Plugin,
   }
 };
 
-} // end namespace plugin
-} // end namespace kaleidoscope
+} // namespace plugin
+} // namespace kaleidoscope

--- a/src/kaleidoscope/plugin/LEDModeInterface.cpp
+++ b/src/kaleidoscope/plugin/LEDModeInterface.cpp
@@ -25,5 +25,5 @@ void LEDModeInterface::activate() {
   LEDControl::activate(this);
 }
 
-} // end namespace plugin
-} // end namespace kaleidoscope
+} // namespace plugin
+} // namespace kaleidoscope

--- a/src/kaleidoscope/plugin/LEDModeInterface.h
+++ b/src/kaleidoscope/plugin/LEDModeInterface.h
@@ -38,5 +38,5 @@ class LEDModeInterface {
   typedef NoLEDMode DynamicLEDMode;
 };
 
-} // end namespace plugin
-} // end namespace kaleidoscope
+} // namespace plugin
+} // namespace kaleidoscope

--- a/src/kaleidoscope/util/flasher/Base.h
+++ b/src/kaleidoscope/util/flasher/Base.h
@@ -57,6 +57,6 @@ class Base {
   }
 };
 
-}
-}
-}
+}  // namespace flasher
+}  // namespace util
+}  // namespace kaleidoscope

--- a/src/kaleidoscope/util/flasher/KeyboardioI2CBootloader.h
+++ b/src/kaleidoscope/util/flasher/KeyboardioI2CBootloader.h
@@ -220,8 +220,8 @@ class KeyboardioI2CBootloader: kaleidoscope::util::flasher::Base<_Props> {
 
 };
 
-}
-}
-}
+}  // namespace flasher
+}  // namespace util
+}  // namespace kaleidoscope
 
 #endif

--- a/src/kaleidoscope_internal/LEDModeManager.cpp
+++ b/src/kaleidoscope_internal/LEDModeManager.cpp
@@ -37,7 +37,7 @@ kaleidoscope::plugin::LEDMode *cur_led_mode = nullptr;
 
 bool current_led_mode_dynamic = false;
 
-}
+}  // namespace
 
 kaleidoscope::plugin::LEDMode *LEDModeManager::getLEDMode(uint8_t mode_id) {
 
@@ -102,5 +102,5 @@ kaleidoscope::plugin::LEDMode *LEDModeManager::getLEDMode(uint8_t mode_id) {
   return cur_led_mode;
 }
 
-} // end namespace internal
-} // end namespace kaleidoscope
+} // namespace internal
+} // namespace kaleidoscope

--- a/src/kaleidoscope_internal/LEDModeManager.h
+++ b/src/kaleidoscope_internal/LEDModeManager.h
@@ -46,7 +46,8 @@ namespace plugin {
 // Forward declarations to avoid header inclusions
 class LEDControl;
 class LEDModeInterface;
-} // end namespace plugin
+
+} // namespace plugin
 
 namespace internal {
 namespace led_mode_management {
@@ -311,7 +312,7 @@ struct TransientLEDModeMaxSize<PluginPtr__> {
   static constexpr size_t value = TransientLEDModeSize<PluginPtr__, ledModePluginType(PluginPtr__())>::value;
 };
 
-} // end namespace led_mode_management
+} // namespace led_mode_management
 
 class LEDModeManager {
  public:
@@ -379,8 +380,8 @@ class LEDModeManager {
   static uint8_t led_mode_buffer_[];
 };
 
-} // end namespace internal
-} // end namespace kaleidoscope
+} // namespace internal
+} // namespace kaleidoscope
 
 // Some auxiliary macros that are mapped to the list of
 // plugins defined via KALEIDOSCOPE_INIT_PLUGINS follow.

--- a/src/kaleidoscope_internal/array_like_storage.h
+++ b/src/kaleidoscope_internal/array_like_storage.h
@@ -110,5 +110,5 @@ struct ArrayLikeStorage<StoredType__, false /* not of appropriate type */> {
   typedef StoredType__ ContentType;
 } __attribute__((packed));
 
-} // end namespace internal
-} // end namespace kaleidoscope
+} // namespace internal
+} // namespace kaleidoscope


### PR DESCRIPTION
This standardizes namespace closing brackets for namespace blocks.  Each one is on its own line, with a comment clearly marking which namespace it closes. Consecutive lines closing namespace blocks have no whitespace between them, but there is one blank line before and after a set of namespace block closing lines.

There should be nothing by comments and whitespace changes in this PR.  I've checked it to verify that, but it changes so many files that someone else should definitely have a look, as well.
