### PR TITLE
Add Storage.isSliceUninitialized(), and convert some of our plugins to use it.

### DIFF
--- a/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
+++ b/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
@@ -37,13 +37,11 @@ uint16_t AutoShiftConfig::settings_base_;
 
 EventHandlerResult AutoShiftConfig::onSetup() {
   settings_base_ = ::EEPROMSettings.requestSlice(sizeof(AutoShift::settings_));
-  uint32_t checker;
 
-  Runtime.storage().get(settings_base_, checker);
-
-  // Check if we have an empty eeprom...
-  if (checker == 0xffffffff) {
-    // ...if the eeprom was empty, store the default settings.
+  if (Runtime.storage().isSliceUninitialized(
+        settings_base_,
+        sizeof(AutoShift::settings_))) {
+    // If our slice is uninitialized, set sensible defaults.
     Runtime.storage().put(settings_base_, AutoShift::settings_);
     Runtime.storage().commit();
   }

--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot-Config.cpp
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot-Config.cpp
@@ -34,13 +34,11 @@ uint16_t EscapeOneShotConfig::settings_base_;
 
 EventHandlerResult EscapeOneShotConfig::onSetup() {
   settings_base_ = ::EEPROMSettings.requestSlice(sizeof(EscapeOneShot::settings_));
-  uint16_t checker;
 
-  Runtime.storage().get(settings_base_, checker);
-
-  // Check if we have an empty eeprom...
-  if (checker == 0xffff) {
-    // ...if the eeprom was empty, store the default settings.
+  if (Runtime.storage().isSliceUninitialized(
+        settings_base_,
+        sizeof(EscapeOneShot::settings_))) {
+    // If our slice is uninitialized, set sensible defaults.
     Runtime.storage().put(settings_base_, EscapeOneShot::settings_);
     Runtime.storage().commit();
   }

--- a/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
+++ b/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
@@ -121,11 +121,10 @@ EventHandlerResult TypingBreaks::onNameQuery() {
 EventHandlerResult TypingBreaks::onSetup() {
   settings_base_ = ::EEPROMSettings.requestSlice(sizeof(settings));
 
-  // If idleTime is max, assume that EEPROM is uninitialized, and store the
-  // defaults.
-  uint32_t idle_time;
-  Runtime.storage().get(settings_base_, idle_time);
-  if (idle_time == 0xffffffff) {
+  if (Runtime.storage().isSliceUninitialized(
+        settings_base_,
+        sizeof(settings))) {
+    // If our slice is uninitialized, set sensible defaults.
     Runtime.storage().put(settings_base_, settings);
     Runtime.storage().commit();
   }

--- a/src/kaleidoscope/driver/storage/Base.h
+++ b/src/kaleidoscope/driver/storage/Base.h
@@ -25,6 +25,7 @@ namespace storage {
 
 struct BaseProps {
   static constexpr uint16_t length = 0;
+  static constexpr uint8_t uninitialized_byte = 0xff;
 };
 
 template <typename _StorageProps>
@@ -47,6 +48,14 @@ class Base {
   void write(int idx, uint8_t val) {}
 
   void update(int idx, uint8_t val) {}
+
+  bool isSliceUninitialized(uint16_t offset, uint16_t size) {
+    for (uint16_t o = offset; o < offset + size; o++) {
+      if (read(o) != _StorageProps::uninitialized_byte)
+        return false;
+    }
+    return true;
+  }
 
   const uint16_t length() {
     return _StorageProps::length;


### PR DESCRIPTION
As explained in #1145, we have a reasonably common pattern of plugins checking if their slice of storage is uninitialized, and then setting up sensible defaults if it is. To reduce code duplication, and eventually allow for the uninitialized byte being something else than `0xff`, introduce `storage().isSliceUninitialized()` that does the checking for us.

The PR also converts three plugins that were using this pattern, to use the new function.

There remain other places that do the checking in a slightly different manner, and where the `0xff` assumption is still hardcoded. Those are harder to update, and even more complicated to remove the assumption, so I'll do that some other time.