### PR TITLE
driver::storage::GD32Flash: Don't duplicate commit()

### DIFF
--- a/src/kaleidoscope/driver/storage/GD32Flash.h
+++ b/src/kaleidoscope/driver/storage/GD32Flash.h
@@ -38,9 +38,6 @@ class GD32Flash : public EEPROMClass<_StorageProps::length> {
   void setup() {
     EEPROMClass<_StorageProps::length>::begin();
   }
-  void commit() {
-    EEPROMClass<_StorageProps::length>::commit();
-  }
 };
 
 }  // namespace storage


### PR DESCRIPTION
The class we're deriving from - `FlashAsEEPROM`'s `EEPROMClass` - already has a `commit()` method, we do not need our own in the child class, especially not when all it does is call the parent.

We previously added this call because in the original implementation of the driver, we had an empty `commit()`. The correct fix is to remove the override, rather than reimplement the inheritance.

Spotted by @obra, thanks!