### PR TITLE
Workaround for GD32 Serial writes dropping characters

### DIFF
--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -42,7 +42,9 @@ class FocusSerial : public kaleidoscope::Plugin {
 
   EventHandlerResult sendName(const __FlashStringHelper *name) {
     Runtime.serialPort().print(name);
+    delayAfterPrint();
     Runtime.serialPort().print(NEWLINE);
+    delayAfterPrint();
     return EventHandlerResult::OK;
   }
 
@@ -55,12 +57,16 @@ class FocusSerial : public kaleidoscope::Plugin {
   }
   void send(const bool b) {
     printBool(b);
+    delayAfterPrint();
     Runtime.serialPort().print(SEPARATOR);
+    delayAfterPrint();
   }
   template<typename V>
   void send(V v) {
     Runtime.serialPort().print(v);
+    delayAfterPrint();
     Runtime.serialPort().print(SEPARATOR);
+    delayAfterPrint();
   }
   template<typename Var, typename... Vars>
   void send(Var v, Vars... vars) {
@@ -72,6 +78,7 @@ class FocusSerial : public kaleidoscope::Plugin {
   template<typename Var, typename... Vars>
   void sendRaw(Var v, Vars... vars) {
     Runtime.serialPort().print(v);
+    delayAfterPrint();
     sendRaw(vars...);
   }
 
@@ -107,6 +114,12 @@ class FocusSerial : public kaleidoscope::Plugin {
   static char command_[32];
   static uint8_t buf_cursor_;
   static void printBool(bool b);
+
+  // This is a hacky workaround for the host seemingly dropping characters
+  // when a client spams its serial port too quickly
+  // Verified on GD32 and macOS 12.3 2022-03-29
+  static constexpr uint8_t focus_delay_us_after_character_ = 100;
+  static void delayAfterPrint() { delayMicroseconds(focus_delay_us_after_character_); }
 };
 
 }  // namespace plugin


### PR DESCRIPTION
@algernon this is a blocker for Model 100 firmware build

Workaround for GD32 Serial writes dropping characters when running
at a high datarate. This is not a proper fix and should be dropped when
the following arduino sketch doesn't drop characters on a GD32F303:

void setup() {
  Serial.begin(9600);
}

void loop() {
 for(auto i=0 ;i<1024; i++)
  Serial.print("0");
 for(auto i=0; i<1024; i++)
  Serial.print("1");
 for(auto i=0; i<1024; i++)
  Serial.print("2");
 for(auto i=0 ;i<1024; i++)
  Serial.print("3");
 for(auto i=0 ;i<1024; i++)
  Serial.print("4");
 for(auto i=0; i<1024; i++)
  Serial.print("5");
 for(auto i=0; i<1024; i++)
  Serial.print("6");
 for(auto i=0 ;i<1024; i++)
  Serial.print("7");
 for(auto i=0 ;i<1024; i++)
  Serial.print("8");
 for(auto i=0 ;i<1024; i++)
  Serial.print("9");
  Serial.println();
  delay(2000);

}