### PR TITLE
Improve output of simulator tests

### DIFF
--- a/testing/bin/ktest-to-cxx
+++ b/testing/bin/ktest-to-cxx
@@ -361,7 +361,7 @@ sub generate_script {
     # We should do this better, inside the core. But until we do
     # I'd rather stick the macro in the code generator so nobody
     # gets to use it from regular tests, boxing us in
-    cxx('#define GTEST_COUT std::cerr << "[ INFO     ] "');
+    cxx('#define GTEST_COUT std::cout << "[ INFO     ] "');
 
     generate_start_new_test('KtestSourceFilename');
     cxx(

--- a/testing/googletest/googletest/src/gtest.cc
+++ b/testing/googletest/googletest/src/gtest.cc
@@ -3240,6 +3240,10 @@ bool ShouldUseColor(bool stdout_is_tty) {
     // console there does support colors.
     return stdout_is_tty;
 #else
+    // In case we're running from `make --output-sync`, we need to check
+    // MAKE_TERMOUT to determine if the output is going to a terminal.
+    const char* const make_termout = posix::GetEnv("MAKE_TERMOUT");
+    if (make_termout != nullptr) stdout_is_tty = true;
     // On non-Windows platforms, we rely on the TERM variable.
     const char* const term = posix::GetEnv("TERM");
     const bool term_supports_color =


### PR DESCRIPTION
This restores the utility of coloring the output to the terminal when running `make -j<N> simulator-tests`, and sends the relevant output from ktest-generated tests to the same output stream as the rest of the gtest output (I didn't bother to color it, though).