### PR TITLE
Use the new Model01 hardware plugin directly for testing

### DIFF
--- a/testing/makefiles/shared.mk
+++ b/testing/makefiles/shared.mk
@@ -8,13 +8,12 @@ shared_defines := \
                 -DUSBCON=dummy \
                 -DARDUINO_ARCH_AVR=1 \
                 -DARDUINO_AVR_MODEL01 \
-                '-DKALEIDOSCOPE_HARDWARE_H="Kaleidoscope-Hardware-Model01.h"' \
+                '-DKALEIDOSCOPE_HARDWARE_H="Kaleidoscope-Hardware-Keyboardio-Model01.h"' \
                 '-DUSB_PRODUCT="Model 01"'
 
 shared_includes := \
 		-I${top_dir} \
 		-I${top_dir}/src \
-		-I${top_dir}/plugins/Kaleidoscope-Hardware-Model01/src \
 		-I${top_dir}/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src \
 		-I${arduino_platform_path}/cores/arduino \
 		-I${arduino_platform_path}/libraries/KeyboardioHID/src \


### PR DESCRIPTION
Instead of using the old `Kaleidoscope-Hardware-Model01` plugin, which basically just redirects to the new(er) `Kaleidoscope-Hardware-Keyboardio-Model01` when running simulator tests, just refer to the actual hardware plugin directly.