### PR TITLE
PB14 and PB15 are the pins the GD32 uses to talk check the prog key. The

### DIFF
--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.cpp
@@ -135,7 +135,6 @@ void Model100KeyScanner::enableScannerPower(void) {
   digitalWrite(PB14, LOW);
   pinMode(PB15, INPUT);
   digitalWrite(PB15, LOW);
-
 }
 
 void Model100KeyScanner::disableScannerPower(void) {

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.cpp
@@ -130,6 +130,12 @@ void Model100KeyScanner::enableScannerPower(void) {
   //
   pinMode(PB9, OUTPUT_OPEN_DRAIN);
   digitalWrite(PB9, LOW);
+
+  pinMode(PB14, INPUT);
+  digitalWrite(PB14, LOW);
+  pinMode(PB15, INPUT);
+  digitalWrite(PB15, LOW);
+
 }
 
 void Model100KeyScanner::disableScannerPower(void) {


### PR DESCRIPTION
bootloader doesn't fully deconfigure them, leading to potentially bad
reads of column 0, so we turn them off ourselves