### PR TITLE
Export mouse warp grid constants

### DIFF
--- a/examples/Features/MouseKeys/MouseKeys.ino
+++ b/examples/Features/MouseKeys/MouseKeys.ino
@@ -1,0 +1,76 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope - A Kaleidoscope example
+ * Copyright (C) 2016-2022  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define DEBUG_SERIAL false
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-MouseKeys.h>
+
+enum {
+  PRIMARY,
+  MOUSEKEYS,
+};
+
+// clang-format off
+KEYMAPS(
+  [PRIMARY] = KEYMAP_STACKED
+  (Key_NoKey,    Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
+   Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+   Key_PageUp,   Key_A, Key_S, Key_D, Key_F, Key_G,
+   Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+
+   Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+   ShiftToLayer(MOUSEKEYS),
+
+   Key_skip,  Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
+   Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
+              Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
+   Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
+
+   Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
+   LockLayer(MOUSEKEYS)
+   ),
+
+  [MOUSEKEYS] =  KEYMAP_STACKED
+  (___, ___, ___,           ___,           ___,             ___,             ___,
+   ___, ___, ___,           ___,           Key_mouseWarpNW, Key_mouseWarpNE, ___,
+   ___, ___, ___,           ___,           Key_mouseWarpSW, Key_mouseWarpSE,
+   ___, ___, Key_mouseBtnL, Key_mouseBtnM, Key_mouseBtnR,   ___,             ___,
+   ___, ___, ___, ___,
+   ___,
+
+   ___, ___, ___,         ___,         ___,        ___, ___,
+   ___, ___, ___,         Key_mouseUp, ___,        ___, ___,
+        ___, Key_mouseUp, Key_mouseDn, Key_mouseR, ___, ___,
+   ___, ___, ___,         ___,         ___,        ___, ___,
+   ___, ___, ___, ___,
+   ___)
+)
+// clang-format on
+
+
+KALEIDOSCOPE_INIT_PLUGINS(MouseKeys);
+
+void setup() {
+  Kaleidoscope.setup();
+  MouseKeys.setSpeedLimit(100);
+  MouseKeys.setWarpGridSize(MOUSE_WARP_GRID_2X2);
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/examples/Features/MouseKeys/sketch.json
+++ b/examples/Features/MouseKeys/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:model01",
+    "port": ""
+  }
+}

--- a/plugins/Kaleidoscope-MouseKeys/README.md
+++ b/plugins/Kaleidoscope-MouseKeys/README.md
@@ -244,3 +244,9 @@ properties available:
 
 > This method changes the size of the grid used for [warping](#warping). The
 > following are valid sizes: `MOUSE_WARP_GRID_2X2`, `MOUSE_WARP_GRID_3X3`
+
+## Further reading
+
+There is an [example][plugin:example] that demonstrates how to use this plugin.
+
+[plugin:example]: /examples/Features/MouseKeys/MouseKeys.ino

--- a/plugins/Kaleidoscope-MouseKeys/src/Kaleidoscope-MouseKeys.h
+++ b/plugins/Kaleidoscope-MouseKeys/src/Kaleidoscope-MouseKeys.h
@@ -16,6 +16,6 @@
 
 #pragma once
 
-#include "kaleidoscope/plugin/MouseKeys.h"               // IWYU pragma: export
-#include "kaleidoscope/plugin/mousekeys/MouseKeyDefs.h"  // IWYU pragma: export
+#include "kaleidoscope/plugin/MouseKeys.h"                 // IWYU pragma: export
+#include "kaleidoscope/plugin/mousekeys/MouseKeyDefs.h"    // IWYU pragma: export
 #include "kaleidoscope/plugin/mousekeys/MouseWarpModes.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-MouseKeys/src/Kaleidoscope-MouseKeys.h
+++ b/plugins/Kaleidoscope-MouseKeys/src/Kaleidoscope-MouseKeys.h
@@ -18,3 +18,4 @@
 
 #include "kaleidoscope/plugin/MouseKeys.h"               // IWYU pragma: export
 #include "kaleidoscope/plugin/mousekeys/MouseKeyDefs.h"  // IWYU pragma: export
+#include "kaleidoscope/plugin/mousekeys/MouseWarpModes.h"  // IWYU pragma: export


### PR DESCRIPTION
This restores access to the mouse warp grid constants (e.g. `MOUSE_WARP_GRID_3X3`) to user sketches.  I also added an example sketch for MouseKeys that would have detected the problem, and added a link to that example in the MouseKeys README file.

Fixes #1166.