### PR TITLE
DynamicMacros fixes

### DIFF
--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -240,6 +240,17 @@ EventHandlerResult DynamicMacros::onKeyEvent(KeyEvent &event) {
   return EventHandlerResult::EVENT_CONSUMED;
 }
 
+EventHandlerResult DynamicMacros::beforeReportingState(const KeyEvent &event) {
+  // Here we add keycodes to the HID report for keys held in a macro sequence.
+  // This is necessary because Kaleidoscope doesn't know about the supplemental
+  // `active_macro_keys_[]` array.
+  for (Key key : active_macro_keys_) {
+    if (key != Key_NoKey)
+      Runtime.addToReport(key);
+  }
+  return EventHandlerResult::OK;
+}
+
 EventHandlerResult DynamicMacros::onNameQuery() {
   return ::Focus.sendName(F("DynamicMacros"));
 }

--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -188,7 +188,7 @@ void DynamicMacros::play(uint8_t macro_id) {
 
     case MACRO_ACTION_STEP_TAP_SEQUENCE: {
       while (true) {
-        key.setFlags(0);
+        key.setFlags(Runtime.storage().read(pos++));
         key.setKeyCode(Runtime.storage().read(pos++));
         if (key == Key_NoKey)
           break;

--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.h
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.h
@@ -39,6 +39,7 @@ class DynamicMacros : public kaleidoscope::Plugin {
  public:
   EventHandlerResult onNameQuery();
   EventHandlerResult onKeyEvent(KeyEvent &event);
+  EventHandlerResult beforeReportingState(const KeyEvent &event);
   EventHandlerResult onFocusEvent(const char *command);
 
   static void reserve_storage(uint16_t size);

--- a/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros.cpp
+++ b/plugins/Kaleidoscope-Macros/src/kaleidoscope/plugin/Macros.cpp
@@ -154,7 +154,7 @@ void Macros::play(const macro_t *macro_p) {
 
     case MACRO_ACTION_STEP_TAP_SEQUENCE: {
       while (true) {
-        key.setFlags(0);
+        key.setFlags(pgm_read_byte(macro_p++));
         key.setKeyCode(pgm_read_byte(macro_p++));
         if (key == Key_NoKey)
           break;


### PR DESCRIPTION
This PR fixes two bugs in DynamicMacros, one of which also existed in the normal Macros plugin as well.

First, the "tap sequence" handler wasn't reading whole `Key` objects, but was instead treating each byte read as a keycode only (correct for the "tap code sequence" handler, but not for "tap sequence").

Second, DynamicMacros had not been updated with the same `beforeReportingState()` handler that Macros uses to keep held macro keys active in the HID report while a macro is playing.

_NOTE: I haven't yet tested this out.  @algernon is better equipped to verify that it works for DynamicMacros.  I also haven't added a testcase for the Macros fix yet, so I'm leaving this as a draft for now._

Fixes #1171