### PR TITLE
k::d::storage::GD32Flash: Implement isSliceUninitialized()

### DIFF
--- a/src/kaleidoscope/driver/storage/GD32Flash.h
+++ b/src/kaleidoscope/driver/storage/GD32Flash.h
@@ -38,6 +38,14 @@ class GD32Flash : public EEPROMClass<_StorageProps::length> {
   void setup() {
     EEPROMClass<_StorageProps::length>::begin();
   }
+
+  bool isSliceUninitialized(uint16_t offset, uint16_t size) {
+    for (uint16_t o = offset; o < offset + size; o++) {
+      if (this->read(o) != _StorageProps::uninitialized_byte)
+        return false;
+    }
+    return true;
+  }
 };
 
 }  // namespace storage


### PR DESCRIPTION
The `::isSliceUninitialized()` method is required by the Base flash driver class, but `GD32Flash` did not implement it. While the Base class does so, `GD32Flash` is subclassing `EEPROMClass`, rather than `storage::Base`, for historical and technical reasons. As such, we need to implement this method ourselves.

We could probably use multiple inheritance, but I feel that would be more trouble than its worth.

This method is used by the `EscapeOneShot` plugin, which I want to enable in the Model100 experimental firmware for Chrysalis.