### PR TITLE
Model100: Increase the default EEPROM size from 4k to 16k

### DIFF
--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.h
@@ -19,10 +19,6 @@
 
 #ifdef ARDUINO_keyboardio_model_100
 
-#ifndef EEPROM_EMULATION_SIZE
-#define EEPROM_EMULATION_SIZE 4096
-#endif
-
 #include <Arduino.h>
 
 #define CRGB(r, g, b) \
@@ -51,7 +47,7 @@ namespace device {
 namespace keyboardio {
 
 struct Model100StorageProps : public kaleidoscope::driver::storage::GD32FlashProps {
-  static constexpr uint16_t length = EEPROM_EMULATION_SIZE;
+  static constexpr uint16_t length = 16384;
 };
 
 


### PR DESCRIPTION
This matches the default EEPROM size of the underlying FlashStorage library, and is substantially bigger than AVR-based keyboards, yet not _too_ big.

For various reasons, we're mirroring EEPROM into RAM 1:1, so we're constrained by the size of that, too. That makes larger storage sizes undesirable at this time. On top of this limitation, larger storage sizes also pose backup & restore speed issues with Chrysalis, so lets settle for 16k, which is still very big, all things considered, but not big enough to be a problem.