### PR TITLE
etc/makefiles/sketch.mk: Copy & symlink .bin files too, if they exist

### DIFF
--- a/etc/makefiles/sketch.mk
+++ b/etc/makefiles/sketch.mk
@@ -45,6 +45,7 @@ OUTPUT_FILE_PREFIX 		:= $(SKETCH_BASE_NAME)-$(GIT_VERSION)
 HEX_FILE_PATH 			:= $(OUTPUT_PATH)/$(OUTPUT_FILE_PREFIX).hex
 HEX_FILE_WITH_BOOTLOADER_PATH 	:= $(OUTPUT_PATH)/$(OUTPUT_FILE_PREFIX)-with-bootloader.hex
 ELF_FILE_PATH 			:= $(OUTPUT_PATH)/$(OUTPUT_FILE_PREFIX).elf
+BIN_FILE_PATH				:= $(OUTPUT_PATH)/$(OUTPUT_FILE_PREFIX).bin
 LIB_FILE_PATH 			:= $(OUTPUT_PATH)/$(OUTPUT_FILE_PREFIX).a
 
 ifeq ($(FQBN),)
@@ -175,8 +176,10 @@ compile: kaleidoscope-hardware-configured
 ifeq ($(LIBONLY),)
 	$(QUIET) cp "${BUILD_PATH}/${SKETCH_FILE_NAME}.hex" "${HEX_FILE_PATH}"
 	$(QUIET) cp "${BUILD_PATH}/${SKETCH_FILE_NAME}.elf" "${ELF_FILE_PATH}"
+	$(QUIET) if [ -e "${BUILD_PATH}/${SKETCH_FILENAME}.bin" ]; then cp "${BUILD_PATH}/${SKETCH_FILE_NAME}.bin" "${BIN_FILE_PATH}"; else :; fi
 	$(QUIET) ln -sf "${OUTPUT_FILE_PREFIX}.hex" "${OUTPUT_PATH}/${SKETCH_BASE_NAME}-latest.hex"
 	$(QUIET) ln -sf "${OUTPUT_FILE_PREFIX}.elf" "${OUTPUT_PATH}/${SKETCH_BASE_NAME}-latest.elf"
+	$(QUIET) if [ -e "${OUTPUT_PATH}/${OUTPUT_FILE_PREFIX}.bin" ]; then ln -sf "${OUTPUT_FILE_PREFIX}.bin" "${OUTPUT_PATH}/${SKETCH_BASE_NAME}-latest.bin"; else :; fi
 else    
 	$(QUIET) cp "${BUILD_PATH}/${SKETCH_FILE_NAME}.a" "${LIB_FILE_PATH}"
 	$(QUIET) ln -sf "${OUTPUT_FILE_PREFIX}.a" "${OUTPUT_PATH}/${SKETCH_BASE_NAME}-latest.a"


### PR DESCRIPTION
On GD32, while the build process does create .hex files, we use the .bin ones for flashing. So copy those to the appropriate place, and do the same symlinking as for the .elf and .hex files.

Because .bin is not compiled on all platforms, we guard it with an if that checks for its existence.

There might be a better way to do this, but this was fast and easy.
