### PR TITLE
plugins/LED-Wavepool: Enable the plugin for the Model 100 too

### DIFF
--- a/plugins/Kaleidoscope-LED-Wavepool/src/kaleidoscope/plugin/LED-Wavepool.cpp
+++ b/plugins/Kaleidoscope-LED-Wavepool/src/kaleidoscope/plugin/LED-Wavepool.cpp
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef ARDUINO_AVR_MODEL01
+#if defined(ARDUINO_AVR_MODEL01) || defined(ARDUINO_keyboardio_model_100)
 
 #include "kaleidoscope/plugin/LED-Wavepool.h"
 

--- a/plugins/Kaleidoscope-LED-Wavepool/src/kaleidoscope/plugin/LED-Wavepool.h
+++ b/plugins/Kaleidoscope-LED-Wavepool/src/kaleidoscope/plugin/LED-Wavepool.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#ifdef ARDUINO_AVR_MODEL01
+#if defined(ARDUINO_AVR_MODEL01) || defined(ARDUINO_keyboardio_model_100)
 
 #include <Arduino.h>  // for PROGMEM
 #include <stdint.h>   // for uint8_t, int16_t, int8_t, INT16_MAX


### PR DESCRIPTION
The plugin was restricted to the Model01, because it depends on a very specific key coordinate -> geometric shape mapping. Because the Model 01 and the Model 100 share this mapping, we can safely enable the plugin for the latter, too.
