### PR TITLE
Stop `check-all-includes` from formatting googletest code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,9 @@ check-all-includes:
 		-I=$(KALEIDOSCOPE_DIR)/testing/googletest/googlemock/include \
 		-I=$(KALEIDOSCOPE_DIR)/testing/googletest/googletest/include \
 		testing
-	bin/format-code.py -f -v --check src plugins testing
+	bin/format-code.py -f -v --check \
+		--exclude-dir 'testing/googletest' \
+		src plugins testing
 
 .PHONY: cpplint-noisy
 cpplint-noisy:


### PR DESCRIPTION
This was a minor oversight in the new header-checking tools.  Running `make check-all-includes` had `format-code.py` called without excluding the googletest directory.  That target still doesn't quite get everything right, but it will after #995 is merged.