### PR TITLE
Fix Turbo's "sticky" mode

### DIFF
--- a/plugins/Kaleidoscope-Turbo/README.md
+++ b/plugins/Kaleidoscope-Turbo/README.md
@@ -24,7 +24,7 @@ void setup() {
     Kaleidoscope.setup();
 
     Turbo.interval(30);
-    Turbo.toggle(true);
+    Turbo.sticky(true);
     Turbo.flash(true);
     Turbo.flashInterval(80);
     Turbo.activeColor(CRGB(0x64, 0x96, 0xed));
@@ -50,7 +50,6 @@ The `Turbo` object has the following user-configurable properties:
 
 ### `.sticky([bool])`
 > This method makes the Turbo functionality sticky, so it remains in effect not only while
->
 > it is held, but after it is released too, until it is toggled off with another tap. Without
 > arguments, the method enables the sticky functionality. Passing a boolean argument
 > sets stickiness to the given value.

--- a/plugins/Kaleidoscope-Turbo/src/kaleidoscope/plugin/Turbo.cpp
+++ b/plugins/Kaleidoscope-Turbo/src/kaleidoscope/plugin/Turbo.cpp
@@ -129,16 +129,9 @@ EventHandlerResult Turbo::afterEachCycle() {
       // Send the empty report to register the release of all the held keys.
       Runtime.hid().keyboard().sendReport();
 
-      // Just in case the Turbo key has been wiped from `live_keys[]` without
-      // `onKeyEvent()` being called with a toggle-off:
-      active_ = false;
-
       // Go through the `live_keys[]` array and add any Keyboard HID keys to the
       // new report.
       for (Key key : live_keys.all()) {
-        if (key == Key_Turbo) {
-          active_ = true;
-        }
         if (key.isKeyboardKey()) {
           Runtime.addToReport(key);
         }

--- a/tests/plugins/Turbo/sticky/sketch.json
+++ b/tests/plugins/Turbo/sticky/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:virtual:model01",
+    "port": ""
+  }
+}

--- a/tests/plugins/Turbo/sticky/sticky.ino
+++ b/tests/plugins/Turbo/sticky/sticky.ino
@@ -1,0 +1,52 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2022  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-Turbo.h>
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        Key_Turbo, Key_RightGui, Key_LeftShift, ___, ___, ___, ___,
+        Key_A, Key_B, Key_C, Key_D, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+KALEIDOSCOPE_INIT_PLUGINS(Turbo);
+
+void setup() {
+  Kaleidoscope.setup();
+
+  Turbo.interval(20);
+  Turbo.sticky(true);
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/plugins/Turbo/sticky/test.ktest
+++ b/tests/plugins/Turbo/sticky/test.ktest
@@ -1,0 +1,138 @@
+VERSION 1
+
+KEYSWITCH TURBO    0 0
+KEYSWITCH R_GUI    0 1
+KEYSWITCH L_SHIFT  0 2
+KEYSWITCH A        1 0
+KEYSWITCH B        1 1
+KEYSWITCH C        1 2
+KEYSWITCH D        1 3
+
+# ==============================================================================
+NAME Turbo no regression
+
+RUN 4 ms
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # report should contain `A` (0x04)
+
+RUN 4 ms
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # report should be empty
+
+RUN 5 ms
+EXPECT no keyboard-report # expect no more reports
+
+# ==============================================================================
+NAME Turbo second
+
+RUN 4 ms
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # report should contain `A` (0x04)
+
+RUN 4 ms
+PRESS TURBO
+RUN 1 cycle
+EXPECT keyboard-report empty # report should be empty
+EXPECT keyboard-report Key_A # report should contain `A` (0x04)
+
+RUN 20 ms
+EXPECT keyboard-report empty # report should be empty
+EXPECT keyboard-report Key_A # report should contain `A` (0x04)
+
+RUN 10 ms
+RELEASE TURBO
+RUN 10 ms
+EXPECT keyboard-report empty # report should be empty
+EXPECT keyboard-report Key_A # report should contain `A` (0x04)
+
+RUN 20 ms
+EXPECT keyboard-report empty # report should be empty
+EXPECT keyboard-report Key_A # report should contain `A` (0x04)
+
+RUN 20 ms
+EXPECT keyboard-report empty # report should be empty
+EXPECT keyboard-report Key_A # report should contain `A` (0x04)
+
+RUN 9 ms
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # report should be empty
+
+RUN 20 ms
+EXPECT no keyboard-report
+
+RUN 4 ms
+PRESS B
+RUN 1 cycle
+EXPECT keyboard-report Key_B # report should contain `B` (0x05)
+
+RUN 5 ms
+EXPECT keyboard-report empty # report should be empty
+EXPECT keyboard-report Key_B # report should contain `B` (0x05)
+
+RUN 20 ms
+EXPECT keyboard-report empty # report should be empty
+EXPECT keyboard-report Key_B # report should contain `B` (0x05)
+
+RUN 4 ms
+PRESS TURBO
+RUN 1 cycle
+
+RUN 4 ms
+RELEASE TURBO
+RUN 1 cycle
+
+RUN 20 ms
+RELEASE B
+RUN 1 cycle
+EXPECT keyboard-report empty # report should be empty
+
+RUN 5 ms
+EXPECT no keyboard-report # expect no more reports
+
+# ==============================================================================
+NAME Turbo first
+
+RUN 4 ms
+PRESS TURBO
+RUN 1 cycle
+
+RUN 4 ms
+RELEASE TURBO
+RUN 1 cycle
+
+RUN 5 ms
+
+RUN 4 ms
+PRESS A
+RUN 1 cycle
+EXPECT keyboard-report Key_A # report should contain `A` (0x04)
+
+RUN 5 ms
+EXPECT keyboard-report empty # report should be empty
+EXPECT keyboard-report Key_A # report should contain `A` (0x04)
+
+RUN 20 ms
+EXPECT keyboard-report empty # report should be empty
+EXPECT keyboard-report Key_A # report should contain `A` (0x04)
+
+RUN 4 ms
+RELEASE A
+RUN 1 cycle
+EXPECT keyboard-report empty # report should be empty
+
+RUN 25 ms
+
+RUN 4 ms
+PRESS TURBO
+RUN 1 cycle
+
+RUN 4 ms
+RELEASE TURBO
+RUN 1 cycle
+
+RUN 5 ms
+EXPECT no keyboard-report # expect no more reports


### PR DESCRIPTION
Previously, `Turbo.sticky(true)` had no effect, because the `sticky_` value was never checked.  Now it is handled properly, including leaving the "sticky" Turbo key in the live keys array while it's active, so layer changes won't make it inaccessible.  This works basically the same way OneShot keys work.

Fixes #1183 