### PR TITLE
Improvements to CycleTimeReport

### DIFF
--- a/examples/Features/CycleTimeReport/CycleTimeReport.ino
+++ b/examples/Features/CycleTimeReport/CycleTimeReport.ino
@@ -40,11 +40,20 @@ KEYMAPS(
 )
 // clang-format on
 
+// Override CycleTimeReport's reporting function:
+void kaleidoscope::plugin::CycleTimeReport::report(uint16_t mean_cycle_time) {
+  Serial.print(F("average loop time = "));
+  Serial.println(mean_cycle_time, DEC);
+}
+
 KALEIDOSCOPE_INIT_PLUGINS(CycleTimeReport);
 
 void setup() {
   Kaleidoscope.serialPort().begin(9600);
   Kaleidoscope.setup();
+
+  // Change the report interval to 2 seconds:
+  CycleTimeReport.setReportInterval(2000);
 }
 
 void loop() {

--- a/plugins/Kaleidoscope-CycleTimeReport/README.md
+++ b/plugins/Kaleidoscope-CycleTimeReport/README.md
@@ -16,7 +16,7 @@ the box, without any further configuration:
 
 KALEIDOSCOPE_INIT_PLUGINS(CycleTimeReport);
 
-void setup (void) {
+void setup () {
   Kaleidoscope.serialPort().begin(9600);
   Kaleidoscope.setup ();
 }
@@ -25,25 +25,23 @@ void setup (void) {
 ## Plugin methods
 
 The plugin provides a single object, `CycleTimeReport`, with the following
-property. All times are in milliseconds.
+methods:
 
-### `.average_loop_time`
+### `.setReportInterval(interval)`
 
-> A read-only by contract value, the average time of main loop lengths between
-> two reports.
+> Sets the length of time between reports to `interval` milliseconds.  The
+> default is `1000`, so it will report once per second.
 
-## Overrideable methods
+### `.report(mean_cycle_time)`
 
-### `cycleTimeReport()`
-
-> Reports the average loop time. By default, it does so over `Serial`, every
-> time when the report period is up.
+> Reports the average (mean) cycle time since the previous report.  This method
+> is called automatically, once per report interval (see above).  By default, it
+> does so over `Serial`.
 >
 > It can be overridden, to change how the report looks, or to make the report
 > toggleable, among other things.
 >
-> It takes no arguments, and returns nothing, but has access to
-> `CycleTimeReport.average_loop_time` above.
+> It takes no arguments, and returns nothing.
 
 ## Further reading
 

--- a/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.cpp
+++ b/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.cpp
@@ -26,43 +26,40 @@
 
 namespace kaleidoscope {
 namespace plugin {
-uint16_t CycleTimeReport::last_report_time_;
-uint32_t CycleTimeReport::loop_start_time_;
-uint32_t CycleTimeReport::average_loop_time;
-
-EventHandlerResult CycleTimeReport::onSetup() {
-  last_report_time_ = Runtime.millisAtCycleStart();
-  return EventHandlerResult::OK;
-}
 
 EventHandlerResult CycleTimeReport::beforeEachCycle() {
-  loop_start_time_ = micros();
+  // A counter storing the number of cycles since the last mean cycle time
+  // report was sent:
+  static uint16_t elapsed_cycles = 0;
+
+  // We only compute the mean cycle time once per report interval.
+  if (Runtime.hasTimeExpired(last_report_millis_, report_interval_)) {
+    uint32_t elapsed_time    = micros() - last_report_micros_;
+    uint32_t mean_cycle_time = elapsed_time / elapsed_cycles;
+
+    report(mean_cycle_time);
+
+    // Reset the cycle counter and timestamps.
+    elapsed_cycles = 0;
+    last_report_millis_ += report_interval_;
+    last_report_micros_ = micros();
+  }
+
+  // Increment the cycle counter unconditionally.
+  ++elapsed_cycles;
+
   return EventHandlerResult::OK;
 }
 
-EventHandlerResult CycleTimeReport::afterEachCycle() {
-  uint32_t loop_time = micros() - loop_start_time_;
-
-  if (average_loop_time)
-    average_loop_time = (average_loop_time + loop_time) / 2;
-  else
-    average_loop_time = loop_time;
-
-  if (Runtime.hasTimeExpired(last_report_time_, uint16_t(1000))) {
-    cycleTimeReport();
-
-    average_loop_time = 0;
-    last_report_time_ = Runtime.millisAtCycleStart();
-  }
-
-  return EventHandlerResult::OK;
+__attribute__((weak)) void CycleTimeReport::report(uint16_t mean_cycle_time) {
+  Focus.send(Focus.COMMENT,
+             F("mean cycle time:"),
+             mean_cycle_time,
+             F("µs"),
+             Focus.NEWLINE);
 }
 
 }  // namespace plugin
 }  // namespace kaleidoscope
-
-__attribute__((weak)) void cycleTimeReport(void) {
-  Focus.send(Focus.COMMENT, F("average loop time:"), CycleTimeReport.average_loop_time, Focus.NEWLINE);
-}
 
 kaleidoscope::plugin::CycleTimeReport CycleTimeReport;

--- a/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.h
+++ b/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.h
@@ -21,6 +21,15 @@
 
 #include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
 #include "kaleidoscope/plugin.h"                // for Plugin
+// -----------------------------------------------------------------------------
+// Deprecation warning messages
+#include "kaleidoscope_internal/deprecations.h"  // for DEPRECATED
+
+#define _DEPRECATED_MESSAGE_CYCLETIMEREPORT_AVG_TIME                      \
+  "The `CycleTimeReport.average_loop_time` variable is deprecated. See\n" \
+  "the current documentation for CycleTimeReport for details.\n"          \
+  "This variable will be removed after 2022-09-01."
+// -----------------------------------------------------------------------------
 
 namespace kaleidoscope {
 namespace plugin {
@@ -32,7 +41,10 @@ class CycleTimeReport : public kaleidoscope::Plugin {
   EventHandlerResult beforeEachCycle();
   EventHandlerResult afterEachCycle();
 
+#ifndef NDEPRECATED
+  DEPRECATED(CYCLETIMEREPORT_AVG_TIME)
   static uint32_t average_loop_time;
+#endif
 
  private:
   static uint16_t last_report_time_;

--- a/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.h
+++ b/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.h
@@ -35,8 +35,6 @@ namespace kaleidoscope {
 namespace plugin {
 class CycleTimeReport : public kaleidoscope::Plugin {
  public:
-  CycleTimeReport() {}
-
   EventHandlerResult onSetup();
   EventHandlerResult beforeEachCycle();
   EventHandlerResult afterEachCycle();

--- a/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.h
+++ b/plugins/Kaleidoscope-CycleTimeReport/src/kaleidoscope/plugin/CycleTimeReport.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <stdint.h>  // for uint32_t, uint16_t
+#include <stdint.h>  // for uint16_t, uint32_t
 
 #include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
 #include "kaleidoscope/plugin.h"                // for Plugin
@@ -35,23 +35,31 @@ namespace kaleidoscope {
 namespace plugin {
 class CycleTimeReport : public kaleidoscope::Plugin {
  public:
-  EventHandlerResult onSetup();
   EventHandlerResult beforeEachCycle();
-  EventHandlerResult afterEachCycle();
 
 #ifndef NDEPRECATED
   DEPRECATED(CYCLETIMEREPORT_AVG_TIME)
   static uint32_t average_loop_time;
 #endif
 
+  /// Set the length of time between reports (in milliseconds)
+  void setReportInterval(uint16_t interval) {
+    report_interval_ = interval;
+  }
+
+  /// Report the given mean cycle time in microseconds
+  void report(uint16_t mean_cycle_time);
+
  private:
-  static uint16_t last_report_time_;
-  static uint32_t loop_start_time_;
+  // Interval between reports, in milliseconds
+  uint16_t report_interval_ = 1000;
+
+  // Timestamps recording when the last report was sent
+  uint16_t last_report_millis_ = 0;
+  uint32_t last_report_micros_ = 0;
 };
 
 }  // namespace plugin
 }  // namespace kaleidoscope
-
-void cycleTimeReport(void);
 
 extern kaleidoscope::plugin::CycleTimeReport CycleTimeReport;


### PR DESCRIPTION
The existing CycleTimeReport plugin uses a weighted average, where each cycle gets twice the weight of the preceding one.  As a result, only the few most recent cycles have any significant impact on the reported average cycle time.  On a keyboard like the Model01, some cycles take much longer than others (in particular, when LED updates happen), but by design those long cycles occur rarely.  This means that CycleTimeReport is unlikely to reflect the impact of those longer cycles in any given report, usually underreporting the average, but occasionally reporting a much higher value.  Also, because it only counts the microseconds between its own `beforeEachCycle()` and `afterEachCycle()` handlers in the elapsed time for a given cycle, it entirely misses any time taken up by `afterEachCycle()` handlers that are registered after it in `KALEIDOSCOPE_INIT_PLUGINS()` (and `beforeEachCycle()` handlers registered before it, though there aren't many of these).

This new version instead computes an unweighted mean cycle time for each report interval, and only does its computation once per report, minimizing its own impact on the value reported.  It's possible to be even more efficient and accurate by reporting every 256 cycles instead of using a configurable interval, but then it makes sense to simply add the code to the main `loop()` function rather than using a plugin.

I think this new plugin is clearer, and does a better job of delivering what it advertises.  It also has a significantly smaller PROGMEM footprint (but it does use a few more bytes of RAM).  This is probably because the new computation method only requires one event handler, rather than two.

### Other minor changes

- I changed the default report function to include the units ("µs") in the output for clarity.
- I deprecated the plugin's public variable, but given the nature of the plugin, maybe it would be better to simply remove it.
- I moved the overridable function from the global namespace to make it a member function, and gave it a parameter to avoid storing the computed average.