### PR TITLE
driver::storage: Fix isSliceUninitialized() for AVREEPROM

### DIFF
--- a/src/kaleidoscope/driver/storage/AVREEPROM.h
+++ b/src/kaleidoscope/driver/storage/AVREEPROM.h
@@ -56,6 +56,14 @@ class AVREEPROM : public kaleidoscope::driver::storage::Base<_StorageProps> {
   void update(int idx, uint8_t val) {
     EEPROM.update(idx, val);
   }
+
+  bool isSliceUninitialized(uint16_t offset, uint16_t size) {
+    for (uint16_t o = offset; o < offset + size; o++) {
+      if (this->read(o) != _StorageProps::uninitialized_byte)
+        return false;
+    }
+    return true;
+  }
 };
 
 }  // namespace storage

--- a/src/kaleidoscope/driver/storage/Base.h
+++ b/src/kaleidoscope/driver/storage/Base.h
@@ -50,11 +50,7 @@ class Base {
   void update(int idx, uint8_t val) {}
 
   bool isSliceUninitialized(uint16_t offset, uint16_t size) {
-    for (uint16_t o = offset; o < offset + size; o++) {
-      if (read(o) != _StorageProps::uninitialized_byte)
-        return false;
-    }
-    return true;
+    return false;
   }
 
   const uint16_t length() {


### PR DESCRIPTION
`kaleidoscope::driver::storage::AVREEPROM` wasn't implementing its own `isSliceUninitialized()` method, and relied on the Base class to do so. However, since we're not using `virtual` methods, the base class was using `Base::read()` (which always returns 0) rather than `AVREEPROM::read()`, so `isSliceUninitialized()` always returned false.

To fix this, we implement the function in `AVREEPROM`, and let the default implementation in Base always return false.

The alternative - which would allow us to have `isSliceUnintialized()` in the base class - would be to make `read()` virtual, but that has quite severe PROGMEM and RAM implications, and we'd rather not have that for AVR.