### PR TITLE
PersistentLEDMode: Revert back to auto-saving

### DIFF
--- a/plugins/Kaleidoscope-PersistentLEDMode/src/kaleidoscope/plugin/PersistentLEDMode.h
+++ b/plugins/Kaleidoscope-PersistentLEDMode/src/kaleidoscope/plugin/PersistentLEDMode.h
@@ -31,18 +31,11 @@ class PersistentLEDMode : public kaleidoscope::Plugin {
   EventHandlerResult onSetup();
   EventHandlerResult onNameQuery();
   EventHandlerResult onLEDModeChange();
-  EventHandlerResult onFocusEvent(const char *command);
-
-  void setAutoSave(bool state);
-  bool getAutoSave() {
-    return settings_.auto_save == 1;
-  }
 
  private:
   static uint16_t settings_base_;
   static struct settings {
-    uint8_t auto_save : 1;
-    uint8_t default_mode_index : 7;
+    uint8_t default_mode_index;
   } settings_;
 };
 


### PR DESCRIPTION
This basically reverts 07dcf1dc9be5845ffaab5f409b67f8ccf5e9b5a2, returning the plugin to its original behaviour of persisting the current led mode.

We do this because we'll be using a new, different plugin to set the default led mode, to not conflate the two different functionalities.

I'll submit the new plugin later today. The main reason behind this is that we'll want a few additional things from said plugin, like setting a custom LED mode as default if EEPROM is uninitialized, which would be hard to squeeze into `PersistentLEDMode`. We also do not want the auto-save stuff for that plugin, at all, and having it off by default turned out to be challenging to implement, so a separate plugin for saving the default led mode, on explicit ask, makes more sense than trying to cram both functionalities into this one.