### PR TITLE
Model100: Add a magic combo to toggle between PROGMEM & EEPROM keymaps

### DIFF
--- a/examples/Devices/Keyboardio/Model100/Model100.ino
+++ b/examples/Devices/Keyboardio/Model100/Model100.ino
@@ -415,6 +415,17 @@ static void toggleKeyboardProtocol(uint8_t combo_index) {
 }
 
 /**
+ * Toggles between using the built-in keymap, and the EEPROM-stored one.
+ */
+static void toggleKeymapSource(uint8_t combo_index) {
+  if (Layer.getKey == Layer.getKeyFromPROGMEM) {
+    Layer.getKey = EEPROMKeymap.getKey;
+  } else {
+    Layer.getKey = Layer.getKeyFromPROGMEM;
+  }
+}
+
+/**
  *  This enters the hardware test mode
  */
 static void enterHardwareTestMode(uint8_t combo_index) {
@@ -430,7 +441,10 @@ USE_MAGIC_COMBOS({.action = toggleKeyboardProtocol,
                   .keys = {R3C6, R2C6, R3C7}},
                  {.action = enterHardwareTestMode,
                   // Left Fn + Prog + LED
-                  .keys = {R3C6, R0C0, R0C6}});
+                  .keys = {R3C6, R0C0, R0C6}},
+                 {.action = toggleKeymapSource,
+                  // Left Fn + Prog + Shift
+                  .keys = {R3C6, R0C0, R3C7}});
 
 // First, tell Kaleidoscope which plugins you want to use.
 // The order can be important. For example, LED effects are


### PR DESCRIPTION
Pressing Left Fn + Prog + Esc together will now toggle between PROGMEM & EEPROM keymaps.

Caveat: this assumes we have onlyCustom enabled. If we don't, it will still work, but toggling back will leave the keyboard in a state as if onlyCustom was enabled.

Fixes #1202.
