### PR TITLE
New plugin: FirmwareVersion

### DIFF
--- a/plugins/Kaleidoscope-FirmwareVersion/README.md
+++ b/plugins/Kaleidoscope-FirmwareVersion/README.md
@@ -1,0 +1,36 @@
+# FirmwareVersion
+
+Implements a new focus command - version - that simply prints the version set up
+at compile time.
+
+## Using the plugin
+
+To use the plugin, first define the version to be printed, then include the
+header, and activate the plugin.
+
+```c++
+#define KALEIDOSCOPE_FIRMWARE_VERSION "0.1.2"
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-FirmwareVersion.h>
+#include <Kaleidoscope-FocusSerial.h>
+
+KALEIDOSCOPE_INIT_PLUGINS(Focus,
+                          FirmwareVersion);
+
+void setup () {
+  Kaleidoscope.setup ();
+}
+```
+
+## Focus commands
+
+The plugin provides a single Focus command: `version`.
+
+### `version`
+
+> Prints the version configured at build time.
+
+## Dependencies
+
+* [Kaleidoscope-FocusSerial](Kaleidoscope-FocusSerial.md)

--- a/plugins/Kaleidoscope-FirmwareVersion/library.properties
+++ b/plugins/Kaleidoscope-FirmwareVersion/library.properties
@@ -1,0 +1,7 @@
+name=Kaleidoscope-FirmwareVersion
+version=0.0.0
+sentence=Provides a Focus command to print a preconfigured version
+maintainer=Kaleidoscope's Developers <jesse@keyboard.io>
+url=https://github.com/keyboardio/Kaleidoscope
+author=Keyboardio
+paragraph=

--- a/plugins/Kaleidoscope-FirmwareVersion/src/Kaleidoscope-FirmwareVersion.h
+++ b/plugins/Kaleidoscope-FirmwareVersion/src/Kaleidoscope-FirmwareVersion.h
@@ -1,0 +1,20 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-FirmwareVersion -- Provides a Focus command to print a version
+ * Copyright (C) 2022  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "kaleidoscope/plugin/FirmwareVersion.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-FirmwareVersion/src/kaleidoscope/plugin/FirmwareVersion.h
+++ b/plugins/Kaleidoscope-FirmwareVersion/src/kaleidoscope/plugin/FirmwareVersion.h
@@ -1,0 +1,54 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-FirmwareVersion -- Provides a Focus command to print a version
+ * Copyright (C) 2022  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifndef KALEIDOSCOPE_FIRMWARE_VERSION
+#define KALEIDOSCOPE_FIRMWARE_VERSION "0.0.0"
+#endif
+
+#include <Arduino.h>                            // for PSTR, F, __FlashStringHelper, strcmp_P
+#include "Kaleidoscope-FocusSerial.h"           // for Focus, FocusSerial
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
+
+namespace kaleidoscope {
+namespace plugin {
+
+class FirmwareVersion : public Plugin {
+ public:
+  EventHandlerResult onFocusEvent(const char *command) {
+    if (::Focus.handleHelp(command, PSTR("version")))
+      return EventHandlerResult::OK;
+
+    if (strcmp_P(command, PSTR("version")) != 0)
+      return EventHandlerResult::OK;
+
+#ifdef KALEIDOSCOPE_FIRMWARE_VERSION
+    ::Focus.send(F(KALEIDOSCOPE_FIRMWARE_VERSION));
+#else
+    ::Focus.send(F("0.0.0"));
+#endif
+
+    return EventHandlerResult::OK;
+  }
+};
+
+}  // namespace plugin
+}  // namespace kaleidoscope
+
+kaleidoscope::plugin::FirmwareVersion FirmwareVersion;


### PR DESCRIPTION
This simple plugin does nothing more than provide a `version` focus command, which will print the firmware version configured at build-time (defaulting to "0.0.0").

This is a header-only plugin, so that Arduino compiles it in the same compilation unit as the main sketch, allowing us to set the version from the sketch, if so desired.
