### PR TITLE
hardware: Fix the bootloader props on a number of devices

### DIFF
--- a/docs/api-reference/device-apis.md
+++ b/docs/api-reference/device-apis.md
@@ -175,7 +175,7 @@ struct KeypadProps : kaleidoscope::device::ATmega32U4KeyboardProps {
   };
 
   typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner;
-  typedef kaleidoscope::driver::bootloader::avr::Caterina BootLoader;
+  typedef kaleidoscope::driver::bootloader::avr::Caterina Bootloader;
   static constexpr const char *short_name = "imaginary-keypad";
 };
 

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/Raise.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/Raise.h
@@ -170,7 +170,7 @@ struct RaiseProps : kaleidoscope::device::BaseProps {
   typedef RaiseKeyScanner KeyScanner;
   typedef RaiseStorageProps StorageProps;
   typedef kaleidoscope::driver::storage::Flash<StorageProps> Storage;
-  typedef kaleidoscope::driver::bootloader::samd::Bossac BootLoader;
+  typedef kaleidoscope::driver::bootloader::samd::Bossac Bootloader;
 
   typedef RaiseSideFlasherProps SideFlasherProps;
   typedef kaleidoscope::util::flasher::KeyboardioI2CBootloader<SideFlasherProps> SideFlasher;

--- a/plugins/Kaleidoscope-Hardware-GD32-Eval/src/kaleidoscope/device/gd32/Eval.h
+++ b/plugins/Kaleidoscope-Hardware-GD32-Eval/src/kaleidoscope/device/gd32/Eval.h
@@ -37,7 +37,7 @@ struct EvalProps : kaleidoscope::device::BaseProps {
   typedef kaleidoscope::driver::hid::KeyboardioProps HIDProps;
   typedef kaleidoscope::driver::hid::Keyboardio<HIDProps> HID;
 
-  typedef kaleidoscope::driver::bootloader::gd32::Base BootLoader;
+  typedef kaleidoscope::driver::bootloader::gd32::Base Bootloader;
   typedef EvalStorageProps StorageProps;
   typedef kaleidoscope::driver::storage::GD32Flash<StorageProps> Storage;
 

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Atreus/src/kaleidoscope/device/keyboardio/Atreus2.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Atreus/src/kaleidoscope/device/keyboardio/Atreus2.h
@@ -45,7 +45,7 @@ struct AtreusProps : kaleidoscope::device::ATmega32U4KeyboardProps {
   };
 
   typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner;
-  typedef kaleidoscope::driver::bootloader::avr::Caterina BootLoader;
+  typedef kaleidoscope::driver::bootloader::avr::Caterina Bootloader;
   static constexpr const char *short_name = "atreus";
 };
 

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Imago/src/kaleidoscope/device/keyboardio/Imago.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Imago/src/kaleidoscope/device/keyboardio/Imago.h
@@ -99,7 +99,7 @@ struct ImagoProps : kaleidoscope::device::ATmega32U4KeyboardProps {
   typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner;
   typedef ImagoLEDDriverProps LEDDriverProps;
   typedef ImagoLEDDriver LEDDriver;
-  typedef kaleidoscope::driver::bootloader::avr::Caterina BootLoader;
+  typedef kaleidoscope::driver::bootloader::avr::Caterina Bootloader;
   static constexpr const char *short_name = "imago";
 };
 

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/kaleidoscope/device/keyboardio/Model01.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src/kaleidoscope/device/keyboardio/Model01.h
@@ -126,7 +126,7 @@ struct Model01Props : public kaleidoscope::device::ATmega32U4KeyboardProps {
   typedef Model01LEDDriver LEDDriver;
   typedef Model01KeyScannerProps KeyScannerProps;
   typedef Model01KeyScanner KeyScanner;
-  typedef kaleidoscope::driver::bootloader::avr::Caterina BootLoader;
+  typedef kaleidoscope::driver::bootloader::avr::Caterina Bootloader;
   static constexpr const char *short_name = "kbio01";
 };
 

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.h
@@ -141,7 +141,7 @@ struct Model100Props : public kaleidoscope::device::BaseProps {
   typedef Model100StorageProps StorageProps;
   typedef kaleidoscope::driver::storage::GD32Flash<StorageProps> Storage;
 
-  typedef kaleidoscope::driver::bootloader::gd32::Base BootLoader;
+  typedef kaleidoscope::driver::bootloader::gd32::Base Bootloader;
   static constexpr const char *short_name = "kbio100";
 
   typedef kaleidoscope::driver::mcu::GD32Props MCUProps;

--- a/plugins/Kaleidoscope-Hardware-SOFTHRUF-Splitography/src/kaleidoscope/device/softhruf/Splitography.h
+++ b/plugins/Kaleidoscope-Hardware-SOFTHRUF-Splitography/src/kaleidoscope/device/softhruf/Splitography.h
@@ -53,7 +53,7 @@ struct SplitographyProps : kaleidoscope::device::ATmega32U4KeyboardProps {
 #endif  // KALEIDOSCOPE_VIRTUAL_BUILD
   };
   typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner;
-  typedef kaleidoscope::driver::bootloader::avr::FLIP BootLoader;
+  typedef kaleidoscope::driver::bootloader::avr::FLIP Bootloader;
   static constexpr const char *short_name = "splitography";
 };
 

--- a/plugins/Kaleidoscope-Hardware-Technomancy-Atreus/src/kaleidoscope/device/technomancy/Atreus.h
+++ b/plugins/Kaleidoscope-Hardware-Technomancy-Atreus/src/kaleidoscope/device/technomancy/Atreus.h
@@ -67,9 +67,9 @@ struct AtreusProps : kaleidoscope::device::ATmega32U4KeyboardProps {
   typedef kaleidoscope::driver::keyscanner::ATmega<KeyScannerProps> KeyScanner;
 
 #ifdef KALEIDOSCOPE_HARDWARE_ATREUS_PINOUT_LEGACY_TEENSY2
-  typedef kaleidoscope::driver::bootloader::avr::HalfKay BootLoader;
+  typedef kaleidoscope::driver::bootloader::avr::HalfKay Bootloader;
 #else
-  typedef kaleidoscope::driver::bootloader::avr::Caterina BootLoader;
+  typedef kaleidoscope::driver::bootloader::avr::Caterina Bootloader;
 #endif
   static constexpr const char *short_name = "atreus";
 };

--- a/src/kaleidoscope/device/virtual/Virtual.h
+++ b/src/kaleidoscope/device/virtual/Virtual.h
@@ -131,7 +131,7 @@ struct VirtualProps : public kaleidoscope::DeviceProps {
   typedef kaleidoscope::driver::mcu::None MCU;
 
   typedef kaleidoscope::driver::bootloader::None
-    BootLoader;
+    Bootloader;
 
   typedef typename kaleidoscope::DeviceProps::StorageProps
     StorageProps;


### PR DESCRIPTION
A number of devices declared the bootloader in their device properties as `BootLoader`, while the base class, and anything using it, was looking for `Bootloader`. This resulted in these devices using the default, dummy bootloader, rather than the one we intended to set.

This patch corrects that, and everything's using `Bootloader` now, including the documentation.

In practice, this means that `Kaleidoscope.device().rebootBootloader()` will now function properly for the affected devices. Without this patch, that function is a no-op, unless it is overridden at the device level, which most of the affected keyboards do not do.
