### PR TITLE
plugins/Colormap: Make DefaultColormap.install() public

### DIFF
--- a/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/DefaultColormap.h
+++ b/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/DefaultColormap.h
@@ -85,11 +85,9 @@ extern uint8_t colormap_layers;
 class DefaultColormap : public Plugin {
  public:
   static void setup();
+  static void install();
 
   EventHandlerResult onFocusEvent(const char *command);
-
- private:
-  static void install();
 };
 
 }  // namespace plugin


### PR DESCRIPTION
It was always intended to be public - it is even documented as such! -, but was mistakenly left private.