### PR TITLE
My take on a Focus refactor

### DIFF
--- a/examples/Features/FocusSerial/FocusSerial.ino
+++ b/examples/Features/FocusSerial/FocusSerial.ino
@@ -50,7 +50,7 @@ class FocusTestCommand : public Plugin {
     if (::Focus.inputMatchesHelp(command))
       return ::Focus.printHelp(PSTR("test"));
 
-    if (strcmp_P(command, cmd) == 0) {
+    if (::Focus.inputMatchesCommand(command, cmd)) {
       ::Focus.send(F("ok!"));
       return EventHandlerResult::EVENT_CONSUMED;
     }

--- a/examples/Features/FocusSerial/FocusSerial.ino
+++ b/examples/Features/FocusSerial/FocusSerial.ino
@@ -47,7 +47,7 @@ class FocusTestCommand : public Plugin {
   EventHandlerResult onFocusEvent(const char *command) {
     const char *cmd = PSTR("test");
 
-    if (::Focus.isHelp(command))
+    if (::Focus.inputMatchesHelp(command))
       return ::Focus.printHelp(PSTR("test"));
 
     if (strcmp_P(command, cmd) == 0) {
@@ -64,7 +64,7 @@ class FocusHelpCommand : public Plugin {
   FocusHelpCommand() {}
 
   EventHandlerResult onFocusEvent(const char *command) {
-    if (::Focus.isHelp(command))
+    if (::Focus.inputMatchesHelp(command))
       return ::Focus.printHelp(PSTR("help"));
 
     return EventHandlerResult::OK;

--- a/examples/Features/FocusSerial/FocusSerial.ino
+++ b/examples/Features/FocusSerial/FocusSerial.ino
@@ -47,8 +47,8 @@ class FocusTestCommand : public Plugin {
   EventHandlerResult onFocusEvent(const char *command) {
     const char *cmd = PSTR("test");
 
-    if (::Focus.handleHelp(command, cmd))
-      return EventHandlerResult::OK;
+    if (::Focus.isHelp(command))
+      return ::Focus.printHelp(PSTR("test"));
 
     if (strcmp_P(command, cmd) == 0) {
       ::Focus.send(F("ok!"));
@@ -64,7 +64,8 @@ class FocusHelpCommand : public Plugin {
   FocusHelpCommand() {}
 
   EventHandlerResult onFocusEvent(const char *command) {
-    ::Focus.handleHelp(command, PSTR("help"));
+    if (::Focus.isHelp(command))
+      return ::Focus.printHelp(PSTR("help"));
 
     return EventHandlerResult::OK;
   }

--- a/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
+++ b/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
@@ -58,7 +58,7 @@ EventHandlerResult AutoShiftConfig::onFocusEvent(const char *command) {
   const char *cmd_timeout    = PSTR("autoshift.timeout");
   const char *cmd_categories = PSTR("autoshift.categories");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_enabled, cmd_timeout, cmd_categories);
 
   if (strcmp_P(command, cmd_enabled) == 0)

--- a/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
+++ b/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
@@ -54,8 +54,8 @@ EventHandlerResult AutoShiftConfig::onFocusEvent(const char *command) {
     CATEGORIES,
   } subCommand;
 
-  const char *cmd_enabled = PSTR("autoshift.enabled");
-  const char *cmd_timeout = PSTR("autoshift.timeout");
+  const char *cmd_enabled    = PSTR("autoshift.enabled");
+  const char *cmd_timeout    = PSTR("autoshift.timeout");
   const char *cmd_categories = PSTR("autoshift.categories");
 
   if (::Focus.isHelp(command))

--- a/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
+++ b/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
@@ -17,7 +17,7 @@
 
 #include "kaleidoscope/plugin/AutoShift.h"  // IWYU pragma: associated
 
-#include <Arduino.h>                       // for PSTR, strcmp_P, strncmp_P
+#include <Arduino.h>                       // for PSTR
 #include <Kaleidoscope-EEPROM-Settings.h>  // for EEPROMSettings
 #include <Kaleidoscope-FocusSerial.h>      // for Focus, FocusSerial
 #include <stdint.h>                        // for uint8_t, uint16_t
@@ -61,11 +61,11 @@ EventHandlerResult AutoShiftConfig::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_enabled, cmd_timeout, cmd_categories);
 
-  if (strcmp_P(command, cmd_enabled) == 0)
+  if (::Focus.inputMatchesCommand(command, cmd_enabled))
     subCommand = ENABLED;
-  else if (strcmp_P(command, cmd_timeout) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_timeout))
     subCommand = TIMEOUT;
-  else if (strcmp_P(command, cmd_categories) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_categories))
     subCommand = CATEGORIES;
   else
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
+++ b/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
@@ -54,10 +54,10 @@ EventHandlerResult AutoShiftConfig::onFocusEvent(const char *command) {
     CATEGORIES,
   } subCommand;
 
-  if (::Focus.handleHelp(command, PSTR("autoshift.enabled\r\n"
-                                       "autoshift.timeout\r\n"
-                                       "autoshift.categories")))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(PSTR("autoshift.enabled"),
+                             PSTR("autoshift.timeout"),
+                             PSTR("autoshift.categories"));
 
   if (strncmp_P(command, PSTR("autoshift."), 10) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
+++ b/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
@@ -54,18 +54,18 @@ EventHandlerResult AutoShiftConfig::onFocusEvent(const char *command) {
     CATEGORIES,
   } subCommand;
 
-  if (::Focus.isHelp(command))
-    return ::Focus.printHelp(PSTR("autoshift.enabled"),
-                             PSTR("autoshift.timeout"),
-                             PSTR("autoshift.categories"));
+  const char *cmd_enabled = PSTR("autoshift.enabled");
+  const char *cmd_timeout = PSTR("autoshift.timeout");
+  const char *cmd_categories = PSTR("autoshift.categories");
 
-  if (strncmp_P(command, PSTR("autoshift."), 10) != 0)
-    return EventHandlerResult::OK;
-  if (strcmp_P(command + 10, PSTR("enabled")) == 0)
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(cmd_enabled, cmd_timeout, cmd_categories);
+
+  if (strcmp_P(command, cmd_enabled) == 0)
     subCommand = ENABLED;
-  else if (strcmp_P(command + 10, PSTR("timeout")) == 0)
+  else if (strcmp_P(command, cmd_timeout) == 0)
     subCommand = TIMEOUT;
-  else if (strcmp_P(command + 10, PSTR("categories")) == 0)
+  else if (strcmp_P(command, cmd_categories) == 0)
     subCommand = CATEGORIES;
   else
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/DefaultColormap.cpp
+++ b/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/DefaultColormap.cpp
@@ -81,7 +81,7 @@ EventHandlerResult DefaultColormap::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd);
 
-  if (strcmp_P(command, cmd) != 0)
+  if (!::Focus.inputMatchesCommand(command, cmd))
     return EventHandlerResult::OK;
 
   install();

--- a/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/DefaultColormap.cpp
+++ b/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/DefaultColormap.cpp
@@ -78,7 +78,7 @@ EventHandlerResult DefaultColormap::onFocusEvent(const char *command) {
 
   const char *cmd = PSTR("colormap.install");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd);
 
   if (strcmp_P(command, cmd) != 0)

--- a/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/DefaultColormap.cpp
+++ b/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/DefaultColormap.cpp
@@ -78,8 +78,8 @@ EventHandlerResult DefaultColormap::onFocusEvent(const char *command) {
 
   const char *cmd = PSTR("colormap.install");
 
-  if (::Focus.handleHelp(command, cmd))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(cmd);
 
   if (strcmp_P(command, cmd) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-DefaultLEDModeConfig/src/kaleidoscope/plugin/DefaultLEDModeConfig.cpp
+++ b/plugins/Kaleidoscope-DefaultLEDModeConfig/src/kaleidoscope/plugin/DefaultLEDModeConfig.cpp
@@ -17,7 +17,7 @@
 
 #include "kaleidoscope/plugin/DefaultLEDModeConfig.h"
 
-#include <Arduino.h>                       // for PSTR, strcmp_P, F, __FlashStringHelper
+#include <Arduino.h>                       // for PSTR, F, __FlashStringHelper
 #include <Kaleidoscope-EEPROM-Settings.h>  // for EEPROMSettings
 #include <Kaleidoscope-FocusSerial.h>      // for Focus, FocusSerial
 #include <stdint.h>                        // for uint8_t, uint16_t
@@ -54,7 +54,7 @@ EventHandlerResult DefaultLEDModeConfig::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd);
 
-  if (strcmp_P(command, cmd) != 0)
+  if (!::Focus.inputMatchesCommand(command, cmd))
     return EventHandlerResult::OK;
 
   if (::Focus.isEOL()) {

--- a/plugins/Kaleidoscope-DefaultLEDModeConfig/src/kaleidoscope/plugin/DefaultLEDModeConfig.cpp
+++ b/plugins/Kaleidoscope-DefaultLEDModeConfig/src/kaleidoscope/plugin/DefaultLEDModeConfig.cpp
@@ -51,8 +51,8 @@ EventHandlerResult DefaultLEDModeConfig::onSetup() {
 EventHandlerResult DefaultLEDModeConfig::onFocusEvent(const char *command) {
   const char *cmd = PSTR("led_mode.default");
 
-  if (::Focus.handleHelp(command, cmd))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(cmd);
 
   if (strcmp_P(command, cmd) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-DefaultLEDModeConfig/src/kaleidoscope/plugin/DefaultLEDModeConfig.cpp
+++ b/plugins/Kaleidoscope-DefaultLEDModeConfig/src/kaleidoscope/plugin/DefaultLEDModeConfig.cpp
@@ -51,7 +51,7 @@ EventHandlerResult DefaultLEDModeConfig::onSetup() {
 EventHandlerResult DefaultLEDModeConfig::onFocusEvent(const char *command) {
   const char *cmd = PSTR("led_mode.default");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd);
 
   if (strcmp_P(command, cmd) != 0)

--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -215,7 +215,7 @@ EventHandlerResult DynamicMacros::onNameQuery() {
 }
 
 EventHandlerResult DynamicMacros::onFocusEvent(const char *command) {
-  const char *cmd_map = PSTR("macros.map");
+  const char *cmd_map     = PSTR("macros.map");
   const char *cmd_trigger = PSTR("macros.trigger");
 
   if (::Focus.isHelp(command))

--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -215,13 +215,13 @@ EventHandlerResult DynamicMacros::onNameQuery() {
 }
 
 EventHandlerResult DynamicMacros::onFocusEvent(const char *command) {
+  const char *cmd_map = PSTR("macros.map");
+  const char *cmd_trigger = PSTR("macros.trigger");
+
   if (::Focus.isHelp(command))
-    return ::Focus.printHelp(PSTR("macros.map"), PSTR("macros.trigger"));
+    return ::Focus.printHelp(cmd_map, cmd_trigger);
 
-  if (strncmp_P(command, PSTR("macros."), 7) != 0)
-    return EventHandlerResult::OK;
-
-  if (strcmp_P(command + 7, PSTR("map")) == 0) {
+  if (strcmp_P(command, cmd_map) == 0) {
     if (::Focus.isEOL()) {
       for (uint16_t i = 0; i < storage_size_; i++) {
         uint8_t b;
@@ -240,15 +240,16 @@ EventHandlerResult DynamicMacros::onFocusEvent(const char *command) {
       Runtime.storage().commit();
       macro_count_ = updateDynamicMacroCache();
     }
-  }
-
-  if (strcmp_P(command + 7, PSTR("trigger")) == 0) {
+    return EventHandlerResult::EVENT_CONSUMED;
+  } else if (strcmp_P(command, cmd_trigger) == 0) {
     uint8_t id = 0;
     ::Focus.read(id);
     play(id);
+
+    return EventHandlerResult::EVENT_CONSUMED;
   }
 
-  return EventHandlerResult::EVENT_CONSUMED;
+  return EventHandlerResult::OK;
 }
 
 // public

--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -215,8 +215,8 @@ EventHandlerResult DynamicMacros::onNameQuery() {
 }
 
 EventHandlerResult DynamicMacros::onFocusEvent(const char *command) {
-  if (::Focus.handleHelp(command, PSTR("macros.map\r\nmacros.trigger")))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(PSTR("macros.map"), PSTR("macros.trigger"));
 
   if (strncmp_P(command, PSTR("macros."), 7) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -16,7 +16,7 @@
 
 #include "kaleidoscope/plugin/DynamicMacros.h"
 
-#include <Arduino.h>                   // for delay, PSTR, strcmp_P, F, __FlashStri...
+#include <Arduino.h>                   // for delay, PSTR, F, __FlashStri...
 #include <Kaleidoscope-FocusSerial.h>  // for Focus, FocusSerial
 #include <Kaleidoscope-Ranges.h>       // for DYNAMIC_MACRO_FIRST, DYNAMIC_MACRO_LAST
 
@@ -221,7 +221,7 @@ EventHandlerResult DynamicMacros::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_map, cmd_trigger);
 
-  if (strcmp_P(command, cmd_map) == 0) {
+  if (::Focus.inputMatchesCommand(command, cmd_map)) {
     if (::Focus.isEOL()) {
       for (uint16_t i = 0; i < storage_size_; i++) {
         uint8_t b;
@@ -241,7 +241,7 @@ EventHandlerResult DynamicMacros::onFocusEvent(const char *command) {
       macro_count_ = updateDynamicMacroCache();
     }
     return EventHandlerResult::EVENT_CONSUMED;
-  } else if (strcmp_P(command, cmd_trigger) == 0) {
+  } else if (::Focus.inputMatchesCommand(command, cmd_trigger)) {
     uint8_t id = 0;
     ::Focus.read(id);
     play(id);

--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -218,7 +218,7 @@ EventHandlerResult DynamicMacros::onFocusEvent(const char *command) {
   const char *cmd_map     = PSTR("macros.map");
   const char *cmd_trigger = PSTR("macros.trigger");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_map, cmd_trigger);
 
   if (strcmp_P(command, cmd_map) == 0) {

--- a/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
+++ b/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
@@ -94,8 +94,8 @@ EventHandlerResult DynamicTapDance::onNameQuery() {
 }
 
 EventHandlerResult DynamicTapDance::onFocusEvent(const char *command) {
-  if (::Focus.handleHelp(command, PSTR("tapdance.map")))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp("tapdance.map");
 
   if (strncmp_P(command, PSTR("tapdance."), 9) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
+++ b/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
@@ -17,7 +17,7 @@
 
 #include "kaleidoscope/plugin/DynamicTapDance.h"
 
-#include <Arduino.h>                       // for PSTR, F, __FlashStringHelper, strcmp_P
+#include <Arduino.h>                       // for PSTR, F, __FlashStringHelper
 #include <Kaleidoscope-EEPROM-Settings.h>  // for EEPROMSettings
 #include <Kaleidoscope-FocusSerial.h>      // for Focus, FocusSerial
 #include <stdint.h>                        // for uint16_t, uint8_t
@@ -99,7 +99,7 @@ EventHandlerResult DynamicTapDance::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_map);
 
-  if (strcmp_P(command, cmd_map) != 0)
+  if (!::Focus.inputMatchesCommand(command, cmd_map))
     return EventHandlerResult::OK;
 
   if (::Focus.isEOL()) {

--- a/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
+++ b/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
@@ -96,7 +96,7 @@ EventHandlerResult DynamicTapDance::onNameQuery() {
 EventHandlerResult DynamicTapDance::onFocusEvent(const char *command) {
   const char *cmd_map = PSTR("tapdance.map");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_map);
 
   if (strcmp_P(command, cmd_map) != 0)

--- a/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
+++ b/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
@@ -94,32 +94,32 @@ EventHandlerResult DynamicTapDance::onNameQuery() {
 }
 
 EventHandlerResult DynamicTapDance::onFocusEvent(const char *command) {
-  if (::Focus.isHelp(command))
-    return ::Focus.printHelp("tapdance.map");
+  const char *cmd_map = PSTR("tapdance.map");
 
-  if (strncmp_P(command, PSTR("tapdance."), 9) != 0)
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(cmd_map);
+
+  if (strcmp_P(command, cmd_map) != 0)
     return EventHandlerResult::OK;
 
-  if (strcmp_P(command + 9, PSTR("map")) == 0) {
-    if (::Focus.isEOL()) {
-      for (uint16_t i = 0; i < storage_size_; i += 2) {
-        Key k;
-        Runtime.storage().get(storage_base_ + i, k);
-        ::Focus.send(k);
-      }
-    } else {
-      uint16_t pos = 0;
-
-      while (!::Focus.isEOL()) {
-        Key k;
-        ::Focus.read(k);
-
-        Runtime.storage().put(storage_base_ + pos, k);
-        pos += 2;
-      }
-      Runtime.storage().commit();
-      updateDynamicTapDanceCache();
+  if (::Focus.isEOL()) {
+    for (uint16_t i = 0; i < storage_size_; i += 2) {
+      Key k;
+      Runtime.storage().get(storage_base_ + i, k);
+      ::Focus.send(k);
     }
+  } else {
+    uint16_t pos = 0;
+
+    while (!::Focus.isEOL()) {
+      Key k;
+      ::Focus.read(k);
+
+      Runtime.storage().put(storage_base_ + pos, k);
+      pos += 2;
+    }
+    Runtime.storage().commit();
+    updateDynamicTapDanceCache();
   }
 
   return EventHandlerResult::EVENT_CONSUMED;

--- a/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
@@ -109,7 +109,7 @@ EventHandlerResult EEPROMKeymapProgrammer::onKeyEvent(KeyEvent &event) {
 EventHandlerResult EEPROMKeymapProgrammer::onFocusEvent(const char *command) {
   const char *cmd = PSTR("keymap.toggleProgrammer");
 
-  if (::Focus.isHelp(command, cmd))
+  if (::Focus.isHelp(command))
     return ::Focus.printHelp(cmd);
 
   if (strcmp_P(command, cmd) != 0)

--- a/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
@@ -109,7 +109,7 @@ EventHandlerResult EEPROMKeymapProgrammer::onKeyEvent(KeyEvent &event) {
 EventHandlerResult EEPROMKeymapProgrammer::onFocusEvent(const char *command) {
   const char *cmd = PSTR("keymap.toggleProgrammer");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd);
 
   if (strcmp_P(command, cmd) != 0)

--- a/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
@@ -17,7 +17,7 @@
 
 #include "kaleidoscope/plugin/EEPROM-Keymap-Programmer.h"
 
-#include <Arduino.h>                     // for PSTR, strcmp_P
+#include <Arduino.h>                     // for PSTR
 #include <Kaleidoscope-EEPROM-Keymap.h>  // for EEPROMKeymap
 #include <Kaleidoscope-FocusSerial.h>    // for Focus, FocusSerial
 #include <stdint.h>                      // for uint16_t, uint8_t
@@ -112,7 +112,7 @@ EventHandlerResult EEPROMKeymapProgrammer::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd);
 
-  if (strcmp_P(command, cmd) != 0)
+  if (!::Focus.inputMatchesCommand(command, cmd))
     return EventHandlerResult::OK;
 
   if (state_ == INACTIVE)

--- a/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap-Programmer/src/kaleidoscope/plugin/EEPROM-Keymap-Programmer.cpp
@@ -109,8 +109,8 @@ EventHandlerResult EEPROMKeymapProgrammer::onKeyEvent(KeyEvent &event) {
 EventHandlerResult EEPROMKeymapProgrammer::onFocusEvent(const char *command) {
   const char *cmd = PSTR("keymap.toggleProgrammer");
 
-  if (::Focus.handleHelp(command, cmd))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command, cmd))
+    return ::Focus.printHelp(cmd);
 
   if (strcmp_P(command, cmd) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -102,8 +102,9 @@ void EEPROMKeymap::dumpKeymap(uint8_t layers, Key (*getkey)(uint8_t, KeyAddr)) {
 }
 
 EventHandlerResult EEPROMKeymap::onFocusEvent(const char *command) {
-  if (::Focus.handleHelp(command, PSTR("keymap.custom\r\nkeymap.default\r\nkeymap.onlyCustom")))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(PSTR("keymap.custom"), PSTR("keymap.default"),
+                             PSTR("keymap.onlyCustom"));
 
   if (strncmp_P(command, PSTR("keymap."), 7) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -102,14 +102,14 @@ void EEPROMKeymap::dumpKeymap(uint8_t layers, Key (*getkey)(uint8_t, KeyAddr)) {
 }
 
 EventHandlerResult EEPROMKeymap::onFocusEvent(const char *command) {
+  const char *cmd_custom = PSTR("keymap.custom");
+  const char *cmd_default = PSTR("keymap.default");
+  const char *cmd_onlyCustom = PSTR("keymap.onlyCustom");
+
   if (::Focus.isHelp(command))
-    return ::Focus.printHelp(PSTR("keymap.custom"), PSTR("keymap.default"),
-                             PSTR("keymap.onlyCustom"));
+    return ::Focus.printHelp(cmd_custom, cmd_default, cmd_onlyCustom);
 
-  if (strncmp_P(command, PSTR("keymap."), 7) != 0)
-    return EventHandlerResult::OK;
-
-  if (strcmp_P(command + 7, PSTR("onlyCustom")) == 0) {
+  if (strcmp_P(command, cmd_onlyCustom) == 0) {
     if (::Focus.isEOL()) {
       ::Focus.send((uint8_t)::EEPROMSettings.ignoreHardcodedLayers());
     } else {
@@ -129,7 +129,7 @@ EventHandlerResult EEPROMKeymap::onFocusEvent(const char *command) {
     return EventHandlerResult::EVENT_CONSUMED;
   }
 
-  if (strcmp_P(command + 7, PSTR("default")) == 0) {
+  if (strcmp_P(command, cmd_default) == 0) {
     // By using a cast to the appropriate function type,
     // tell the compiler which overload of getKeyFromPROGMEM
     // we actully want.
@@ -139,7 +139,7 @@ EventHandlerResult EEPROMKeymap::onFocusEvent(const char *command) {
     return EventHandlerResult::EVENT_CONSUMED;
   }
 
-  if (strcmp_P(command + 7, PSTR("custom")) != 0)
+  if (strcmp_P(command, cmd_custom) != 0)
     return EventHandlerResult::OK;
 
   if (::Focus.isEOL()) {

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -102,8 +102,8 @@ void EEPROMKeymap::dumpKeymap(uint8_t layers, Key (*getkey)(uint8_t, KeyAddr)) {
 }
 
 EventHandlerResult EEPROMKeymap::onFocusEvent(const char *command) {
-  const char *cmd_custom = PSTR("keymap.custom");
-  const char *cmd_default = PSTR("keymap.default");
+  const char *cmd_custom     = PSTR("keymap.custom");
+  const char *cmd_default    = PSTR("keymap.default");
   const char *cmd_onlyCustom = PSTR("keymap.onlyCustom");
 
   if (::Focus.isHelp(command))

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -106,7 +106,7 @@ EventHandlerResult EEPROMKeymap::onFocusEvent(const char *command) {
   const char *cmd_default    = PSTR("keymap.default");
   const char *cmd_onlyCustom = PSTR("keymap.onlyCustom");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_custom, cmd_default, cmd_onlyCustom);
 
   if (strcmp_P(command, cmd_onlyCustom) == 0) {

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -17,7 +17,7 @@
 
 #include "kaleidoscope/plugin/EEPROM-Keymap.h"
 
-#include <Arduino.h>                       // for PSTR, strcmp_P, F, __FlashStringHelper
+#include <Arduino.h>                       // for PSTR, F, __FlashStringHelper
 #include <Kaleidoscope-EEPROM-Settings.h>  // for EEPROMSettings
 #include <Kaleidoscope-FocusSerial.h>      // for Focus, FocusSerial
 #include <stdint.h>                        // for uint8_t, uint16_t
@@ -109,7 +109,7 @@ EventHandlerResult EEPROMKeymap::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_custom, cmd_default, cmd_onlyCustom);
 
-  if (strcmp_P(command, cmd_onlyCustom) == 0) {
+  if (::Focus.inputMatchesCommand(command, cmd_onlyCustom)) {
     if (::Focus.isEOL()) {
       ::Focus.send((uint8_t)::EEPROMSettings.ignoreHardcodedLayers());
     } else {
@@ -129,7 +129,7 @@ EventHandlerResult EEPROMKeymap::onFocusEvent(const char *command) {
     return EventHandlerResult::EVENT_CONSUMED;
   }
 
-  if (strcmp_P(command, cmd_default) == 0) {
+  if (::Focus.inputMatchesCommand(command, cmd_default)) {
     // By using a cast to the appropriate function type,
     // tell the compiler which overload of getKeyFromPROGMEM
     // we actully want.
@@ -139,7 +139,7 @@ EventHandlerResult EEPROMKeymap::onFocusEvent(const char *command) {
     return EventHandlerResult::EVENT_CONSUMED;
   }
 
-  if (strcmp_P(command, cmd_custom) != 0)
+  if (!::Focus.inputMatchesCommand(command, cmd_custom))
     return EventHandlerResult::OK;
 
   if (::Focus.isEOL()) {

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -169,7 +169,7 @@ EventHandlerResult FocusSettingsCommand::onFocusEvent(const char *command) {
   const char *cmd_version      = PSTR("settings.version");
   const char *cmd_crc          = PSTR("settings.crc");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_defaultLayer, cmd_isValid, cmd_version, cmd_crc);
 
   if (strcmp_P(command, cmd_defaultLayer) == 0)
@@ -219,7 +219,7 @@ EventHandlerResult FocusEEPROMCommand::onFocusEvent(const char *command) {
   const char *cmd_free     = PSTR("eeprom.free");
   const char *cmd_erase    = PSTR("eeprom.erase");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_contents, cmd_free, cmd_erase);
 
   if (strcmp_P(command, cmd_contents) == 0)

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -164,22 +164,21 @@ EventHandlerResult FocusSettingsCommand::onFocusEvent(const char *command) {
     GET_CRC,
   } sub_command;
 
+  const char *cmd_defaultLayer = PSTR("settings.defaultLayer");
+  const char *cmd_isValid = PSTR("settings.valid?");
+  const char *cmd_version = PSTR("settings.version");
+  const char *cmd_crc = PSTR("settings.crc");
+
   if (::Focus.isHelp(command))
-    return ::Focus.printHelp(PSTR("settings.defaultLayer"),
-                             PSTR("settings.valid?"),
-                             PSTR("settings.version"),
-                             PSTR("settings.crc"));
+    return ::Focus.printHelp(cmd_defaultLayer, cmd_isValid, cmd_version, cmd_crc);
 
-  if (strncmp_P(command, PSTR("settings."), 9) != 0)
-    return EventHandlerResult::OK;
-
-  if (strcmp_P(command + 9, PSTR("defaultLayer")) == 0)
+  if (strcmp_P(command, cmd_defaultLayer) == 0)
     sub_command = DEFAULT_LAYER;
-  else if (strcmp_P(command + 9, PSTR("valid?")) == 0)
+  else if (strcmp_P(command, cmd_isValid) == 0)
     sub_command = IS_VALID;
-  else if (strcmp_P(command + 9, PSTR("version")) == 0)
+  else if (strcmp_P(command, cmd_version) == 0)
     sub_command = GET_VERSION;
-  else if (strcmp_P(command + 9, PSTR("crc")) == 0)
+  else if (strcmp_P(command, cmd_crc) == 0)
     sub_command = GET_CRC;
   else
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -216,16 +216,18 @@ EventHandlerResult FocusEEPROMCommand::onFocusEvent(const char *command) {
     ERASE,
   } sub_command;
 
-  if (::Focus.isHelp(command))
-    return ::Focus.printHelp(PSTR("eeprom.contents"),
-                             PSTR("eeprom.free"),
-                             PSTR("eeprom.erase"));
+  const char *cmd_contents = PSTR("eeprom.contents");
+  const char *cmd_free = PSTR("eeprom.free");
+  const char *cmd_erase = PSTR("eeprom.erase");
 
-  if (strcmp_P(command, PSTR("eeprom.contents")) == 0)
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(cmd_contents, cmd_free, cmd_erase);
+
+  if (strcmp_P(command, cmd_contents) == 0)
     sub_command = CONTENTS;
-  else if (strcmp_P(command, PSTR("eeprom.free")) == 0)
+  else if (strcmp_P(command, cmd_free) == 0)
     sub_command = FREE;
-  else if (strcmp_P(command, PSTR("eeprom.erase")) == 0)
+  else if (strcmp_P(command, cmd_erase) == 0)
     sub_command = ERASE;
   else
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -165,9 +165,9 @@ EventHandlerResult FocusSettingsCommand::onFocusEvent(const char *command) {
   } sub_command;
 
   const char *cmd_defaultLayer = PSTR("settings.defaultLayer");
-  const char *cmd_isValid = PSTR("settings.valid?");
-  const char *cmd_version = PSTR("settings.version");
-  const char *cmd_crc = PSTR("settings.crc");
+  const char *cmd_isValid      = PSTR("settings.valid?");
+  const char *cmd_version      = PSTR("settings.version");
+  const char *cmd_crc          = PSTR("settings.crc");
 
   if (::Focus.isHelp(command))
     return ::Focus.printHelp(cmd_defaultLayer, cmd_isValid, cmd_version, cmd_crc);
@@ -216,8 +216,8 @@ EventHandlerResult FocusEEPROMCommand::onFocusEvent(const char *command) {
   } sub_command;
 
   const char *cmd_contents = PSTR("eeprom.contents");
-  const char *cmd_free = PSTR("eeprom.free");
-  const char *cmd_erase = PSTR("eeprom.erase");
+  const char *cmd_free     = PSTR("eeprom.free");
+  const char *cmd_erase    = PSTR("eeprom.erase");
 
   if (::Focus.isHelp(command))
     return ::Focus.printHelp(cmd_contents, cmd_free, cmd_erase);

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -164,8 +164,11 @@ EventHandlerResult FocusSettingsCommand::onFocusEvent(const char *command) {
     GET_CRC,
   } sub_command;
 
-  if (::Focus.handleHelp(command, PSTR("settings.defaultLayer\r\nsettings.valid?\r\nsettings.version\r\nsettings.crc")))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(PSTR("settings.defaultLayer"),
+                             PSTR("settings.valid?"),
+                             PSTR("settings.version"),
+                             PSTR("settings.crc"));
 
   if (strncmp_P(command, PSTR("settings."), 9) != 0)
     return EventHandlerResult::OK;
@@ -213,8 +216,10 @@ EventHandlerResult FocusEEPROMCommand::onFocusEvent(const char *command) {
     ERASE,
   } sub_command;
 
-  if (::Focus.handleHelp(command, PSTR("eeprom.contents\r\neeprom.free\r\neeprom.erase")))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(PSTR("eeprom.contents"),
+                             PSTR("eeprom.free"),
+                             PSTR("eeprom.erase"));
 
   if (strcmp_P(command, PSTR("eeprom.contents")) == 0)
     sub_command = CONTENTS;

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -17,7 +17,7 @@
 
 #include "kaleidoscope/plugin/EEPROM-Settings.h"
 
-#include <Arduino.h>                   // for PSTR, strcmp_P, F, __FlashStringHelper
+#include <Arduino.h>                   // for PSTR, F, __FlashStringHelper
 #include <Kaleidoscope-FocusSerial.h>  // for Focus, FocusSerial
 #include <stdint.h>                    // for uint16_t, uint8_t
 
@@ -172,13 +172,13 @@ EventHandlerResult FocusSettingsCommand::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_defaultLayer, cmd_isValid, cmd_version, cmd_crc);
 
-  if (strcmp_P(command, cmd_defaultLayer) == 0)
+  if (::Focus.inputMatchesCommand(command, cmd_defaultLayer))
     sub_command = DEFAULT_LAYER;
-  else if (strcmp_P(command, cmd_isValid) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_isValid))
     sub_command = IS_VALID;
-  else if (strcmp_P(command, cmd_version) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_version))
     sub_command = GET_VERSION;
-  else if (strcmp_P(command, cmd_crc) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_crc))
     sub_command = GET_CRC;
   else
     return EventHandlerResult::OK;
@@ -222,11 +222,11 @@ EventHandlerResult FocusEEPROMCommand::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_contents, cmd_free, cmd_erase);
 
-  if (strcmp_P(command, cmd_contents) == 0)
+  if (::Focus.inputMatchesCommand(command, cmd_contents))
     sub_command = CONTENTS;
-  else if (strcmp_P(command, cmd_free) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_free))
     sub_command = FREE;
-  else if (strcmp_P(command, cmd_erase) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_erase))
     sub_command = ERASE;
   else
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot-Config.cpp
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot-Config.cpp
@@ -49,10 +49,11 @@ EventHandlerResult EscapeOneShotConfig::onNameQuery() {
 }
 
 EventHandlerResult EscapeOneShotConfig::onFocusEvent(const char *command) {
+  const char *cmd_cancel_key = PSTR("escape_oneshot.cancel_key");
   if (::Focus.isHelp(command))
-    return ::Focus.printHelp(PSTR("escape_oneshot.cancel_key"));
+    return ::Focus.printHelp(cmd_cancel_key);
 
-  if (strcmp_P(command, PSTR("escape_oneshot.cancel_key")) != 0)
+  if (strcmp_P(command, cmd_cancel_key) != 0)
     return EventHandlerResult::OK;
 
   if (::Focus.isEOL()) {

--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot-Config.cpp
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot-Config.cpp
@@ -50,7 +50,7 @@ EventHandlerResult EscapeOneShotConfig::onNameQuery() {
 
 EventHandlerResult EscapeOneShotConfig::onFocusEvent(const char *command) {
   const char *cmd_cancel_key = PSTR("escape_oneshot.cancel_key");
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_cancel_key);
 
   if (strcmp_P(command, cmd_cancel_key) != 0)

--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot-Config.cpp
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot-Config.cpp
@@ -49,8 +49,8 @@ EventHandlerResult EscapeOneShotConfig::onNameQuery() {
 }
 
 EventHandlerResult EscapeOneShotConfig::onFocusEvent(const char *command) {
-  if (::Focus.handleHelp(command, PSTR("escape_oneshot.cancel_key")))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(PSTR("escape_oneshot.cancel_key"));
 
   if (strcmp_P(command, PSTR("escape_oneshot.cancel_key")) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot-Config.cpp
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot-Config.cpp
@@ -17,7 +17,7 @@
 
 #include "kaleidoscope/plugin/Escape-OneShot.h"  // IWYU pragma: associated
 
-#include <Arduino.h>                       // for PSTR, F, __FlashStringHelper, strcmp_P
+#include <Arduino.h>                       // for PSTR, F, __FlashStringHelper
 #include <Kaleidoscope-EEPROM-Settings.h>  // for EEPROMSettings
 #include <Kaleidoscope-FocusSerial.h>      // for Focus, FocusSerial
 
@@ -53,7 +53,7 @@ EventHandlerResult EscapeOneShotConfig::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_cancel_key);
 
-  if (strcmp_P(command, cmd_cancel_key) != 0)
+  if (!::Focus.inputMatchesCommand(command, cmd_cancel_key))
     return EventHandlerResult::OK;
 
   if (::Focus.isEOL()) {

--- a/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
+++ b/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
@@ -17,7 +17,7 @@
 
 #include "kaleidoscope/plugin/FingerPainter.h"
 
-#include <Arduino.h>                         // for PSTR, strcmp_P, F, __FlashStringHelper
+#include <Arduino.h>                         // for PSTR, F, __FlashStringHelper
 #include <Kaleidoscope-FocusSerial.h>        // for Focus, FocusSerial
 #include <Kaleidoscope-LED-Palette-Theme.h>  // for LEDPaletteTheme
 #include <stdint.h>                          // for uint16_t, uint8_t
@@ -106,9 +106,9 @@ EventHandlerResult FingerPainter::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_toggle, cmd_clear);
 
-  if (strcmp_P(command, cmd_toggle) == 0)
+  if (::Focus.inputMatchesCommand(command, cmd_toggle))
     sub_command = TOGGLE;
-  else if (strcmp_P(command, cmd_clear) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_clear))
     sub_command = CLEAR;
   else
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
+++ b/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
@@ -100,16 +100,15 @@ EventHandlerResult FingerPainter::onFocusEvent(const char *command) {
     CLEAR,
   } sub_command;
 
+  const char *cmd_toggle = PSTR("fingerpainter.toggle");
+  const char *cmd_clear = PSTR("fingerpainter.clear");
+
   if (::Focus.isHelp(command))
-    return ::Focus.printHelp(PSTR("fingerpainter.toggle"),
-                             PSTR("fingerpainter.clear"));
+    return ::Focus.printHelp(cmd_toggle, cmd_clear);
 
-  if (strncmp_P(command, PSTR("fingerpainter."), 14) != 0)
-    return EventHandlerResult::OK;
-
-  if (strcmp_P(command + 14, PSTR("toggle")) == 0)
+  if (strcmp_P(command, cmd_toggle) == 0)
     sub_command = TOGGLE;
-  else if (strcmp_P(command + 14, PSTR("clear")) == 0)
+  else if (strcmp_P(command, cmd_clear) == 0)
     sub_command = CLEAR;
   else
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
+++ b/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
@@ -100,8 +100,9 @@ EventHandlerResult FingerPainter::onFocusEvent(const char *command) {
     CLEAR,
   } sub_command;
 
-  if (::Focus.handleHelp(command, PSTR("fingerpainter.toggle\r\nfingerpainter.clear")))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(PSTR("fingerpainter.toggle"),
+                             PSTR("fingerpainter.clear"));
 
   if (strncmp_P(command, PSTR("fingerpainter."), 14) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
+++ b/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
@@ -103,7 +103,7 @@ EventHandlerResult FingerPainter::onFocusEvent(const char *command) {
   const char *cmd_toggle = PSTR("fingerpainter.toggle");
   const char *cmd_clear  = PSTR("fingerpainter.clear");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_toggle, cmd_clear);
 
   if (strcmp_P(command, cmd_toggle) == 0)

--- a/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
+++ b/plugins/Kaleidoscope-FingerPainter/src/kaleidoscope/plugin/FingerPainter.cpp
@@ -101,7 +101,7 @@ EventHandlerResult FingerPainter::onFocusEvent(const char *command) {
   } sub_command;
 
   const char *cmd_toggle = PSTR("fingerpainter.toggle");
-  const char *cmd_clear = PSTR("fingerpainter.clear");
+  const char *cmd_clear  = PSTR("fingerpainter.clear");
 
   if (::Focus.isHelp(command))
     return ::Focus.printHelp(cmd_toggle, cmd_clear);

--- a/plugins/Kaleidoscope-FirmwareDump/src/kaleidoscope/plugin/FirmwareDump.cpp
+++ b/plugins/Kaleidoscope-FirmwareDump/src/kaleidoscope/plugin/FirmwareDump.cpp
@@ -56,7 +56,7 @@ EventHandlerResult FirmwareDump::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd);
 
-  if (strcmp_P(command, cmd) != 0)
+  if (!::Focus.inputMatchesCommand(command, cmd))
     return EventHandlerResult::OK;
 
   uint16_t flash_size = (FLASHEND + 1L);

--- a/plugins/Kaleidoscope-FirmwareDump/src/kaleidoscope/plugin/FirmwareDump.cpp
+++ b/plugins/Kaleidoscope-FirmwareDump/src/kaleidoscope/plugin/FirmwareDump.cpp
@@ -53,7 +53,7 @@ EventHandlerResult FirmwareDump::onSetup() {
 EventHandlerResult FirmwareDump::onFocusEvent(const char *command) {
   const char *cmd = PSTR("firmware.dump");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd);
 
   if (strcmp_P(command, cmd) != 0)

--- a/plugins/Kaleidoscope-FirmwareDump/src/kaleidoscope/plugin/FirmwareDump.cpp
+++ b/plugins/Kaleidoscope-FirmwareDump/src/kaleidoscope/plugin/FirmwareDump.cpp
@@ -53,8 +53,8 @@ EventHandlerResult FirmwareDump::onSetup() {
 EventHandlerResult FirmwareDump::onFocusEvent(const char *command) {
   const char *cmd = PSTR("firmware.dump");
 
-  if (::Focus.handleHelp(command, cmd))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(cmd);
 
   if (strcmp_P(command, cmd) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-FirmwareVersion/src/kaleidoscope/plugin/FirmwareVersion.h
+++ b/plugins/Kaleidoscope-FirmwareVersion/src/kaleidoscope/plugin/FirmwareVersion.h
@@ -34,7 +34,7 @@ class FirmwareVersion : public Plugin {
   EventHandlerResult onFocusEvent(const char *command) {
     const char *cmd_version = PSTR("version");
 
-    if (::Focus.isHelp(command))
+    if (::Focus.inputMatchesHelp(command))
       return ::Focus.printHelp(cmd_version);
 
     if (strcmp_P(command, cmd_version) != 0)

--- a/plugins/Kaleidoscope-FirmwareVersion/src/kaleidoscope/plugin/FirmwareVersion.h
+++ b/plugins/Kaleidoscope-FirmwareVersion/src/kaleidoscope/plugin/FirmwareVersion.h
@@ -32,10 +32,12 @@ namespace plugin {
 class FirmwareVersion : public Plugin {
  public:
   EventHandlerResult onFocusEvent(const char *command) {
-    if (::Focus.isHelp(command))
-      return ::Focus.printHelp(PSTR("version"));
+    const char *cmd_version = PSTR("version");
 
-    if (strcmp_P(command, PSTR("version")) != 0)
+    if (::Focus.isHelp(command))
+      return ::Focus.printHelp(cmd_version);
+
+    if (strcmp_P(command, cmd_version) != 0)
       return EventHandlerResult::OK;
 
 #ifdef KALEIDOSCOPE_FIRMWARE_VERSION

--- a/plugins/Kaleidoscope-FirmwareVersion/src/kaleidoscope/plugin/FirmwareVersion.h
+++ b/plugins/Kaleidoscope-FirmwareVersion/src/kaleidoscope/plugin/FirmwareVersion.h
@@ -21,7 +21,7 @@
 #define KALEIDOSCOPE_FIRMWARE_VERSION "0.0.0"
 #endif
 
-#include <Arduino.h>                            // for PSTR, F, __FlashStringHelper, strcmp_P
+#include <Arduino.h>                            // for PSTR, F, __FlashStringHelper
 #include "Kaleidoscope-FocusSerial.h"           // for Focus, FocusSerial
 #include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
 #include "kaleidoscope/plugin.h"                // for Plugin
@@ -37,7 +37,7 @@ class FirmwareVersion : public Plugin {
     if (::Focus.inputMatchesHelp(command))
       return ::Focus.printHelp(cmd_version);
 
-    if (strcmp_P(command, cmd_version) != 0)
+    if (!::Focus.inputMatchesCommand(command, cmd_version))
       return EventHandlerResult::OK;
 
 #ifdef KALEIDOSCOPE_FIRMWARE_VERSION

--- a/plugins/Kaleidoscope-FirmwareVersion/src/kaleidoscope/plugin/FirmwareVersion.h
+++ b/plugins/Kaleidoscope-FirmwareVersion/src/kaleidoscope/plugin/FirmwareVersion.h
@@ -32,8 +32,8 @@ namespace plugin {
 class FirmwareVersion : public Plugin {
  public:
   EventHandlerResult onFocusEvent(const char *command) {
-    if (::Focus.handleHelp(command, PSTR("version")))
-      return EventHandlerResult::OK;
+    if (::Focus.isHelp(command))
+      return ::Focus.printHelp(PSTR("version"));
 
     if (strcmp_P(command, PSTR("version")) != 0)
       return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-FocusSerial/README.md
+++ b/plugins/Kaleidoscope-FocusSerial/README.md
@@ -25,7 +25,7 @@ class FocusTestCommand : public Plugin {
   }
 
   EventHandlerResult onFocusEvent(const char *command) {
-    if (strcmp_P(command, PSTR("test")) != 0)
+    if (!::Focus.inputMatchesCommand(command, PSTR("test")))
       return EventHandlerResult::OK;
 
     ::Focus.send(F("Congratulations, the test command works!"));

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -78,14 +78,18 @@ EventHandlerResult FocusSerial::afterEachCycle() {
 }
 
 EventHandlerResult FocusSerial::onFocusEvent(const char *command) {
-  if (isHelp(command))
-    return printHelp(PSTR("help"), PSTR("device.reset"), PSTR("plugins"));
+  const char *cmd_help = PSTR("help");
+  const char *cmd_reset = PSTR("device.reset");
+  const char *cmd_plugins = PSTR("plugins");
 
-  if (strcmp_P(command, PSTR("device.reset")) == 0) {
+  if (isHelp(command))
+    return printHelp(cmd_help, cmd_reset, cmd_plugins);
+
+  if (strcmp_P(command, cmd_reset) == 0) {
     Runtime.device().rebootBootloader();
     return EventHandlerResult::EVENT_CONSUMED;
   }
-  if (strcmp_P(command, PSTR("plugins")) == 0) {
+  if (strcmp_P(command, cmd_plugins) == 0) {
     kaleidoscope::Hooks::onNameQuery();
     return EventHandlerResult::EVENT_CONSUMED;
   }

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -78,8 +78,8 @@ EventHandlerResult FocusSerial::afterEachCycle() {
 }
 
 EventHandlerResult FocusSerial::onFocusEvent(const char *command) {
-  const char *cmd_help = PSTR("help");
-  const char *cmd_reset = PSTR("device.reset");
+  const char *cmd_help    = PSTR("help");
+  const char *cmd_reset   = PSTR("device.reset");
   const char *cmd_plugins = PSTR("plugins");
 
   if (isHelp(command))

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -97,6 +97,15 @@ EventHandlerResult FocusSerial::onFocusEvent(const char *command) {
   return EventHandlerResult::OK;
 }
 
+#ifndef NDEPRECATED
+bool FocusSerial::handleHelp(const char *command, const char *help_message) {
+  if (!inputMatchesHelp(command)) return false;
+
+  printHelp(help_message);
+  return true;
+}
+#endif
+
 void FocusSerial::printBool(bool b) {
   Runtime.serialPort().print((b) ? F("true") : F("false"));
 }

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -82,7 +82,7 @@ EventHandlerResult FocusSerial::onFocusEvent(const char *command) {
   const char *cmd_reset   = PSTR("device.reset");
   const char *cmd_plugins = PSTR("plugins");
 
-  if (isHelp(command))
+  if (inputMatchesHelp(command))
     return printHelp(cmd_help, cmd_reset, cmd_plugins);
 
   if (strcmp_P(command, cmd_reset) == 0) {
@@ -99,6 +99,14 @@ EventHandlerResult FocusSerial::onFocusEvent(const char *command) {
 
 void FocusSerial::printBool(bool b) {
   Runtime.serialPort().print((b) ? F("true") : F("false"));
+}
+
+bool FocusSerial::inputMatchesHelp(const char *input) {
+  return inputMatchesCommand(input, PSTR("help"));
+}
+
+bool FocusSerial::inputMatchesCommand(const char *input, const char *expected) {
+  return strcmp_P(input, expected) == 0;
 }
 
 }  // namespace plugin

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -85,11 +85,11 @@ EventHandlerResult FocusSerial::onFocusEvent(const char *command) {
   if (inputMatchesHelp(command))
     return printHelp(cmd_help, cmd_reset, cmd_plugins);
 
-  if (strcmp_P(command, cmd_reset) == 0) {
+  if (inputMatchesCommand(command, cmd_reset)) {
     Runtime.device().rebootBootloader();
     return EventHandlerResult::EVENT_CONSUMED;
   }
-  if (strcmp_P(command, cmd_plugins) == 0) {
+  if (inputMatchesCommand(command, cmd_plugins)) {
     kaleidoscope::Hooks::onNameQuery();
     return EventHandlerResult::EVENT_CONSUMED;
   }

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -77,18 +77,9 @@ EventHandlerResult FocusSerial::afterEachCycle() {
   return EventHandlerResult::OK;
 }
 
-bool FocusSerial::handleHelp(const char *command,
-                             const char *help_message) {
-  if (strcmp_P(command, PSTR("help")) != 0)
-    return false;
-
-  Runtime.serialPort().println((const __FlashStringHelper *)help_message);
-  return true;
-}
-
 EventHandlerResult FocusSerial::onFocusEvent(const char *command) {
-  if (handleHelp(command, PSTR("help\r\ndevice.reset\r\nplugins")))
-    return EventHandlerResult::OK;
+  if (isHelp(command))
+    return printHelp(PSTR("help"), PSTR("device.reset"), PSTR("plugins"));
 
   if (strcmp_P(command, PSTR("device.reset")) == 0) {
     Runtime.device().rebootBootloader();

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -26,6 +26,15 @@
 #include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult, EventHandlerResult::OK
 #include "kaleidoscope/key_defs.h"              // for Key
 #include "kaleidoscope/plugin.h"                // for Plugin
+// -----------------------------------------------------------------------------
+// Deprecation warning messages
+#include "kaleidoscope_internal/deprecations.h"  // for DEPRECATED
+
+#define _DEPRECATED_MESSAGE_FOCUS_HANDLEHELP                      \
+  "The `Focus.handeHelp()` method is deprecated. Please use\n"    \
+  "`Focus.inputMatchesHelp()` and `Focus.printHelp()` instead.\n" \
+  "This method will be removed after 2022-12-08."
+// -----------------------------------------------------------------------------
 
 // IWYU pragma: no_include "WString.h"
 
@@ -37,13 +46,10 @@ class FocusSerial : public kaleidoscope::Plugin {
   static constexpr char SEPARATOR = ' ';
   static constexpr char NEWLINE   = '\n';
 
-  __attribute__((deprecated("bla bla bla"))) bool handleHelp(const char *command,
-                                                             const char *help_message) {
-    if (!inputMatchesHelp(command)) return false;
-
-    printHelp(help_message);
-    return true;
-  }
+#ifndef NDEPRECATED
+  DEPRECATED(FOCUS_HANDLEHELP)
+  bool handleHelp(const char *command, const char *help_message);
+#endif
 
   bool inputMatchesHelp(const char *input);
   bool inputMatchesCommand(const char *input, const char *expected);

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -37,8 +37,27 @@ class FocusSerial : public kaleidoscope::Plugin {
   static constexpr char SEPARATOR = ' ';
   static constexpr char NEWLINE   = '\n';
 
+  __attribute__((deprecated("bla bla bla")))
   bool handleHelp(const char *command,
-                  const char *help_message);
+                  const char *help_message) {
+    if (!isHelp(command)) return false;
+
+    printHelp(help_message);
+    return true;
+  }
+
+  bool isHelp(const char *command) {
+    return strcmp_P(command, PSTR("help")) == 0;
+  }
+
+  EventHandlerResult printHelp() {
+    return EventHandlerResult::OK;
+  }
+  template<typename... Vars>
+  EventHandlerResult printHelp(const char *h1, Vars... vars) {
+    Runtime.serialPort().println((const __FlashStringHelper *)h1);
+    return printHelp(vars...);
+  }
 
   EventHandlerResult sendName(const __FlashStringHelper *name) {
     Runtime.serialPort().print(name);

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -37,9 +37,8 @@ class FocusSerial : public kaleidoscope::Plugin {
   static constexpr char SEPARATOR = ' ';
   static constexpr char NEWLINE   = '\n';
 
-  __attribute__((deprecated("bla bla bla")))
-  bool handleHelp(const char *command,
-                  const char *help_message) {
+  __attribute__((deprecated("bla bla bla"))) bool handleHelp(const char *command,
+                                                             const char *help_message) {
     if (!isHelp(command)) return false;
 
     printHelp(help_message);

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -39,15 +39,14 @@ class FocusSerial : public kaleidoscope::Plugin {
 
   __attribute__((deprecated("bla bla bla"))) bool handleHelp(const char *command,
                                                              const char *help_message) {
-    if (!isHelp(command)) return false;
+    if (!inputMatchesHelp(command)) return false;
 
     printHelp(help_message);
     return true;
   }
 
-  bool isHelp(const char *command) {
-    return strcmp_P(command, PSTR("help")) == 0;
-  }
+  bool inputMatchesHelp(const char *input);
+  bool inputMatchesCommand(const char *input, const char *expected);
 
   EventHandlerResult printHelp() {
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
@@ -34,8 +34,17 @@ namespace raise {
 #endif
 
 EventHandlerResult Focus::onFocusEvent(const char *command) {
-  if (::Focus.handleHelp(command, PSTR("hardware.version\r\nhardware.side_power\r\nhardware.side_ver\r\nhardware.sled_ver\r\nhardware.sled_current\r\nhardware.layout\r\nhardware.joint\r\nhardware.keyscan\r\nhardware.crc_errors\r\nhardware.firmware")))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(PSTR("hardware.version"),
+                             PSTR("hardware.side_power"),
+                             PSTR("hardware.side_ver"),
+                             PSTR("hardware.sled_ver"),
+                             PSTR("hardware.sled_current"),
+                             PSTR("hardware.layout"),
+                             PSTR("hardware.joint"),
+                             PSTR("hardware.keyscan"),
+                             PSTR("hardware.crc_errors"),
+                             PSTR("hardware.firmware"));
 
   if (strncmp_P(command, PSTR("hardware."), 9) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
@@ -44,7 +44,7 @@ EventHandlerResult Focus::onFocusEvent(const char *command) {
   const char *cmd_keyscan      = PSTR("hardware.keyscan");
   const char *cmd_crc_errors   = PSTR("hardware.crc_errors");
   const char *cmd_firmware     = PSTR("hardware.firmware");
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_version,
                              cmd_side_power,
                              cmd_side_ver,

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
@@ -56,13 +56,13 @@ EventHandlerResult Focus::onFocusEvent(const char *command) {
                              cmd_crc_errors,
                              cmd_firmware);
 
-  if (strcmp_P(command, cmd_version) == 0) {
+  if (::Focus.inputMatchesCommand(command, cmd_version)) {
     ::Focus.send("Dygma Raise");
     return EventHandlerResult::EVENT_CONSUMED;
-  } else if (strcmp_P(command, cmd_firmware) == 0) {
+  } else if (::Focus.inputMatchesCommand(command, cmd_firmware)) {
     ::Focus.send(RAISE_FIRMWARE_VERSION);
     return EventHandlerResult::EVENT_CONSUMED;
-  } else if (strcmp_P(command, cmd_side_power) == 0) {
+  } else if (::Focus.inputMatchesCommand(command, cmd_side_power)) {
     if (::Focus.isEOL()) {
       ::Focus.send(Runtime.device().side.getPower());
       return EventHandlerResult::EVENT_CONSUMED;
@@ -72,25 +72,25 @@ EventHandlerResult Focus::onFocusEvent(const char *command) {
       Runtime.device().side.setPower(power);
       return EventHandlerResult::EVENT_CONSUMED;
     }
-  } else if (strcmp_P(command, cmd_side_ver) == 0) {
+  } else if (::Focus.inputMatchesCommand(command, cmd_side_ver)) {
     ::Focus.send("left:");
     ::Focus.send(Runtime.device().side.leftVersion());
     ::Focus.send("\r\nright:");
     ::Focus.send(Runtime.device().side.rightVersion());
     return EventHandlerResult::EVENT_CONSUMED;
-  } else if (strcmp_P(command, cmd_crc_errors) == 0) {
+  } else if (::Focus.inputMatchesCommand(command, cmd_crc_errors)) {
     ::Focus.send("left:");
     ::Focus.send(Runtime.device().side.leftCRCErrors());
     ::Focus.send("\r\nright:");
     ::Focus.send(Runtime.device().side.rightCRCErrors());
     return EventHandlerResult::EVENT_CONSUMED;
-  } else if (strcmp_P(command, cmd_sled_ver) == 0) {
+  } else if (::Focus.inputMatchesCommand(command, cmd_sled_ver)) {
     ::Focus.send("left:");
     ::Focus.send(Runtime.device().side.leftSLEDVersion());
     ::Focus.send("\r\nright:");
     ::Focus.send(Runtime.device().side.rightSLEDVersion());
     return EventHandlerResult::EVENT_CONSUMED;
-  } else if (strcmp_P(command, cmd_sled_current) == 0) {
+  } else if (::Focus.inputMatchesCommand(command, cmd_sled_current)) {
     if (::Focus.isEOL()) {
       ::Focus.send("left:");
       ::Focus.send(Runtime.device().side.leftSLEDCurrent());
@@ -103,14 +103,14 @@ EventHandlerResult Focus::onFocusEvent(const char *command) {
       Runtime.device().side.setSLEDCurrent(current);
       return EventHandlerResult::EVENT_CONSUMED;
     }
-  } else if (strcmp_P(command, cmd_layout) == 0) {
+  } else if (::Focus.inputMatchesCommand(command, cmd_layout)) {
     static const auto ANSI = Runtime.device().settings.Layout::ANSI;
     ::Focus.send(Runtime.device().settings.layout() == ANSI ? "ANSI" : "ISO");
     return EventHandlerResult::EVENT_CONSUMED;
-  } else if (strcmp_P(command, cmd_joint) == 0) {
+  } else if (::Focus.inputMatchesCommand(command, cmd_joint)) {
     ::Focus.send(Runtime.device().settings.joint());
     return EventHandlerResult::EVENT_CONSUMED;
-  } else if (strcmp_P(command, cmd_keyscan) == 0) {
+  } else if (::Focus.inputMatchesCommand(command, cmd_keyscan)) {
     if (::Focus.isEOL()) {
       ::Focus.send(Runtime.device().settings.keyscanInterval());
       return EventHandlerResult::EVENT_CONSUMED;

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
@@ -34,16 +34,16 @@ namespace raise {
 #endif
 
 EventHandlerResult Focus::onFocusEvent(const char *command) {
-  const char *cmd_version = PSTR("hardware.version");
-  const char *cmd_side_power = PSTR("hardware.side_power");
-  const char *cmd_side_ver = PSTR("hardware.side_ver");
-  const char *cmd_sled_ver = PSTR("hardware.sled_ver");
+  const char *cmd_version      = PSTR("hardware.version");
+  const char *cmd_side_power   = PSTR("hardware.side_power");
+  const char *cmd_side_ver     = PSTR("hardware.side_ver");
+  const char *cmd_sled_ver     = PSTR("hardware.sled_ver");
   const char *cmd_sled_current = PSTR("hardware.sled_current");
-  const char *cmd_layout = PSTR("hardware.layout");
-  const char *cmd_joint = PSTR("hardware.joint");
-  const char *cmd_keyscan = PSTR("hardware.keyscan");
-  const char *cmd_crc_errors = PSTR("hardware.crc_errors");
-  const char *cmd_firmware = PSTR("hardware.firmware");
+  const char *cmd_layout       = PSTR("hardware.layout");
+  const char *cmd_joint        = PSTR("hardware.joint");
+  const char *cmd_keyscan      = PSTR("hardware.keyscan");
+  const char *cmd_crc_errors   = PSTR("hardware.crc_errors");
+  const char *cmd_firmware     = PSTR("hardware.firmware");
   if (::Focus.isHelp(command))
     return ::Focus.printHelp(cmd_version,
                              cmd_side_power,

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
@@ -34,32 +34,35 @@ namespace raise {
 #endif
 
 EventHandlerResult Focus::onFocusEvent(const char *command) {
+  const char *cmd_version = PSTR("hardware.version");
+  const char *cmd_side_power = PSTR("hardware.side_power");
+  const char *cmd_side_ver = PSTR("hardware.side_ver");
+  const char *cmd_sled_ver = PSTR("hardware.sled_ver");
+  const char *cmd_sled_current = PSTR("hardware.sled_current");
+  const char *cmd_layout = PSTR("hardware.layout");
+  const char *cmd_joint = PSTR("hardware.joint");
+  const char *cmd_keyscan = PSTR("hardware.keyscan");
+  const char *cmd_crc_errors = PSTR("hardware.crc_errors");
+  const char *cmd_firmware = PSTR("hardware.firmware");
   if (::Focus.isHelp(command))
-    return ::Focus.printHelp(PSTR("hardware.version"),
-                             PSTR("hardware.side_power"),
-                             PSTR("hardware.side_ver"),
-                             PSTR("hardware.sled_ver"),
-                             PSTR("hardware.sled_current"),
-                             PSTR("hardware.layout"),
-                             PSTR("hardware.joint"),
-                             PSTR("hardware.keyscan"),
-                             PSTR("hardware.crc_errors"),
-                             PSTR("hardware.firmware"));
+    return ::Focus.printHelp(cmd_version,
+                             cmd_side_power,
+                             cmd_side_ver,
+                             cmd_sled_ver,
+                             cmd_sled_current,
+                             cmd_layout,
+                             cmd_joint,
+                             cmd_keyscan,
+                             cmd_crc_errors,
+                             cmd_firmware);
 
-  if (strncmp_P(command, PSTR("hardware."), 9) != 0)
-    return EventHandlerResult::OK;
-
-  if (strcmp_P(command + 9, PSTR("version")) == 0) {
+  if (strcmp_P(command, cmd_version) == 0) {
     ::Focus.send("Dygma Raise");
     return EventHandlerResult::EVENT_CONSUMED;
-  }
-
-  if (strcmp_P(command + 9, PSTR("firmware")) == 0) {
+  } else if (strcmp_P(command, cmd_firmware) == 0) {
     ::Focus.send(RAISE_FIRMWARE_VERSION);
     return EventHandlerResult::EVENT_CONSUMED;
-  }
-
-  if (strcmp_P(command + 9, PSTR("side_power")) == 0) {
+  } else if (strcmp_P(command, cmd_side_power) == 0) {
     if (::Focus.isEOL()) {
       ::Focus.send(Runtime.device().side.getPower());
       return EventHandlerResult::EVENT_CONSUMED;
@@ -69,33 +72,25 @@ EventHandlerResult Focus::onFocusEvent(const char *command) {
       Runtime.device().side.setPower(power);
       return EventHandlerResult::EVENT_CONSUMED;
     }
-  }
-
-  if (strcmp_P(command + 9, PSTR("side_ver")) == 0) {
+  } else if (strcmp_P(command, cmd_side_ver) == 0) {
     ::Focus.send("left:");
     ::Focus.send(Runtime.device().side.leftVersion());
     ::Focus.send("\r\nright:");
     ::Focus.send(Runtime.device().side.rightVersion());
     return EventHandlerResult::EVENT_CONSUMED;
-  }
-
-  if (strcmp_P(command + 9, PSTR("crc_errors")) == 0) {
+  } else if (strcmp_P(command, cmd_crc_errors) == 0) {
     ::Focus.send("left:");
     ::Focus.send(Runtime.device().side.leftCRCErrors());
     ::Focus.send("\r\nright:");
     ::Focus.send(Runtime.device().side.rightCRCErrors());
     return EventHandlerResult::EVENT_CONSUMED;
-  }
-
-  if (strcmp_P(command + 9, PSTR("sled_ver")) == 0) {
+  } else if (strcmp_P(command, cmd_sled_ver) == 0) {
     ::Focus.send("left:");
     ::Focus.send(Runtime.device().side.leftSLEDVersion());
     ::Focus.send("\r\nright:");
     ::Focus.send(Runtime.device().side.rightSLEDVersion());
     return EventHandlerResult::EVENT_CONSUMED;
-  }
-
-  if (strcmp_P(command + 9, PSTR("sled_current")) == 0) {
+  } else if (strcmp_P(command, cmd_sled_current) == 0) {
     if (::Focus.isEOL()) {
       ::Focus.send("left:");
       ::Focus.send(Runtime.device().side.leftSLEDCurrent());
@@ -108,20 +103,14 @@ EventHandlerResult Focus::onFocusEvent(const char *command) {
       Runtime.device().side.setSLEDCurrent(current);
       return EventHandlerResult::EVENT_CONSUMED;
     }
-  }
-
-  if (strcmp_P(command + 9, PSTR("layout")) == 0) {
+  } else if (strcmp_P(command, cmd_layout) == 0) {
     static const auto ANSI = Runtime.device().settings.Layout::ANSI;
     ::Focus.send(Runtime.device().settings.layout() == ANSI ? "ANSI" : "ISO");
     return EventHandlerResult::EVENT_CONSUMED;
-  }
-
-  if (strcmp_P(command + 9, PSTR("joint")) == 0) {
+  } else if (strcmp_P(command, cmd_joint) == 0) {
     ::Focus.send(Runtime.device().settings.joint());
     return EventHandlerResult::EVENT_CONSUMED;
-  }
-
-  if (strcmp_P(command + 9, PSTR("keyscan")) == 0) {
+  } else if (strcmp_P(command, cmd_keyscan) == 0) {
     if (::Focus.isEOL()) {
       ::Focus.send(Runtime.device().settings.keyscanInterval());
       return EventHandlerResult::EVENT_CONSUMED;

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/SideFlash.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/SideFlash.h
@@ -51,16 +51,16 @@ class SideFlash : public kaleidoscope::Plugin {
     } sub_command;
     uint8_t address = 0;
 
-    if (strcmp_P(command, cmd_flash_left) == 0) {
+    if (::Focus.inputMatchesCommand(command, cmd_flash_left)) {
       sub_command = FLASH;
       address     = left_boot_address;
-    } else if (strcmp_P(command, cmd_flash_right) == 0) {
+    } else if (::Focus.inputMatchesCommand(command, cmd_flash_right)) {
       sub_command = FLASH;
       address     = right_boot_address;
-    } else if (strcmp_P(command, cmd_verify_left) == 0) {
+    } else if (::Focus.inputMatchesCommand(command, cmd_verify_left)) {
       sub_command = VERIFY;
       address     = left_boot_address;
-    } else if (strcmp_P(command, cmd_verify_right) == 0) {
+    } else if (::Focus.inputMatchesCommand(command, cmd_verify_right)) {
       sub_command = VERIFY;
       address     = right_boot_address;
     } else {

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/SideFlash.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/SideFlash.h
@@ -35,14 +35,13 @@ class SideFlash : public kaleidoscope::Plugin {
 
  public:
   EventHandlerResult onFocusEvent(const char *command) {
+    const char *cmd_flash_left = PSTR("hardware.flash_left_side");
+    const char *cmd_flash_right = PSTR("hardware.flash_right_side");
+    const char *cmd_verify_left = PSTR("hardware.verify_left_side");
+    const char *cmd_verify_right = PSTR("hardware.verify_right_side");
     if (::Focus.isHelp(command))
-      return ::Focus.printHelp(PSTR("hardware.flash_left_side"),
-                               PSTR("hardware.flash_right_side"),
-                               PSTR("hardware.verify_left_side"),
-                               PSTR("hardware.verify_right_side"));
-
-    if (strncmp_P(command, PSTR("hardware."), 9) != 0)
-      return EventHandlerResult::OK;
+      return ::Focus.printHelp(cmd_flash_left, cmd_flash_right,
+                               cmd_verify_left, cmd_verify_right);
 
     auto sideFlasher           = Runtime.device().sideFlasher();
     uint8_t left_boot_address  = Runtime.device().side.left_boot_address;
@@ -53,16 +52,16 @@ class SideFlash : public kaleidoscope::Plugin {
     } sub_command;
     uint8_t address = 0;
 
-    if (strcmp_P(command + 9, PSTR("flash_left_side")) == 0) {
+    if (strcmp_P(command, cmd_flash_left) == 0) {
       sub_command = FLASH;
       address     = left_boot_address;
-    } else if (strcmp_P(command + 9, PSTR("flash_right_side")) == 0) {
+    } else if (strcmp_P(command, cmd_flash_right) == 0) {
       sub_command = FLASH;
       address     = right_boot_address;
-    } else if (strcmp_P(command + 9, PSTR("verify_left_side")) == 0) {
+    } else if (strcmp_P(command, cmd_verify_left) == 0) {
       sub_command = VERIFY;
       address     = left_boot_address;
-    } else if (strcmp_P(command + 9, PSTR("verify_right_side")) == 0) {
+    } else if (strcmp_P(command, cmd_verify_right) == 0) {
       sub_command = VERIFY;
       address     = right_boot_address;
     } else {

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/SideFlash.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/SideFlash.h
@@ -35,13 +35,12 @@ class SideFlash : public kaleidoscope::Plugin {
 
  public:
   EventHandlerResult onFocusEvent(const char *command) {
-    const char *cmd_flash_left = PSTR("hardware.flash_left_side");
-    const char *cmd_flash_right = PSTR("hardware.flash_right_side");
-    const char *cmd_verify_left = PSTR("hardware.verify_left_side");
+    const char *cmd_flash_left   = PSTR("hardware.flash_left_side");
+    const char *cmd_flash_right  = PSTR("hardware.flash_right_side");
+    const char *cmd_verify_left  = PSTR("hardware.verify_left_side");
     const char *cmd_verify_right = PSTR("hardware.verify_right_side");
     if (::Focus.isHelp(command))
-      return ::Focus.printHelp(cmd_flash_left, cmd_flash_right,
-                               cmd_verify_left, cmd_verify_right);
+      return ::Focus.printHelp(cmd_flash_left, cmd_flash_right, cmd_verify_left, cmd_verify_right);
 
     auto sideFlasher           = Runtime.device().sideFlasher();
     uint8_t left_boot_address  = Runtime.device().side.left_boot_address;

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/SideFlash.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/SideFlash.h
@@ -39,7 +39,7 @@ class SideFlash : public kaleidoscope::Plugin {
     const char *cmd_flash_right  = PSTR("hardware.flash_right_side");
     const char *cmd_verify_left  = PSTR("hardware.verify_left_side");
     const char *cmd_verify_right = PSTR("hardware.verify_right_side");
-    if (::Focus.isHelp(command))
+    if (::Focus.inputMatchesHelp(command))
       return ::Focus.printHelp(cmd_flash_left, cmd_flash_right, cmd_verify_left, cmd_verify_right);
 
     auto sideFlasher           = Runtime.device().sideFlasher();

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/SideFlash.h
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/SideFlash.h
@@ -35,8 +35,11 @@ class SideFlash : public kaleidoscope::Plugin {
 
  public:
   EventHandlerResult onFocusEvent(const char *command) {
-    if (::Focus.handleHelp(command, PSTR("hardware.flash_left_side\nhardware.flash_right_side\nhardware.verify_left_side\nhardware.verify_right_side")))
-      return EventHandlerResult::OK;
+    if (::Focus.isHelp(command))
+      return ::Focus.printHelp(PSTR("hardware.flash_left_side"),
+                               PSTR("hardware.flash_right_side"),
+                               PSTR("hardware.verify_left_side"),
+                               PSTR("hardware.verify_right_side"));
 
     if (strncmp_P(command, PSTR("hardware."), 9) != 0)
       return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.cpp
+++ b/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.cpp
@@ -30,8 +30,9 @@ namespace plugin {
 EventHandlerResult FocusHostOSCommand::onFocusEvent(const char *command) {
   const char *cmd = PSTR("hostos.type");
 
-  if (::Focus.handleHelp(command, cmd))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(cmd);
+
   if (strcmp_P(command, cmd) != 0)
     return EventHandlerResult::OK;
 

--- a/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.cpp
+++ b/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.cpp
@@ -17,7 +17,7 @@
 
 #include "kaleidoscope/plugin/HostOS-Focus.h"
 
-#include <Arduino.h>                   // for PSTR, strcmp_P
+#include <Arduino.h>                   // for PSTR
 #include <Kaleidoscope-FocusSerial.h>  // for Focus, FocusSerial
 #include <stdint.h>                    // for uint8_t
 
@@ -33,7 +33,7 @@ EventHandlerResult FocusHostOSCommand::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd);
 
-  if (strcmp_P(command, cmd) != 0)
+  if (!::Focus.inputMatchesCommand(command, cmd))
     return EventHandlerResult::OK;
 
   if (::Focus.isEOL()) {

--- a/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.cpp
+++ b/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.cpp
@@ -30,7 +30,7 @@ namespace plugin {
 EventHandlerResult FocusHostOSCommand::onFocusEvent(const char *command) {
   const char *cmd = PSTR("hostos.type");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd);
 
   if (strcmp_P(command, cmd) != 0)

--- a/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -100,8 +100,8 @@ void PersistentIdleLEDs::setIdleTimeoutSeconds(uint32_t new_limit) {
 EventHandlerResult PersistentIdleLEDs::onFocusEvent(const char *command) {
   const char *cmd = PSTR("idleleds.time_limit");
 
-  if (::Focus.handleHelp(command, cmd))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(cmd);
 
   if (strcmp_P(command, cmd) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -100,7 +100,7 @@ void PersistentIdleLEDs::setIdleTimeoutSeconds(uint32_t new_limit) {
 EventHandlerResult PersistentIdleLEDs::onFocusEvent(const char *command) {
   const char *cmd = PSTR("idleleds.time_limit");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd);
 
   if (strcmp_P(command, cmd) != 0)

--- a/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -18,7 +18,7 @@
 
 #include "kaleidoscope/plugin/IdleLEDs.h"
 
-#include <Arduino.h>                       // for F, PSTR, __FlashStringHelper, strcmp_P
+#include <Arduino.h>                       // for F, PSTR, __FlashStringHelper
 #include <Kaleidoscope-EEPROM-Settings.h>  // for EEPROMSettings
 #include <Kaleidoscope-FocusSerial.h>      // for Focus, FocusSerial
 #include <stdint.h>                        // for uint32_t, uint16_t
@@ -103,7 +103,7 @@ EventHandlerResult PersistentIdleLEDs::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd);
 
-  if (strcmp_P(command, cmd) != 0)
+  if (!::Focus.inputMatchesCommand(command, cmd))
     return EventHandlerResult::OK;
 
   if (::Focus.isEOL()) {

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -128,7 +128,7 @@ EventHandlerResult LEDPaletteTheme::onFocusEvent(const char *command) {
 
   const char *cmd = PSTR("palette");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd);
 
   if (strcmp_P(command, cmd) != 0)
@@ -166,7 +166,7 @@ EventHandlerResult LEDPaletteTheme::themeFocusEvent(const char *command,
   if (!Runtime.has_leds)
     return EventHandlerResult::OK;
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(expected_command);
 
   if (strcmp_P(command, expected_command) != 0)

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -128,8 +128,8 @@ EventHandlerResult LEDPaletteTheme::onFocusEvent(const char *command) {
 
   const char *cmd = PSTR("palette");
 
-  if (::Focus.handleHelp(command, cmd))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(cmd);
 
   if (strcmp_P(command, cmd) != 0)
     return EventHandlerResult::OK;
@@ -166,8 +166,8 @@ EventHandlerResult LEDPaletteTheme::themeFocusEvent(const char *command,
   if (!Runtime.has_leds)
     return EventHandlerResult::OK;
 
-  if (::Focus.handleHelp(command, expected_command))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(expected_command);
 
   if (strcmp_P(command, expected_command) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -17,7 +17,7 @@
 
 #include "kaleidoscope/plugin/LED-Palette-Theme.h"
 
-#include <Arduino.h>                       // for strcmp_P, PSTR
+#include <Arduino.h>                       // for PSTR
 #include <Kaleidoscope-EEPROM-Settings.h>  // for EEPROMSettings
 #include <Kaleidoscope-FocusSerial.h>      // for Focus, FocusSerial
 #include <stdint.h>                        // for uint8_t, uint16_t
@@ -131,7 +131,7 @@ EventHandlerResult LEDPaletteTheme::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd);
 
-  if (strcmp_P(command, cmd) != 0)
+  if (!::Focus.inputMatchesCommand(command, cmd))
     return EventHandlerResult::OK;
 
   if (::Focus.isEOL()) {
@@ -169,7 +169,7 @@ EventHandlerResult LEDPaletteTheme::themeFocusEvent(const char *command,
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(expected_command);
 
-  if (strcmp_P(command, expected_command) != 0)
+  if (!::Focus.inputMatchesCommand(command, expected_command))
     return EventHandlerResult::OK;
 
   uint16_t max_index = (max_themes * Runtime.device().led_count) / 2;

--- a/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
+++ b/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
@@ -33,9 +33,12 @@ EventHandlerResult LayerFocus::onNameQuery() {
 }
 
 EventHandlerResult LayerFocus::onFocusEvent(const char *command) {
-  if (::Focus.handleHelp(command, PSTR("layer.activate\r\nlayer.deactivate\r\nlayer.isActive"
-                                       "\r\nlayer.moveTo\r\nlayer.state")))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(PSTR("layer.activate"),
+                             PSTR("layer.deactivate"),
+                             PSTR("layer.isActive"),
+                             PSTR("layer.moveTo"),
+                             PSTR("layer.state"));
 
   if (strncmp_P(command, PSTR("layer."), 6) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
+++ b/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
@@ -33,41 +33,44 @@ EventHandlerResult LayerFocus::onNameQuery() {
 }
 
 EventHandlerResult LayerFocus::onFocusEvent(const char *command) {
+  const char *cmd_activate = PSTR("layer.activate");
+  const char *cmd_deactivate = PSTR("layer.deactivate");
+  const char *cmd_isActive = PSTR("layer.isActive");
+  const char *cmd_moveTo = PSTR("layer.moveTo");
+  const char *cmd_state = PSTR("layer.state");
+
   if (::Focus.isHelp(command))
-    return ::Focus.printHelp(PSTR("layer.activate"),
-                             PSTR("layer.deactivate"),
-                             PSTR("layer.isActive"),
-                             PSTR("layer.moveTo"),
-                             PSTR("layer.state"));
+    return ::Focus.printHelp(cmd_activate,
+                             cmd_deactivate,
+                             cmd_isActive,
+                             cmd_moveTo,
+                             cmd_state);
 
-  if (strncmp_P(command, PSTR("layer."), 6) != 0)
-    return EventHandlerResult::OK;
-
-  if (strcmp_P(command + 6, PSTR("activate")) == 0) {
+  if (strcmp_P(command, cmd_activate) == 0) {
     if (!::Focus.isEOL()) {
       uint8_t layer;
       ::Focus.read(layer);
       ::Layer.activate(layer);
     }
-  } else if (strcmp_P(command + 6, PSTR("deactivate")) == 0) {
+  } else if (strcmp_P(command, cmd_deactivate) == 0) {
     if (!::Focus.isEOL()) {
       uint8_t layer;
       ::Focus.read(layer);
       ::Layer.deactivate(layer);
     }
-  } else if (strcmp_P(command + 6, PSTR("isActive")) == 0) {
+  } else if (strcmp_P(command, cmd_isActive) == 0) {
     if (!::Focus.isEOL()) {
       uint8_t layer;
       ::Focus.read(layer);
       ::Focus.send(::Layer.isActive(layer));
     }
-  } else if (strcmp_P(command + 6, PSTR("moveTo")) == 0) {
+  } else if (strcmp_P(command, cmd_moveTo) == 0) {
     if (!::Focus.isEOL()) {
       uint8_t layer;
       ::Focus.read(layer);
       ::Layer.move(layer);
     }
-  } else if (strcmp_P(command + 6, PSTR("state")) == 0) {
+  } else if (strcmp_P(command, cmd_state) == 0) {
     if (::Focus.isEOL()) {
       for (uint8_t i = 0; i < 32; i++) {
         ::Focus.send(::Layer.isActive(i) ? 1 : 0);
@@ -83,6 +86,8 @@ EventHandlerResult LayerFocus::onFocusEvent(const char *command) {
           ::Layer.activate(i);
       }
     }
+  } else {
+    return EventHandlerResult::OK;
   }
 
   return EventHandlerResult::EVENT_CONSUMED;

--- a/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
+++ b/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
@@ -18,7 +18,7 @@
 
 #include "kaleidoscope/plugin/LayerFocus.h"
 
-#include <Arduino.h>                   // for PSTR, strcmp_P, F, __FlashStringHelper
+#include <Arduino.h>                   // for PSTR, F, __FlashStringHelper
 #include <Kaleidoscope-FocusSerial.h>  // for Focus, FocusSerial
 #include <stdint.h>                    // for uint8_t
 
@@ -46,31 +46,31 @@ EventHandlerResult LayerFocus::onFocusEvent(const char *command) {
                              cmd_moveTo,
                              cmd_state);
 
-  if (strcmp_P(command, cmd_activate) == 0) {
+  if (::Focus.inputMatchesCommand(command, cmd_activate)) {
     if (!::Focus.isEOL()) {
       uint8_t layer;
       ::Focus.read(layer);
       ::Layer.activate(layer);
     }
-  } else if (strcmp_P(command, cmd_deactivate) == 0) {
+  } else if (::Focus.inputMatchesCommand(command, cmd_deactivate)) {
     if (!::Focus.isEOL()) {
       uint8_t layer;
       ::Focus.read(layer);
       ::Layer.deactivate(layer);
     }
-  } else if (strcmp_P(command, cmd_isActive) == 0) {
+  } else if (::Focus.inputMatchesCommand(command, cmd_isActive)) {
     if (!::Focus.isEOL()) {
       uint8_t layer;
       ::Focus.read(layer);
       ::Focus.send(::Layer.isActive(layer));
     }
-  } else if (strcmp_P(command, cmd_moveTo) == 0) {
+  } else if (::Focus.inputMatchesCommand(command, cmd_moveTo)) {
     if (!::Focus.isEOL()) {
       uint8_t layer;
       ::Focus.read(layer);
       ::Layer.move(layer);
     }
-  } else if (strcmp_P(command, cmd_state) == 0) {
+  } else if (::Focus.inputMatchesCommand(command, cmd_state)) {
     if (::Focus.isEOL()) {
       for (uint8_t i = 0; i < 32; i++) {
         ::Focus.send(::Layer.isActive(i) ? 1 : 0);

--- a/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
+++ b/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
@@ -39,7 +39,7 @@ EventHandlerResult LayerFocus::onFocusEvent(const char *command) {
   const char *cmd_moveTo     = PSTR("layer.moveTo");
   const char *cmd_state      = PSTR("layer.state");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_activate,
                              cmd_deactivate,
                              cmd_isActive,

--- a/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
+++ b/plugins/Kaleidoscope-LayerFocus/src/kaleidoscope/plugin/LayerFocus.cpp
@@ -33,11 +33,11 @@ EventHandlerResult LayerFocus::onNameQuery() {
 }
 
 EventHandlerResult LayerFocus::onFocusEvent(const char *command) {
-  const char *cmd_activate = PSTR("layer.activate");
+  const char *cmd_activate   = PSTR("layer.activate");
   const char *cmd_deactivate = PSTR("layer.deactivate");
-  const char *cmd_isActive = PSTR("layer.isActive");
-  const char *cmd_moveTo = PSTR("layer.moveTo");
-  const char *cmd_state = PSTR("layer.state");
+  const char *cmd_isActive   = PSTR("layer.isActive");
+  const char *cmd_moveTo     = PSTR("layer.moveTo");
+  const char *cmd_state      = PSTR("layer.state");
 
   if (::Focus.isHelp(command))
     return ::Focus.printHelp(cmd_activate,

--- a/plugins/Kaleidoscope-LayerNames/src/kaleidoscope/plugin/LayerNames.cpp
+++ b/plugins/Kaleidoscope-LayerNames/src/kaleidoscope/plugin/LayerNames.cpp
@@ -32,8 +32,8 @@ EventHandlerResult LayerNames::onNameQuery() {
 }
 
 EventHandlerResult LayerNames::onFocusEvent(const char *command) {
-  if (::Focus.handleHelp(command, PSTR("keymap.layerNames")))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(PSTR("keymap.layerNames"));
 
   if (strcmp_P(command, PSTR("keymap.layerNames")) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-LayerNames/src/kaleidoscope/plugin/LayerNames.cpp
+++ b/plugins/Kaleidoscope-LayerNames/src/kaleidoscope/plugin/LayerNames.cpp
@@ -32,10 +32,12 @@ EventHandlerResult LayerNames::onNameQuery() {
 }
 
 EventHandlerResult LayerNames::onFocusEvent(const char *command) {
-  if (::Focus.isHelp(command))
-    return ::Focus.printHelp(PSTR("keymap.layerNames"));
+  const char *cmd_layerNames = PSTR("keymap.layerNames");
 
-  if (strcmp_P(command, PSTR("keymap.layerNames")) != 0)
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(cmd_layerNames);
+
+  if (strcmp_P(command, cmd_layerNames) != 0)
     return EventHandlerResult::OK;
 
   if (::Focus.isEOL()) {

--- a/plugins/Kaleidoscope-LayerNames/src/kaleidoscope/plugin/LayerNames.cpp
+++ b/plugins/Kaleidoscope-LayerNames/src/kaleidoscope/plugin/LayerNames.cpp
@@ -16,7 +16,7 @@
 
 #include "kaleidoscope/plugin/LayerNames.h"
 
-#include <Arduino.h>                   // for delay, PSTR, strcmp_P, F, __FlashStri...
+#include <Arduino.h>                   // for delay, PSTR, F, __FlashStri...
 #include <Kaleidoscope-FocusSerial.h>  // for Focus, FocusSerial
 
 #include "kaleidoscope/Runtime.h"                 // for Runtime, Runtime_
@@ -37,7 +37,7 @@ EventHandlerResult LayerNames::onFocusEvent(const char *command) {
   if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_layerNames);
 
-  if (strcmp_P(command, cmd_layerNames) != 0)
+  if (!::Focus.inputMatchesCommand(command, cmd_layerNames))
     return EventHandlerResult::OK;
 
   if (::Focus.isEOL()) {

--- a/plugins/Kaleidoscope-LayerNames/src/kaleidoscope/plugin/LayerNames.cpp
+++ b/plugins/Kaleidoscope-LayerNames/src/kaleidoscope/plugin/LayerNames.cpp
@@ -34,7 +34,7 @@ EventHandlerResult LayerNames::onNameQuery() {
 EventHandlerResult LayerNames::onFocusEvent(const char *command) {
   const char *cmd_layerNames = PSTR("keymap.layerNames");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_layerNames);
 
   if (strcmp_P(command, cmd_layerNames) != 0)

--- a/plugins/Kaleidoscope-PersistentLEDMode/src/kaleidoscope/plugin/PersistentLEDMode.cpp
+++ b/plugins/Kaleidoscope-PersistentLEDMode/src/kaleidoscope/plugin/PersistentLEDMode.cpp
@@ -18,7 +18,7 @@
 
 #include "kaleidoscope/plugin/PersistentLEDMode.h"
 
-#include <Arduino.h>                       // for PSTR, strcmp_P, F, __FlashStringHelper
+#include <Arduino.h>                       // for PSTR, F, __FlashStringHelper
 #include <Kaleidoscope-EEPROM-Settings.h>  // for EEPROMSettings
 #include <Kaleidoscope-FocusSerial.h>      // for Focus, FocusSerial
 #include <stdint.h>                        // for uint8_t, uint16_t

--- a/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
+++ b/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
@@ -149,10 +149,10 @@ EventHandlerResult TypingBreaks::onFocusEvent(const char *command) {
   } subCommand;
 
   const char *cmd_idleTimeLimit = PSTR("typingbreaks.idleTimeLimit");
-  const char *cmd_lockTimeOut = PSTR("typingbreaks.lockTimeOut");
-  const char *cmd_lockLength = PSTR("typingbreaks.lockLength");
-  const char *cmd_leftMaxKeys = PSTR("typingbreaks.leftMaxKeys");
-  const char *cmd_rightMaxKeys = PSTR("typingbreaks.rightMaxKeys");
+  const char *cmd_lockTimeOut   = PSTR("typingbreaks.lockTimeOut");
+  const char *cmd_lockLength    = PSTR("typingbreaks.lockLength");
+  const char *cmd_leftMaxKeys   = PSTR("typingbreaks.leftMaxKeys");
+  const char *cmd_rightMaxKeys  = PSTR("typingbreaks.rightMaxKeys");
   if (::Focus.isHelp(command))
     return ::Focus.printHelp(cmd_idleTimeLimit,
                              cmd_lockTimeOut,

--- a/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
+++ b/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
@@ -17,7 +17,7 @@
 
 #include "kaleidoscope/plugin/TypingBreaks.h"
 
-#include <Arduino.h>                       // for PSTR, strcmp_P, F, __FlashStringHelper
+#include <Arduino.h>                       // for PSTR, F, __FlashStringHelper
 #include <Kaleidoscope-EEPROM-Settings.h>  // for EEPROMSettings
 #include <Kaleidoscope-FocusSerial.h>      // for Focus, FocusSerial
 #include <stdint.h>                        // for uint32_t, uint16_t
@@ -160,15 +160,15 @@ EventHandlerResult TypingBreaks::onFocusEvent(const char *command) {
                              cmd_leftMaxKeys,
                              cmd_rightMaxKeys);
 
-  if (strcmp_P(command, cmd_idleTimeLimit) == 0)
+  if (::Focus.inputMatchesCommand(command, cmd_idleTimeLimit))
     subCommand = IDLE_TIME_LIMIT;
-  else if (strcmp_P(command, cmd_lockTimeOut) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_lockTimeOut))
     subCommand = LOCK_TIMEOUT;
-  else if (strcmp_P(command, cmd_lockLength) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_lockLength))
     subCommand = LOCK_LENGTH;
-  else if (strcmp_P(command, cmd_leftMaxKeys) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_leftMaxKeys))
     subCommand = LEFT_MAX;
-  else if (strcmp_P(command, cmd_rightMaxKeys) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_rightMaxKeys))
     subCommand = RIGHT_MAX;
   else
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
+++ b/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
@@ -153,7 +153,7 @@ EventHandlerResult TypingBreaks::onFocusEvent(const char *command) {
   const char *cmd_lockLength    = PSTR("typingbreaks.lockLength");
   const char *cmd_leftMaxKeys   = PSTR("typingbreaks.leftMaxKeys");
   const char *cmd_rightMaxKeys  = PSTR("typingbreaks.rightMaxKeys");
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_idleTimeLimit,
                              cmd_lockTimeOut,
                              cmd_lockLength,

--- a/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
+++ b/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
@@ -148,12 +148,12 @@ EventHandlerResult TypingBreaks::onFocusEvent(const char *command) {
     RIGHT_MAX,
   } subCommand;
 
-  if (::Focus.handleHelp(command, PSTR("typingbreaks.idleTimeLimit\r\n"
-                                       "typingbreaks.lockTimeOut\r\n"
-                                       "typingbreaks.lockLength\r\n"
-                                       "typingbreaks.leftMaxKeys\r\n"
-                                       "typingbreaks.rightMaxKeys")))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(PSTR("typingbreaks.idleTimeLimit"),
+                             PSTR("typingbreaks.lockTimeOut"),
+                             PSTR("typingbreaks.lockLength"),
+                             PSTR("typingbreaks.leftMaxKeys"),
+                             PSTR("typingbreaks.rightMaxKeys"));
 
   if (strncmp_P(command, PSTR("typingbreaks."), 13) != 0)
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
+++ b/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
@@ -148,24 +148,27 @@ EventHandlerResult TypingBreaks::onFocusEvent(const char *command) {
     RIGHT_MAX,
   } subCommand;
 
+  const char *cmd_idleTimeLimit = PSTR("typingbreaks.idleTimeLimit");
+  const char *cmd_lockTimeOut = PSTR("typingbreaks.lockTimeOut");
+  const char *cmd_lockLength = PSTR("typingbreaks.lockLength");
+  const char *cmd_leftMaxKeys = PSTR("typingbreaks.leftMaxKeys");
+  const char *cmd_rightMaxKeys = PSTR("typingbreaks.rightMaxKeys");
   if (::Focus.isHelp(command))
-    return ::Focus.printHelp(PSTR("typingbreaks.idleTimeLimit"),
-                             PSTR("typingbreaks.lockTimeOut"),
-                             PSTR("typingbreaks.lockLength"),
-                             PSTR("typingbreaks.leftMaxKeys"),
-                             PSTR("typingbreaks.rightMaxKeys"));
+    return ::Focus.printHelp(cmd_idleTimeLimit,
+                             cmd_lockTimeOut,
+                             cmd_lockLength,
+                             cmd_leftMaxKeys,
+                             cmd_rightMaxKeys);
 
-  if (strncmp_P(command, PSTR("typingbreaks."), 13) != 0)
-    return EventHandlerResult::OK;
-  if (strcmp_P(command + 13, PSTR("idleTimeLimit")) == 0)
+  if (strcmp_P(command, cmd_idleTimeLimit) == 0)
     subCommand = IDLE_TIME_LIMIT;
-  else if (strcmp_P(command + 13, PSTR("lockTimeOut")) == 0)
+  else if (strcmp_P(command, cmd_lockTimeOut) == 0)
     subCommand = LOCK_TIMEOUT;
-  else if (strcmp_P(command + 13, PSTR("lockLength")) == 0)
+  else if (strcmp_P(command, cmd_lockLength) == 0)
     subCommand = LOCK_LENGTH;
-  else if (strcmp_P(command + 13, PSTR("leftMaxKeys")) == 0)
+  else if (strcmp_P(command, cmd_leftMaxKeys) == 0)
     subCommand = LEFT_MAX;
-  else if (strcmp_P(command + 13, PSTR("rightMaxKeys")) == 0)
+  else if (strcmp_P(command, cmd_rightMaxKeys) == 0)
     subCommand = RIGHT_MAX;
   else
     return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -224,12 +224,12 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
   if (!Runtime.has_leds)
     return EventHandlerResult::OK;
 
-  if (::Focus.handleHelp(command, PSTR("led.at\r\n"
-                                       "led.setAll\r\n"
-                                       "led.mode\r\n"
-                                       "led.brightness\r\n"
-                                       "led.theme")))
-    return EventHandlerResult::OK;
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(PSTR("led.at"),
+                             PSTR("led.setAll"),
+                             PSTR("led.mode"),
+                             PSTR("led.brightness"),
+                             PSTR("led.theme"));
 
   if (strncmp_P(command, PSTR("led."), 4) != 0)
     return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -224,11 +224,11 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
   if (!Runtime.has_leds)
     return EventHandlerResult::OK;
 
-  const char *cmd_at = PSTR("led.at");
-  const char *cmd_setAll = PSTR("led.setAll");
-  const char *cmd_mode = PSTR("led.mode");
+  const char *cmd_at         = PSTR("led.at");
+  const char *cmd_setAll     = PSTR("led.setAll");
+  const char *cmd_mode       = PSTR("led.mode");
   const char *cmd_brightness = PSTR("led.brightness");
-  const char *cmd_theme = PSTR("led.theme");
+  const char *cmd_theme      = PSTR("led.theme");
 
   if (::Focus.isHelp(command))
     return ::Focus.printHelp(cmd_at,

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -16,7 +16,7 @@
 
 #include "kaleidoscope/plugin/LEDControl.h"
 
-#include <Arduino.h>                   // for PSTR, strcmp_P, strncmp_P
+#include <Arduino.h>                   // for PSTR, strncmp_P
 #include <Kaleidoscope-FocusSerial.h>  // for Focus, FocusSerial
 
 #include "kaleidoscope/KeyAddrMap.h"               // for KeyAddrMap<>::Iterator, KeyAddrMap
@@ -237,15 +237,15 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
                              cmd_brightness,
                              cmd_theme);
 
-  if (strcmp_P(command, cmd_at) == 0)
+  if (::Focus.inputMatchesCommand(command, cmd_at))
     subCommand = AT;
-  else if (strcmp_P(command, cmd_setAll) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_setAll))
     subCommand = SETALL;
-  else if (strcmp_P(command, cmd_mode) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_mode))
     subCommand = MODE;
-  else if (strcmp_P(command, cmd_theme) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_theme))
     subCommand = THEME;
-  else if (strcmp_P(command, cmd_brightness) == 0)
+  else if (::Focus.inputMatchesCommand(command, cmd_brightness))
     subCommand = BRIGHTNESS;
   else
     return EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -230,7 +230,7 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
   const char *cmd_brightness = PSTR("led.brightness");
   const char *cmd_theme      = PSTR("led.theme");
 
-  if (::Focus.isHelp(command))
+  if (::Focus.inputMatchesHelp(command))
     return ::Focus.printHelp(cmd_at,
                              cmd_setAll,
                              cmd_mode,

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -224,24 +224,28 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
   if (!Runtime.has_leds)
     return EventHandlerResult::OK;
 
-  if (::Focus.isHelp(command))
-    return ::Focus.printHelp(PSTR("led.at"),
-                             PSTR("led.setAll"),
-                             PSTR("led.mode"),
-                             PSTR("led.brightness"),
-                             PSTR("led.theme"));
+  const char *cmd_at = PSTR("led.at");
+  const char *cmd_setAll = PSTR("led.setAll");
+  const char *cmd_mode = PSTR("led.mode");
+  const char *cmd_brightness = PSTR("led.brightness");
+  const char *cmd_theme = PSTR("led.theme");
 
-  if (strncmp_P(command, PSTR("led."), 4) != 0)
-    return EventHandlerResult::OK;
-  if (strcmp_P(command + 4, PSTR("at")) == 0)
+  if (::Focus.isHelp(command))
+    return ::Focus.printHelp(cmd_at,
+                             cmd_setAll,
+                             cmd_mode,
+                             cmd_brightness,
+                             cmd_theme);
+
+  if (strcmp_P(command, cmd_at) == 0)
     subCommand = AT;
-  else if (strcmp_P(command + 4, PSTR("setAll")) == 0)
+  else if (strcmp_P(command, cmd_setAll) == 0)
     subCommand = SETALL;
-  else if (strcmp_P(command + 4, PSTR("mode")) == 0)
+  else if (strcmp_P(command, cmd_mode) == 0)
     subCommand = MODE;
-  else if (strcmp_P(command + 4, PSTR("theme")) == 0)
+  else if (strcmp_P(command, cmd_theme) == 0)
     subCommand = THEME;
-  else if (strcmp_P(command + 4, PSTR("brightness")) == 0)
+  else if (strcmp_P(command, cmd_brightness) == 0)
     subCommand = BRIGHTNESS;
   else
     return EventHandlerResult::OK;


### PR DESCRIPTION
In a similar - but perhaps bolder - spirit as #1230, this is a refactor of some parts of `Focus`, namely the parts around `onFocusEvent`. It introduces a number of new helper functions, and replaces a number of patterns with something that I believe to be better.

The refactor is likely best explained by a few examples that show the old and new ways. The old ways still work, mind you, compatibility is not broken, but the new patterns are more efficient.

## `Focus.handleHelp` => `.inputMatchesHelp()` + `.printHelp()`

Old:

```c++
  if (::Focus.handleHelp(command, PSTR("autoshift.enabled\r\n"
                                       "autoshift.timeout\r\n"
                                       "autoshift.categories")))
    return EventHandlerResult::OK;
```

New:

```c++
  const char *cmd_enabled    = PSTR("autoshift.enabled");
  const char *cmd_timeout    = PSTR("autoshift.timeout");
  const char *cmd_categories = PSTR("autoshift.categories");

  if (::Focus.inputMatchesHelp(command))
    return ::Focus.printHelp(cmd_enabled, cmd_timeout, cmd_categories);
```

## Subcommands

Old:

```c++
  if (strncmp_P(command, PSTR("autoshift."), 10) != 0)
    return EventHandlerResult::OK;
  if (strcmp_P(command + 10, PSTR("enabled")) == 0)
    subCommand = ENABLED;
  else if (strcmp_P(command + 10, PSTR("timeout")) == 0)
    subCommand = TIMEOUT;
  else if (strcmp_P(command + 10, PSTR("categories")) == 0)
    subCommand = CATEGORIES;
  else
    return EventHandlerResult::OK;
```

New:

```c++
  if (::Focus.inputMatchesCommand(command, cmd_enabled))
    subCommand = ENABLED;
  else if (::Focus.inputMatchesCommand(command, cmd_timeout))
    subCommand = TIMEOUT;
  else if (::Focus.inputMatchesCommand(command, cmd_categories))
    subCommand = CATEGORIES;
  else
    return EventHandlerResult::OK;
```

There are multiple wins here.

First, we no longer need to hand-write the help message. We can reuse the same strings used for the help for detecting the commands we handle. This reduces duplicated strings considerably.

Second, we no longer need to check for a prefix first (an error prone operation previously, having to maintain the prefix length for the `strncmp_P` call), we can just check the full command against the strings we used for `help`. This makes the flow of code shorter, and cleaner.

Third, since we no longer need the prefix check, that's both code dropped, and smaller binary size.

## `inputMatchesCommand`

This helper is also used above, but it doesn't depend on subcommands, can be used anytime we want to check if a particular input matches a command.

# Size matters!

Comparing the sketches of `Chrysalis-Firmware-Bundle`:

- ErgoDox is down 72 bytes
- Keyboardio Atreus is down by 80 bytes
- Keyboardio Model01 is down by 34 bytes
- Keyboardio Model100 is up by 160 bytes (but the Model100 is unoptimized, and has a lot of space, so doesn't matter much at this point)
- Splitography is down by 72 bytes
- Original Atreus is down by 72 bytes

Not a lot of bytes saved, but considering that the code got cleaner, and easier, and our size went down, rather than up, I'll call that a big win anyway.

# TODO

- [ ] Review the naming. Not entirely happy with `.inputMatchesCommand(command, cmd_something)`.
- [ ] Clean up the history
- [ ] Update the FocusSerial README to show the new helpers
- [ ] Update `UPGRADING.md` too