### PR TITLE
DefaultLEDModeConfig: Fix a typo in the documentation

### DIFF
--- a/plugins/Kaleidoscope-DefaultLEDModeConfig/README.md
+++ b/plugins/Kaleidoscope-DefaultLEDModeConfig/README.md
@@ -31,7 +31,7 @@ KALEIDOSCOPE_INIT_PLUGINS(EEPROMSettings,
 void setup() {
   Kaleidoscope.setup();
 
-  DefaultLEDModeConfig.activeLEDModeIfUnconfigured(
+  DefaultLEDModeConfig.activateLEDModeIfUnconfigured(
     &LEDRainbowWaveEffect
   );
 }


### PR DESCRIPTION
The example in the documentation was referring to a function that does not exist. Correct it to use the one that does.
