### PR TITLE
restore gamma correction on Model 100

### DIFF
--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/driver/keyboardio/Model100Side.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/driver/keyboardio/Model100Side.cpp
@@ -214,6 +214,7 @@ void Model100Side::sendLEDData() {
   }
 }
 
+auto constexpr gamma8 = kaleidoscope::driver::color::gamma_correction;
 
 void Model100Side::sendLEDBank(uint8_t bank) {
   uint8_t data[LED_BYTES_PER_BANK + 1];
@@ -229,25 +230,25 @@ void Model100Side::sendLEDBank(uint8_t bank) {
     else
       c = 0;
 
-    data[i + 1] = c;
+    data[i + 1] = pgm_read_byte(&gamma8[c]);
   }
   uint8_t result = writeData(data, ELEMENTS(data));
 }
 
 void Model100Side::setAllLEDsTo(cRGB color) {
   uint8_t data[] = {TWI_CMD_LED_SET_ALL_TO,
-                    color.b,
-                    color.g,
-                    color.r};
+                    pgm_read_byte(&gamma8[color.b]),
+                    pgm_read_byte(&gamma8[color.g]),
+                    pgm_read_byte(&gamma8[color.r])};
   uint8_t result = writeData(data, ELEMENTS(data));
 }
 
 void Model100Side::setOneLEDTo(uint8_t led, cRGB color) {
   uint8_t data[] = {TWI_CMD_LED_SET_ONE_TO,
                     led,
-                    color.b,
-                    color.g,
-                    color.r};
+                    pgm_read_byte(&gamma8[color.b]),
+                    pgm_read_byte(&gamma8[color.g]),
+                    pgm_read_byte(&gamma8[color.r])};
   uint8_t result = writeData(data, ELEMENTS(data));
 }
 


### PR DESCRIPTION
This reverts commit 1d8eb6d2e22026ad55b9bf967bd2119db8cc508f.

Rainbow effects on the Model 100 had some harsh transitions, especially from red/orange to yellow.

@obra reported that the gamma implementation was disabled on the Model 100 earlier because it broke the firmware so badly that the keyboard was unusable for typing. This no longer seems to be the case, possibly due to changes in the Arduino core and/or <pgmspace.h> compatibility.
