### PR TITLE
SpaceCadet: Fix flushing the on-tap action

### DIFF
--- a/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadet.cpp
+++ b/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadet.cpp
@@ -193,7 +193,7 @@ void SpaceCadet::flushEvent(bool is_tap) {
     event.key = map_[pending_map_index_].output;
   }
   event_queue_.shift();
-  Runtime.handleKeyswitchEvent(event);
+  Runtime.handleKeyEvent(event);
 }
 
 }  // namespace plugin


### PR DESCRIPTION
When flushing the on-tap action, we need to use `handleKeyEvent`, because our address may not be valid, and `handleKeyswitchEvent` will not perform the action if the address is invalid.

This addresses keyboardio/Chrysalis#1055.