### PR TITLE
New plugin: LEDBrightnessConfig

### DIFF
--- a/plugins/Kaleidoscope-LEDBrightnessConfig/README.md
+++ b/plugins/Kaleidoscope-LEDBrightnessConfig/README.md
@@ -1,0 +1,41 @@
+# LEDBrightnessConfig
+
+The `LEDBrightnessConfig` plugin provides a way to set the brightness of all
+LEDs on a keyboard, and persist this setting to EEPROM too.
+
+## Using the plugin
+
+```c++
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-EEPROM-Settings.h>
+#include <Kaleidoscope-LEDControl.h>
+#include <Kaleidoscope-LEDBrightnessConfig.h>
+#include <Kaleidoscope-LEDEffect-Rainbow.h>
+#include <Kaleidoscope-FocusSerial.h>
+
+KALEIDOSCOPE_INIT_PLUGINS(EEPROMSettings,
+                          LEDControl,
+                          LEDOff,
+                          LEDRainbowEffect,
+                          LEDRainbowWaveEffect,
+                          Focus,
+                          LEDBrightnessConfig);
+
+void setup() {
+  Kaleidoscope.setup();
+}
+```
+
+## Focus commands
+
+### `led.brightness`
+
+> Without arguments, prints the current brightness.
+>
+> If an argument is given, it sets the brightness to the desired value, and
+> stores it in EEPROM.
+
+## Dependencies
+
+* [Kaleidoscope-EEPROM-Settings](Kaleidoscope-EEPROM-Settings.md)
+* [Kaleidoscope-FocusSerial](Kaleidoscope-FocusSerial.md)

--- a/plugins/Kaleidoscope-LEDBrightnessConfig/library.properties
+++ b/plugins/Kaleidoscope-LEDBrightnessConfig/library.properties
@@ -1,0 +1,7 @@
+name=Kaleidoscope-LEDBrightnessConfig
+version=0.0.0
+sentence=LED Brightness configuration, with EEPROM persistence
+maintainer=Kaleidoscope's Developers <jesse@keyboard.io>
+url=https://github.com/keyboardio/Kaleidoscope
+author=Keyboardio
+paragraph=

--- a/plugins/Kaleidoscope-LEDBrightnessConfig/src/Kaleidoscope-LEDBrightnessConfig.h
+++ b/plugins/Kaleidoscope-LEDBrightnessConfig/src/Kaleidoscope-LEDBrightnessConfig.h
@@ -1,0 +1,20 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2022  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "kaleidoscope/plugin/LEDBrightnessConfig.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LEDBrightnessConfig/src/kaleidoscope/plugin/LEDBrightnessConfig.cpp
+++ b/plugins/Kaleidoscope-LEDBrightnessConfig/src/kaleidoscope/plugin/LEDBrightnessConfig.cpp
@@ -1,0 +1,77 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2022  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "kaleidoscope/plugin/LEDBrightnessConfig.h"
+
+#include <Arduino.h>                       // for PSTR, strcmp_P, F, __FlashStringHelper
+#include <Kaleidoscope-EEPROM-Settings.h>  // for EEPROMSettings
+#include <Kaleidoscope-FocusSerial.h>      // for Focus, FocusSerial
+#include <stdint.h>                        // for uint8_t, uint16_t
+
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for VirtualProps::Storage, Base<>::Storage
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult, EventHandlerResult::OK
+#include "kaleidoscope/plugin/LEDControl.h"     // for LEDControl
+
+namespace kaleidoscope {
+namespace plugin {
+
+uint16_t LEDBrightnessConfig::settings_base_;
+struct LEDBrightnessConfig::settings LEDBrightnessConfig::settings_;
+
+EventHandlerResult LEDBrightnessConfig::onSetup() {
+  settings_base_ = ::EEPROMSettings.requestSlice(sizeof(settings_));
+
+  Runtime.storage().get(settings_base_, settings_);
+
+  // We do not need to treat uninitialized slices in any special way, because
+  // uninitialized defaults to `255`, which happens to be our desired default
+  // brightness, too.
+  ::LEDControl.setBrightness(settings_.brightness);
+
+  return EventHandlerResult::OK;
+}
+
+EventHandlerResult LEDBrightnessConfig::onFocusEvent(const char *command) {
+  const char *cmd = PSTR("led.brightness");
+
+  if (::Focus.handleHelp(command, cmd))
+    return EventHandlerResult::OK;
+
+  if (strcmp_P(command, cmd) != 0)
+    return EventHandlerResult::OK;
+
+  if (::Focus.isEOL()) {
+    ::Focus.send(settings_.brightness);
+  } else {
+    ::Focus.read(settings_.brightness);
+    ::LEDControl.setBrightness(settings_.brightness);
+    Runtime.storage().put(settings_base_, settings_);
+    Runtime.storage().commit();
+  }
+
+  return EventHandlerResult::EVENT_CONSUMED;
+}
+
+EventHandlerResult LEDBrightnessConfig::onNameQuery() {
+  return ::Focus.sendName(F("LEDBrightnessConfig"));
+}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
+
+kaleidoscope::plugin::LEDBrightnessConfig LEDBrightnessConfig;

--- a/plugins/Kaleidoscope-LEDBrightnessConfig/src/kaleidoscope/plugin/LEDBrightnessConfig.h
+++ b/plugins/Kaleidoscope-LEDBrightnessConfig/src/kaleidoscope/plugin/LEDBrightnessConfig.h
@@ -1,0 +1,44 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2022  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>  // for uint8_t, uint16_t
+
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
+#include "kaleidoscope/plugin.h"                // for Plugin
+
+namespace kaleidoscope {
+namespace plugin {
+
+class LEDBrightnessConfig : public kaleidoscope::Plugin {
+ public:
+  EventHandlerResult onSetup();
+  EventHandlerResult onNameQuery();
+  EventHandlerResult onFocusEvent(const char *command);
+
+ private:
+  static uint16_t settings_base_;
+  static struct settings {
+    uint8_t brightness;
+  } settings_;
+};
+
+}  // namespace plugin
+}  // namespace kaleidoscope
+
+extern kaleidoscope::plugin::LEDBrightnessConfig LEDBrightnessConfig;

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -27,6 +27,16 @@
 #include "kaleidoscope/plugin.h"                   // for Plugin
 #include "kaleidoscope/plugin/LEDMode.h"           // for LEDMode
 #include "kaleidoscope/plugin/LEDModeInterface.h"  // for LEDModeInterface
+// -----------------------------------------------------------------------------
+// Deprecation warning messages
+#include "kaleidoscope_internal/deprecations.h"  // for DEPRECATED
+
+#define _DEPRECATED_MESSAGE_FOCUSLEDCOMMAND                                  \
+  "The `FocusLEDCommand` plugin is deprecated. For its most useful\n"        \
+  "functionality - led.brightness -, please see the `LEDBrightnessConfig`\n" \
+  "plugin.\n"                                                                \
+  "This plugin will be removed after 2023-01-01."
+// -----------------------------------------------------------------------------
 
 constexpr uint8_t LED_TOGGLE = 0b00000001;  // Synthetic, internal
 
@@ -128,6 +138,7 @@ class LEDControl : public kaleidoscope::Plugin {
   static bool enabled_;
 };
 
+DEPRECATED(FOCUSLEDCOMMAND)
 class FocusLEDCommand : public Plugin {
  public:
   FocusLEDCommand() {}


### PR DESCRIPTION
This plugin provides a `led.brightness` Focus command, along with persisting the setting to EEPROM. This is a superset of the command of the same name provided by `FocusLEDCommand` in `LEDControl`.

The reason this is a separate plugin is because I did not want to introduce an EEPROM dependency to `FocusLEDCommand`. The plugin uses the same command name however, to be compatible with the existing support in Chrysalis, and because it is a superset anyway.

The two plugins can both be used at the same time, as long as this new one comes first in the list, to take precedence: it will handle `led.brightness`, while `FocusLEDCommand` can handle the rest.

This addresses the Kaleidoscope parts of keyboardio/Chrysalis#1114.