### PR TITLE
Make the test suite a lot faster without sacrificing anything.

### DIFF
--- a/etc/makefiles/sketch.mk
+++ b/etc/makefiles/sketch.mk
@@ -191,9 +191,8 @@ endif
 #TODO (arduino team) I'd love to do this with their json output
 #but it's short some of the data we kind of need
 
-flashing_instructions = $(call _arduino_prop,build.flashing_instructions)
 
-_device_port = $(shell $(ARDUINO_CLI) board list --format=text | grep $(FQBN) |cut -d' ' -f 1)
+flashing_instructions = $(call _arduino_prop,build.flashing_instructions)
 
 flash: ${HEX_FILE_PATH}
 ifneq ($(flashing_instructions),)
@@ -205,11 +204,11 @@ endif
 	$(info When you're ready to proceed, press 'Enter'.)
 	$(info )
 	@$(shell read _)
-# If we have a device serial port available, try to trigger a Kaliedoscope reset
-ifneq ($(_device_port),)
-	-$(QUIET) DEVICE=$(_device_port) $(KALEIDOSCOPE_DIR)/bin/focus-send "device.reset"
-	sleep 2
-endif
+	# If we have a device serial port available, try to trigger a Kaliedoscope reset
+	-$(QUIET) DEVICE=$(shell $(ARDUINO_CLI) board list --format=text | grep $(FQBN) |cut -d' ' -f 1) && \
+		[ -e $$DEVICE ] && \
+		$(KALEIDOSCOPE_DIR)/bin/focus-send "device.reset" && \
+		sleep 2
 	$(QUIET) $(ARDUINO_CLI) upload --fqbn $(FQBN) \
 	$(shell $(ARDUINO_CLI) board list --format=text | grep $(FQBN) |cut -d' ' -f 1 | xargs -n 1 echo "--port" ) \
 	--input-dir "${OUTPUT_PATH}" \


### PR DESCRIPTION
Because of how makefile rules are evaluated, the previous code was detecting the device port at evaluation time rather than execution time.

This meant that we were doing the "where is the board" check for any compilation target, even if we'd never flash.

Arduino's board probing is somewhat heavyweight and can take a couple of seconds.

We move that logic into a shell expression executed at runtime.

On my laptop, this shaves 10 seconds off make -j 9 simulator tests, which is pretty nice since that used to take about 30 seconds.

But on a plain `make simulator-tests`, it shaved a full minute from the 2 minute and 30 second runtime.