### PR TITLE
HostPowerManagement: Lift out the suspension check, to remove code duplication

### DIFF
--- a/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.h
+++ b/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.h
@@ -35,6 +35,8 @@ class HostPowerManagement : public kaleidoscope::Plugin {
  private:
   static bool was_suspended_;
   static bool initial_suspend_;
+
+  bool isSuspended();
 };
 
 }  // namespace plugin


### PR DESCRIPTION
The difference between the AVR and the GD32 implementation was the way we checked if the device is suspended, otherwise the logic was exactly the same, duplicated.

To remove the need for duplicating the same code for every architecture we support, lift out the suspension check instead. This way the core logic becomes shared between all of them.
