### PR TITLE
fix race in sketch.mk

### DIFF
--- a/etc/makefiles/sketch.mk
+++ b/etc/makefiles/sketch.mk
@@ -164,7 +164,7 @@ endif
 compile: kaleidoscope-hardware-configured
 
 
-	$(QUIET) install -d "${OUTPUT_PATH}"
+	-$(QUIET) install -d "${OUTPUT_PATH}"
 	$(QUIET) $(ARDUINO_CLI) compile --fqbn "${FQBN}" ${ARDUINO_VERBOSE} ${ccache_wrapper_property} ${local_cflags_property} \
 	  ${_arduino_local_libraries_prop} ${_ARDUINO_CLI_COMPILE_CUSTOM_FLAGS} \
 	  --library "${KALEIDOSCOPE_DIR}" \


### PR DESCRIPTION
Fix a race condition in `sketch.mk` that tends to pop up when doing `make -j smoke-sketches`. Ignore failures from `install -d`, because they seem to only occur due to a TOCTOU condition in `install`.

Fixes #1258.