### PR TITLE
clean up HostPowerManagement

### DIFF
--- a/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.cpp
+++ b/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.cpp
@@ -26,15 +26,10 @@
 
 #include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult, EventHandlerResult::OK
 
-// This is a terrible hack until Arduino#6964 gets implemented.
-// It makes the `_usbSuspendState` symbol available to us.
-extern uint8_t _usbSuspendState;
-
 namespace kaleidoscope {
 namespace plugin {
 
-bool HostPowerManagement::was_suspended_   = false;
-bool HostPowerManagement::initial_suspend_ = true;
+bool HostPowerManagement::was_suspended_ = false;
 
 bool HostPowerManagement::isSuspended() {
 #if defined(__AVR__)
@@ -48,17 +43,13 @@ bool HostPowerManagement::isSuspended() {
 
 EventHandlerResult HostPowerManagement::beforeEachCycle() {
   if (isSuspended()) {
-    if (!initial_suspend_) {
-      if (!was_suspended_) {
-        was_suspended_ = true;
-        hostPowerManagementEventHandler(Suspend);
-      } else {
-        hostPowerManagementEventHandler(Sleep);
-      }
+    if (!was_suspended_) {
+      was_suspended_ = true;
+      hostPowerManagementEventHandler(Suspend);
+    } else {
+      hostPowerManagementEventHandler(Sleep);
     }
   } else {
-    if (initial_suspend_)
-      initial_suspend_ = false;
     if (was_suspended_) {
       was_suspended_ = false;
       hostPowerManagementEventHandler(Resume);

--- a/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.h
+++ b/plugins/Kaleidoscope-HostPowerManagement/src/kaleidoscope/plugin/HostPowerManagement.h
@@ -34,7 +34,6 @@ class HostPowerManagement : public kaleidoscope::Plugin {
 
  private:
   static bool was_suspended_;
-  static bool initial_suspend_;
 
   bool isSuspended();
 };


### PR DESCRIPTION
Remove the effectively unused `initial_suspend_` variable. It wasn't doing  anything useful, because it was set to false on the first round through the event loop. Also remove the unused reference to the internal AVR USB core variable `_usbSuspendState`.

Saves 18 bytes of flash on AVR, and 32 on GD32.
