### PR TITLE
use device.reset less

### DIFF
--- a/etc/makefiles/sketch.mk
+++ b/etc/makefiles/sketch.mk
@@ -204,11 +204,14 @@ endif
 	$(info When you're ready to proceed, press 'Enter'.)
 	$(info )
 	@$(shell read _)
+	# Earlier Model 100 firmware didn't implement 1200bps touch
+ifeq ($(FQBN),keyboardio:gd32:keyboardio_model_100)
 	# If we have a device serial port available, try to trigger a Kaliedoscope reset
 	-$(QUIET) export DEVICE=$(shell $(ARDUINO_CLI) board list --format=text | grep $(FQBN) |cut -d' ' -f 1) && \
 		[ -e "$$DEVICE" ] && \
 		$(KALEIDOSCOPE_DIR)/bin/focus-send "device.reset" && \
 		sleep 2
+endif
 	$(QUIET) $(ARDUINO_CLI) upload --fqbn $(FQBN) \
 	$(shell $(ARDUINO_CLI) board list --format=text | grep $(FQBN) |cut -d' ' -f 1 | xargs -n 1 echo "--port" ) \
 	--input-dir "${OUTPUT_PATH}" \


### PR DESCRIPTION
Only use `device.reset` on the Model 100, because we have 1200bps touch capability on everything else, and it was causing some poor UX when flashing the Model 01 from sketch Makefiles.
