### PR TITLE
Layer system bug fixes

### DIFF
--- a/src/kaleidoscope/layers.cpp
+++ b/src/kaleidoscope/layers.cpp
@@ -248,7 +248,7 @@ void Layer_::activateNext() {
 }
 
 void Layer_::deactivateMostRecent() {
-  uint8_t layer = unshifted(active_layers_[active_layer_count_ - 1]);
+  uint8_t layer = active_layers_[active_layer_count_ - 1];
   deactivate(layer);
 }
 

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -102,7 +102,8 @@ class Layer_ {
   static void move(uint8_t layer);
 
   static uint8_t mostRecent() {
-    return active_layers_[active_layer_count_ - 1];
+    uint8_t top_layer = active_layers_[active_layer_count_ - 1];
+    return unshifted(top_layer);
   }
   static bool isActive(uint8_t layer);
 

--- a/src/kaleidoscope/layers.h
+++ b/src/kaleidoscope/layers.h
@@ -28,6 +28,18 @@
 #include "kaleidoscope_internal/device.h"                                 // for device
 #include "kaleidoscope_internal/shortname.h"                              // for _INIT_HID_GETSH...
 #include "kaleidoscope_internal/sketch_exploration/sketch_exploration.h"  // for _INIT_SKETCH_EX...
+// -----------------------------------------------------------------------------
+// Deprecation warning messages
+#include "kaleidoscope_internal/deprecations.h"  // for DEPRECATED
+
+#define _DEPRECATED_MESSAGE_LAYER_ACTIVATE_NEXT                             \
+  "The `Layer.activateNext() function is deprecated, and will be removed\n" \
+  "after 2023-04-06."
+
+#define _DEPRECATED_MESSAGE_LAYER_DEACTIVATE_MOST_RECENT                    \
+  "The `Layer.deactivateMostRecent() function is deprecated, and will be\n" \
+  "removed after 2023-04-06."
+// -----------------------------------------------------------------------------
 
 // clang-format off
 #ifndef MAX_ACTIVE_LAYERS
@@ -97,7 +109,9 @@ class Layer_ {
 
   static void activate(uint8_t layer);
   static void deactivate(uint8_t layer);
+  DEPRECATED(LAYER_ACTIVATE_NEXT)
   static void activateNext();
+  DEPRECATED(LAYER_DEACTIVATE_MOST_RECENT)
   static void deactivateMostRecent();
   static void move(uint8_t layer);
 


### PR DESCRIPTION
This fixes a couple of bugs introduce by #1039, but which had gone unnoticed because no core plugins made use of the affected functions.

- `Layer.mostRecent()` — Because shifted (momentary) layers are now represented with an offset on the layer stack, this function was returning unexpected results when a shifted layer was on top of the stack.  This bug has been fixed by always returning the "unshifted" layer number, with the offset removed.
- `Layer.deactivateMostRecent()` — I had erroneously "unshifted" the value of the top layer before calling `deactivate()` on it.  This was clearly an error, and could have resulted in the wrong layer being deactivated anywhere in the stack.

In addition to fixing these bugs, I've deprecated both `deactivateMostRecent()` and `activateNext()` on the grounds that they are not used, and don't really make sense any longer, now that the layer system is no longer index-based.

[Thanks to @sboesebeck for discovering the problem with `mostRecent()`.]