### PR TITLE
OneShot: Add an optional OneShotConfig plugin

### DIFF
--- a/plugins/Kaleidoscope-OneShot/README.md
+++ b/plugins/Kaleidoscope-OneShot/README.md
@@ -65,6 +65,13 @@ void setup() {
 }
 ```
 
+To enable configuring the plugin via [Focus][focus] (including via
+[Chrysalis][chrysalis]), one will also need the `OneShotConfig` plugin enabled
+in addition.
+
+ [focus]: Kaleidoscope-FocusSerial.md
+ [chrysalis]: https://github.com/keyboardio/Chrysalis
+
 ## Keymap markup
 
 There are two macros the plugin provides:
@@ -230,7 +237,7 @@ modifiers and one-shot layer keys. It has the following methods:
 > Immediately deactivates the one-shot status of any _temporary_
 > one-shot keys. Any keys still being physically held will continue to
 > function as normal modifier/layer-shift keys.
-> 
+>
 > If `with_stickies` is `true` (the default is `false`), _sticky_
 > one-shot keys will also be deactivated, in the same way.
 
@@ -275,9 +282,43 @@ based on `Key` values; it has since be rewritten to be based on
 > not a one-shot key is still pressed any more. This function was
 > mainly used by LED-ActiveModColor, which no longer needs it.
 
+## Focus commands
+
+When the `OneShotConfig` plugin is enabled, the following Focus commands become
+available:
+
+### `.timeout`
+### `.hold_timeout`
+### `.double_tap_timeout`
+
+> These correspond to the `.setTimeout()`, `.setHoldTimeout()`, and
+> `.setDoubleTapTimeout()` methods, and can be used to query or set the
+> respective timeout value. When used without an argument, the command will
+> print the current timeout value. When used with one, it will update it.
+
+### `.auto_modifiers`
+### `.auto_layers`
+
+> Corresponds to the `.enableAutoModifiers()` and `.enableAutoLayers()` methods.
+> Used without an argument, the command will print the current status of the
+> setting, otherwise it will update it.
+>
+> A value of `1` means the setting is enabled, a value of `0` means it is disabled.
+
+### `.stickable_keys`
+
+> Can be used to query or set the bitmap used for controlling the stickability
+> of the oneshot modifier and layer keys. Constructing the bitmap is
+> complicated, and is best done through Chrysalis.
+
 ## Dependencies
 
 * [Kaleidoscope-Ranges](Kaleidoscope-Ranges.md)
+
+If the `OneShotConfig` plugin is enabled, additional dependencies are:
+
+* [Kaleidoscope-EEPROM-Settings](Kaleidoscope-EEPROM-Settings.md)
+* [Kaleidoscope-FocusSerial][focus]
 
 ## Further reading
 

--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.h
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.h
@@ -74,10 +74,10 @@ class OneShot : public kaleidoscope::Plugin {
   void disableStickabilityForLayers();
 
   void enableAutoModifiers() {
-    auto_modifiers_ = true;
+    settings_.auto_modifiers = true;
   }
   void enableAutoLayers() {
-    auto_layers_ = true;
+    settings_.auto_layers = true;
   }
   void enableAutoOneShot() {
     enableAutoModifiers();
@@ -85,10 +85,10 @@ class OneShot : public kaleidoscope::Plugin {
   }
 
   void disableAutoModifiers() {
-    auto_modifiers_ = false;
+    settings_.auto_modifiers = false;
   }
   void disableAutoLayers() {
-    auto_layers_ = false;
+    settings_.auto_layers = false;
   }
   void disableAutoOneShot() {
     disableAutoModifiers();
@@ -96,13 +96,13 @@ class OneShot : public kaleidoscope::Plugin {
   }
 
   void toggleAutoModifiers() {
-    auto_modifiers_ = !auto_modifiers_;
+    settings_.auto_modifiers = !settings_.auto_modifiers;
   }
   void toggleAutoLayers() {
-    auto_layers_ = !auto_layers_;
+    settings_.auto_layers = !settings_.auto_layers;
   }
   void toggleAutoOneShot() {
-    if (auto_modifiers_ || auto_layers_) {
+    if (settings_.auto_modifiers || settings_.auto_layers) {
       disableAutoOneShot();
     } else {
       enableAutoOneShot();
@@ -172,13 +172,22 @@ class OneShot : public kaleidoscope::Plugin {
   // --------------------------------------------------------------------------
   // Timeout onfiguration functions
   void setTimeout(uint16_t ttl) {
-    timeout_ = ttl;
+    settings_.timeout = ttl;
+  }
+  uint16_t getTimeout() {
+    return settings_.timeout;
   }
   void setHoldTimeout(uint16_t ttl) {
-    hold_timeout_ = ttl;
+    settings_.hold_timeout = ttl;
+  }
+  uint16_t getHoldTimeout() {
+    return settings_.hold_timeout;
   }
   void setDoubleTapTimeout(int16_t ttl) {
-    double_tap_timeout_ = ttl;
+    settings_.double_tap_timeout = ttl;
+  }
+  int16_t getDoubleTapTimeout() {
+    return settings_.double_tap_timeout;
   }
 
   // --------------------------------------------------------------------------
@@ -201,13 +210,22 @@ class OneShot : public kaleidoscope::Plugin {
 
   // --------------------------------------------------------------------------
   // Configuration variables
-  uint16_t timeout_           = 2500;
-  uint16_t hold_timeout_      = 250;
-  int16_t double_tap_timeout_ = -1;
+  struct Settings {
+    uint16_t timeout;
+    uint16_t hold_timeout;
+    int16_t double_tap_timeout;
 
-  uint16_t stickable_keys_ = -1;
-  bool auto_modifiers_     = false;
-  bool auto_layers_        = false;
+    uint16_t stickable_keys;
+    bool auto_modifiers;
+    bool auto_layers;
+  } settings_ = {
+    .timeout            = 2500,
+    .hold_timeout       = 250,
+    .double_tap_timeout = -1,
+    .stickable_keys     = -1,
+    .auto_modifiers     = false,
+    .auto_layers        = false,
+  };
 
   // --------------------------------------------------------------------------
   // State variables
@@ -224,7 +242,9 @@ class OneShot : public kaleidoscope::Plugin {
   }
   bool hasDoubleTapTimedOut() const {
     // Derive the true double-tap timeout value if we're using the default.
-    uint16_t dtto = (double_tap_timeout_ < 0) ? timeout_ : double_tap_timeout_;
+    uint16_t dtto = (settings_.double_tap_timeout < 0)
+                      ? settings_.timeout
+                      : settings_.double_tap_timeout;
     return hasTimedOut(dtto);
   }
   uint8_t getOneShotKeyIndex(Key oneshot_key) const;

--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.h
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.h
@@ -198,6 +198,8 @@ class OneShot : public kaleidoscope::Plugin {
   EventHandlerResult afterReportingState(const KeyEvent &event);
   EventHandlerResult afterEachCycle();
 
+  friend class OneShotConfig;
+
  private:
   // --------------------------------------------------------------------------
   // Constants
@@ -256,7 +258,22 @@ class OneShot : public kaleidoscope::Plugin {
   void releaseKey(KeyAddr key_addr);
 };
 
+// =============================================================================
+// Plugin for configuration of OneShot via Focus and persistent storage of
+// settins in EEPROM (i.e. Chrysalis).
+class OneShotConfig : public Plugin {
+ public:
+  EventHandlerResult onNameQuery();
+  EventHandlerResult onSetup();
+  EventHandlerResult onFocusEvent(const char *command);
+
+ private:
+  // The base address in persistent storage for configuration data:
+  uint16_t settings_addr_;
+};
+
 }  // namespace plugin
 }  // namespace kaleidoscope
 
 extern kaleidoscope::plugin::OneShot OneShot;
+extern kaleidoscope::plugin::OneShotConfig OneShotConfig;

--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShotConfig.cpp
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShotConfig.cpp
@@ -1,0 +1,157 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2022  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "kaleidoscope/plugin/OneShot.h"
+
+#include <Arduino.h>                       // for F
+#include <Kaleidoscope-EEPROM-Settings.h>  // for EEPROMSettings
+#include <Kaleidoscope-FocusSerial.h>      // for Focus, FocusSerial
+#include <stdint.h>                        // for uint16_t, uint32_t, uint8_t
+
+#include "kaleidoscope/Runtime.h"               // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"         // for VirtualProps::Storage, Base<>::Storage
+#include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult, EventHandlerResult::OK
+
+namespace kaleidoscope {
+namespace plugin {
+
+EventHandlerResult OneShotConfig::onSetup() {
+  settings_addr_ = ::EEPROMSettings.requestSlice(sizeof(::OneShot.settings_));
+
+  // If the EEPROM is empty, store the default settings.
+  if (Runtime.storage().isSliceUninitialized(settings_addr_, sizeof(::OneShot.settings_))) {
+    Runtime.storage().put(settings_addr_, ::OneShot.settings_);
+    Runtime.storage().commit();
+  }
+
+  Runtime.storage().get(settings_addr_, ::OneShot.settings_);
+  return EventHandlerResult::OK;
+}
+
+EventHandlerResult OneShotConfig::onNameQuery() {
+  return ::Focus.sendName(F("OneShotConfig"));
+}
+
+EventHandlerResult OneShotConfig::onFocusEvent(const char *input) {
+  enum Command : uint8_t {
+    TIMEOUT,
+    HOLD_TIMEOUT,
+    DOUBLE_TAP_TIMEOUT,
+    STICKABLE_KEYS,
+    AUTO_MODS,
+    AUTO_LAYERS,
+  } cmd;
+  const char *cmd_timeout            = PSTR("oneshot.timeout");
+  const char *cmd_hold_timeout       = PSTR("oneshot.hold_timeout");
+  const char *cmd_double_tap_timeout = PSTR("oneshot.double_tap_timeout");
+  const char *cmd_stickable_keys     = PSTR("oneshot.stickable_keys");
+  const char *cmd_auto_mods          = PSTR("oneshot.auto_mods");
+  const char *cmd_auto_layers        = PSTR("oneshot.auto_layers");
+
+  if (::Focus.inputMatchesHelp(input))
+    return ::Focus.printHelp(
+      cmd_timeout,
+      cmd_hold_timeout,
+      cmd_double_tap_timeout,
+      cmd_stickable_keys,
+      cmd_auto_mods,
+      cmd_auto_layers);
+
+  if (::Focus.inputMatchesCommand(input, cmd_timeout))
+    cmd = Command::TIMEOUT;
+  else if (::Focus.inputMatchesCommand(input, cmd_hold_timeout))
+    cmd = Command::HOLD_TIMEOUT;
+  else if (::Focus.inputMatchesCommand(input, cmd_double_tap_timeout))
+    cmd = Command::DOUBLE_TAP_TIMEOUT;
+  else if (::Focus.inputMatchesCommand(input, cmd_stickable_keys))
+    cmd = Command::STICKABLE_KEYS;
+  else if (::Focus.inputMatchesCommand(input, cmd_auto_mods))
+    cmd = Command::AUTO_MODS;
+  else if (::Focus.inputMatchesCommand(input, cmd_auto_layers))
+    cmd = Command::AUTO_LAYERS;
+  else
+    return EventHandlerResult::OK;
+
+  if (::Focus.isEOL()) {
+    // If there are no arguments, send back the current configuration values.
+    switch (cmd) {
+    case Command::TIMEOUT:
+      ::Focus.send(::OneShot.getTimeout());
+      break;
+    case Command::HOLD_TIMEOUT:
+      ::Focus.send(::OneShot.getHoldTimeout());
+      break;
+    case Command::DOUBLE_TAP_TIMEOUT:
+      ::Focus.send(::OneShot.getDoubleTapTimeout());
+      break;
+    case Command::STICKABLE_KEYS:
+      ::Focus.send(::OneShot.settings_.stickable_keys);
+      break;
+    case Command::AUTO_MODS:
+      ::Focus.send(::OneShot.settings_.auto_modifiers ? 1 : 0);
+      break;
+    case Command::AUTO_LAYERS:
+      ::Focus.send(::OneShot.settings_.auto_layers ? 1 : 0);
+      break;
+    default:
+      // if a valid command is issued but there is no 0-arg handler for it,
+      // we stop processing the event.
+      return EventHandlerResult::ABORT;
+    }
+  } else {
+    switch (cmd) {
+      uint16_t v;
+      uint8_t b;
+
+    case Command::TIMEOUT:
+      ::Focus.read(v);
+      ::OneShot.setTimeout(v);
+      break;
+    case Command::HOLD_TIMEOUT:
+      ::Focus.read(v);
+      ::OneShot.setHoldTimeout(v);
+      break;
+    case Command::DOUBLE_TAP_TIMEOUT:
+      ::Focus.read(v);
+      ::OneShot.setDoubleTapTimeout(static_cast<int16_t>(v));
+      break;
+    case Command::STICKABLE_KEYS:
+      ::Focus.read(v);
+      ::OneShot.settings_.stickable_keys = v;
+      break;
+    case Command::AUTO_MODS:
+      ::Focus.read(b);
+      ::OneShot.settings_.auto_modifiers = b;
+      break;
+    case Command::AUTO_LAYERS:
+      ::Focus.read(b);
+      ::OneShot.settings_.auto_layers = b;
+      break;
+    default:
+      return EventHandlerResult::ABORT;
+    }
+    Runtime.storage().put(settings_addr_, ::OneShot.settings_);
+    Runtime.storage().commit();
+  }
+
+  return EventHandlerResult::EVENT_CONSUMED;
+}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
+
+kaleidoscope::plugin::OneShotConfig OneShotConfig;


### PR DESCRIPTION
Adds a `OneShotConfig` plugin to address the Kaleidoscope parts of keyboardio/Chrysalis#732. It's split in two halves: the first commit moves the configuration into a `settings_` struct, the second implements the actual plugin.

The tricky part here is setting stickable keys: that's done with a bitmap, so it's a bit tricky to do that on the commandline. I considered making the plugin to use a friendlier format, but it didn't feel like its worth the trouble. I could certainly make it so that it outputs the bits one by one, and allows partial reading, but it's easier to delegate that work to Chrysalis instead.