### PR TITLE
Focus: Add a mechanism to discover commands eligible for backup

### DIFF
--- a/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
+++ b/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
@@ -58,8 +58,9 @@ EventHandlerResult AutoShiftConfig::onFocusEvent(const char *input) {
   const char *cmd_timeout    = PSTR("autoshift.timeout");
   const char *cmd_categories = PSTR("autoshift.categories");
 
-  if (::Focus.inputMatchesHelp(input))
-    return ::Focus.printHelp(cmd_enabled, cmd_timeout, cmd_categories);
+  if (::Focus.inputMatchesHelp(input) ||
+      ::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd_enabled, cmd_timeout, cmd_categories);
 
   if (::Focus.inputMatchesCommand(input, cmd_enabled))
     subCommand = ENABLED;

--- a/plugins/Kaleidoscope-DefaultLEDModeConfig/src/kaleidoscope/plugin/DefaultLEDModeConfig.cpp
+++ b/plugins/Kaleidoscope-DefaultLEDModeConfig/src/kaleidoscope/plugin/DefaultLEDModeConfig.cpp
@@ -51,8 +51,9 @@ EventHandlerResult DefaultLEDModeConfig::onSetup() {
 EventHandlerResult DefaultLEDModeConfig::onFocusEvent(const char *input) {
   const char *cmd = PSTR("led_mode.default");
 
-  if (::Focus.inputMatchesHelp(input))
-    return ::Focus.printHelp(cmd);
+  if (::Focus.inputMatchesHelp(input) ||
+      ::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd);
 
   if (!::Focus.inputMatchesCommand(input, cmd))
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -220,6 +220,8 @@ EventHandlerResult DynamicMacros::onFocusEvent(const char *input) {
 
   if (::Focus.inputMatchesHelp(input))
     return ::Focus.printHelp(cmd_map, cmd_trigger);
+  if (::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd_map);
 
   if (::Focus.inputMatchesCommand(input, cmd_map)) {
     if (::Focus.isEOL()) {

--- a/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
+++ b/plugins/Kaleidoscope-DynamicTapDance/src/kaleidoscope/plugin/DynamicTapDance.cpp
@@ -96,8 +96,9 @@ EventHandlerResult DynamicTapDance::onNameQuery() {
 EventHandlerResult DynamicTapDance::onFocusEvent(const char *input) {
   const char *cmd_map = PSTR("tapdance.map");
 
-  if (::Focus.inputMatchesHelp(input))
-    return ::Focus.printHelp(cmd_map);
+  if (::Focus.inputMatchesHelp(input) ||
+      ::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd_map);
 
   if (!::Focus.inputMatchesCommand(input, cmd_map))
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -108,6 +108,8 @@ EventHandlerResult EEPROMKeymap::onFocusEvent(const char *input) {
 
   if (::Focus.inputMatchesHelp(input))
     return ::Focus.printHelp(cmd_custom, cmd_default, cmd_onlyCustom);
+  if (::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd_custom, cmd_onlyCustom);
 
   if (::Focus.inputMatchesCommand(input, cmd_onlyCustom)) {
     if (::Focus.isEOL()) {

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -171,6 +171,8 @@ EventHandlerResult FocusSettingsCommand::onFocusEvent(const char *input) {
 
   if (::Focus.inputMatchesHelp(input))
     return ::Focus.printHelp(cmd_defaultLayer, cmd_isValid, cmd_version, cmd_crc);
+  if (::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd_defaultLayer);
 
   if (::Focus.inputMatchesCommand(input, cmd_defaultLayer))
     sub_command = DEFAULT_LAYER;

--- a/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot-Config.cpp
+++ b/plugins/Kaleidoscope-Escape-OneShot/src/kaleidoscope/plugin/Escape-OneShot-Config.cpp
@@ -50,8 +50,9 @@ EventHandlerResult EscapeOneShotConfig::onNameQuery() {
 
 EventHandlerResult EscapeOneShotConfig::onFocusEvent(const char *input) {
   const char *cmd_cancel_key = PSTR("escape_oneshot.cancel_key");
-  if (::Focus.inputMatchesHelp(input))
-    return ::Focus.printHelp(cmd_cancel_key);
+  if (::Focus.inputMatchesHelp(input) ||
+      ::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd_cancel_key);
 
   if (!::Focus.inputMatchesCommand(input, cmd_cancel_key))
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -81,9 +81,10 @@ EventHandlerResult FocusSerial::onFocusEvent(const char *input) {
   const char *cmd_help    = PSTR("help");
   const char *cmd_reset   = PSTR("device.reset");
   const char *cmd_plugins = PSTR("plugins");
+  const char *cmd_backup  = PSTR("backup");
 
   if (inputMatchesHelp(input))
-    return printHelp(cmd_help, cmd_reset, cmd_plugins);
+    return printHelp(cmd_help, cmd_reset, cmd_plugins, cmd_backup);
 
   if (inputMatchesCommand(input, cmd_reset)) {
     Runtime.device().rebootBootloader();
@@ -112,6 +113,10 @@ void FocusSerial::printBool(bool b) {
 
 bool FocusSerial::inputMatchesHelp(const char *input) {
   return inputMatchesCommand(input, PSTR("help"));
+}
+
+bool FocusSerial::inputMatchesBackup(const char *input) {
+  return inputMatchesCommand(input, PSTR("backup"));
 }
 
 bool FocusSerial::inputMatchesCommand(const char *input, const char *expected) {

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -52,6 +52,7 @@ class FocusSerial : public kaleidoscope::Plugin {
 #endif
 
   bool inputMatchesHelp(const char *input);
+  bool inputMatchesBackup(const char *input);
   bool inputMatchesCommand(const char *input, const char *expected);
 
   EventHandlerResult printHelp() {
@@ -62,6 +63,15 @@ class FocusSerial : public kaleidoscope::Plugin {
     Runtime.serialPort().println((const __FlashStringHelper *)h1);
     delayAfterPrint();
     return printHelp(vars...);
+  }
+  EventHandlerResult printCommands() {
+    return EventHandlerResult::OK;
+  }
+  template<typename... Vars>
+  EventHandlerResult printCommands(const char *c1, Vars... vars) {
+    Runtime.serialPort().println((const __FlashStringHelper *)c1);
+    delayAfterPrint();
+    return printCommands(vars...);
   }
 
   EventHandlerResult sendName(const __FlashStringHelper *name) {

--- a/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
+++ b/plugins/Kaleidoscope-Hardware-Dygma-Raise/src/kaleidoscope/device/dygma/raise/Focus.cpp
@@ -56,6 +56,10 @@ EventHandlerResult Focus::onFocusEvent(const char *input) {
                              cmd_keyscan,
                              cmd_crc_errors,
                              cmd_firmware);
+  if (::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd_side_power,
+                                 cmd_sled_current,
+                                 cmd_keyscan);
 
   if (::Focus.inputMatchesCommand(input, cmd_version)) {
     ::Focus.send("Dygma Raise");

--- a/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.cpp
+++ b/plugins/Kaleidoscope-HostOS/src/kaleidoscope/plugin/HostOS-Focus.cpp
@@ -30,8 +30,9 @@ namespace plugin {
 EventHandlerResult FocusHostOSCommand::onFocusEvent(const char *input) {
   const char *cmd = PSTR("hostos.type");
 
-  if (::Focus.inputMatchesHelp(input))
-    return ::Focus.printHelp(cmd);
+  if (::Focus.inputMatchesHelp(input) ||
+      ::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd);
 
   if (!::Focus.inputMatchesCommand(input, cmd))
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -100,8 +100,9 @@ void PersistentIdleLEDs::setIdleTimeoutSeconds(uint32_t new_limit) {
 EventHandlerResult PersistentIdleLEDs::onFocusEvent(const char *input) {
   const char *cmd = PSTR("idleleds.time_limit");
 
-  if (::Focus.inputMatchesHelp(input))
-    return ::Focus.printHelp(cmd);
+  if (::Focus.inputMatchesHelp(input) ||
+      ::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd);
 
   if (!::Focus.inputMatchesCommand(input, cmd))
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -128,8 +128,9 @@ EventHandlerResult LEDPaletteTheme::onFocusEvent(const char *input) {
 
   const char *cmd = PSTR("palette");
 
-  if (::Focus.inputMatchesHelp(input))
-    return ::Focus.printHelp(cmd);
+  if (::Focus.inputMatchesHelp(input) ||
+      ::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd);
 
   if (!::Focus.inputMatchesCommand(input, cmd))
     return EventHandlerResult::OK;
@@ -166,8 +167,9 @@ EventHandlerResult LEDPaletteTheme::themeFocusEvent(const char *input,
   if (!Runtime.has_leds)
     return EventHandlerResult::OK;
 
-  if (::Focus.inputMatchesHelp(input))
-    return ::Focus.printHelp(expected_input);
+  if (::Focus.inputMatchesHelp(input) ||
+      ::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(expected_input);
 
   if (!::Focus.inputMatchesCommand(input, expected_input))
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-LEDBrightnessConfig/src/kaleidoscope/plugin/LEDBrightnessConfig.cpp
+++ b/plugins/Kaleidoscope-LEDBrightnessConfig/src/kaleidoscope/plugin/LEDBrightnessConfig.cpp
@@ -46,13 +46,14 @@ EventHandlerResult LEDBrightnessConfig::onSetup() {
   return EventHandlerResult::OK;
 }
 
-EventHandlerResult LEDBrightnessConfig::onFocusEvent(const char *command) {
+EventHandlerResult LEDBrightnessConfig::onFocusEvent(const char *input) {
   const char *cmd = PSTR("led.brightness");
 
-  if (::Focus.handleHelp(command, cmd))
-    return EventHandlerResult::OK;
+  if (::Focus.inputMatchesHelp(input) ||
+      ::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd);
 
-  if (strcmp_P(command, cmd) != 0)
+  if (!::Focus.inputMatchesCommand(input, cmd))
     return EventHandlerResult::OK;
 
   if (::Focus.isEOL()) {

--- a/plugins/Kaleidoscope-LayerNames/src/kaleidoscope/plugin/LayerNames.cpp
+++ b/plugins/Kaleidoscope-LayerNames/src/kaleidoscope/plugin/LayerNames.cpp
@@ -34,8 +34,9 @@ EventHandlerResult LayerNames::onNameQuery() {
 EventHandlerResult LayerNames::onFocusEvent(const char *input) {
   const char *cmd_layerNames = PSTR("keymap.layerNames");
 
-  if (::Focus.inputMatchesHelp(input))
-    return ::Focus.printHelp(cmd_layerNames);
+  if (::Focus.inputMatchesHelp(input) ||
+      ::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd_layerNames);
 
   if (!::Focus.inputMatchesCommand(input, cmd_layerNames))
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeysConfig.cpp
+++ b/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeysConfig.cpp
@@ -58,8 +58,9 @@ EventHandlerResult MouseKeysConfig::onFocusEvent(const char *input) {
   const char *cmd_base_speed      = PSTR("mousekeys.base_speed");
   const char *cmd_accel_duration  = PSTR("mousekeys.accel_duration");
 
-  if (::Focus.inputMatchesHelp(input))
-    return ::Focus.printHelp(
+  if (::Focus.inputMatchesHelp(input) ||
+      ::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(
       cmd_scroll_interval,
       cmd_initial_speed,
       cmd_base_speed,

--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShotConfig.cpp
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShotConfig.cpp
@@ -62,8 +62,9 @@ EventHandlerResult OneShotConfig::onFocusEvent(const char *input) {
   const char *cmd_auto_mods          = PSTR("oneshot.auto_mods");
   const char *cmd_auto_layers        = PSTR("oneshot.auto_layers");
 
-  if (::Focus.inputMatchesHelp(input))
-    return ::Focus.printHelp(
+  if (::Focus.inputMatchesHelp(input) ||
+      ::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(
       cmd_timeout,
       cmd_hold_timeout,
       cmd_double_tap_timeout,

--- a/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadetConfig.cpp
+++ b/plugins/Kaleidoscope-SpaceCadet/src/kaleidoscope/plugin/SpaceCadetConfig.cpp
@@ -51,8 +51,9 @@ EventHandlerResult SpaceCadetConfig::onFocusEvent(const char *input) {
   const char *cmd_mode    = PSTR("spacecadet.mode");
   const char *cmd_timeout = PSTR("spacecadet.timeout");
 
-  if (::Focus.inputMatchesHelp(input))
-    return ::Focus.printHelp(cmd_mode, cmd_timeout);
+  if (::Focus.inputMatchesHelp(input) ||
+      ::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd_mode, cmd_timeout);
 
   if (::Focus.inputMatchesCommand(input, cmd_mode)) {
     if (::Focus.isEOL()) {

--- a/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
+++ b/plugins/Kaleidoscope-TypingBreaks/src/kaleidoscope/plugin/TypingBreaks.cpp
@@ -161,6 +161,12 @@ EventHandlerResult TypingBreaks::onFocusEvent(const char *input) {
                              cmd_leftKeys,
                              cmd_rightKeys,
                              cmd_lockSecsRem);
+  if (::Focus.inputMatchesBackup(input))
+    return ::Focus.printCommands(cmd_idleTimeLimit,
+                                 cmd_lockTimeOut,
+                                 cmd_lockLength,
+                                 cmd_leftMaxKeys,
+                                 cmd_rightMaxKeys);
 
   if (::Focus.inputMatchesCommand(input, cmd_idleTimeLimit))
     subCommand = IDLE_TIME_LIMIT;


### PR DESCRIPTION
The goal here is to make it easier for Chrysalis and other tools to make structured backups. Chrysalis currently has a hard-coded list of commands to run and backup the results of - not ideal. We want a solution where a tool can automatically discover what can be backed up safely.

We can't just call every command in the `help` output without an argument, because some of them (`device.reset`, `eeprom.erase`, etc) are destructive. We do not wish to maintain a deny list, either.

We'd like a mechanism where plugins themselves can tell which commands they can offer for backing up. This patch implements such a solution, one very similar to how we handle `help`. In addition to responding to `help`, plugins can now respond to `backup`, and write a list of commands in the same format as for `help`: one per line.

The tool on the host side can take this list of commands, execute them, and store their values for backup purposes. Simple, straightforward, lightweight.

On top of adding the mechanism, the patch also changes all bundled plugins to respond to the `backup` command if appropriate, with the commands that should be backed up.

Fixes #1279.