### PR TITLE
Switch to clang-format-15 for CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,11 +26,11 @@ AttributeMacros:
   - __attribute__((unused))
 BinPackArguments: false
 BinPackParameters: false
-# BraceWrapping:
-#   SplitEmptyFunction: false
-#   SplitEmptyRecord: true
-#   SplitEmptyNamespace: true
-# BreakBeforeBraces: Custom
+BraceWrapping:
+  SplitEmptyFunction: false
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBraces: Custom
 ColumnLimit: 0
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
@@ -39,9 +39,9 @@ FixNamespaceComments: true
 IndentCaseLabels: false
 KeepEmptyLinesAtTheStartOfBlocks: true
 MaxEmptyLinesToKeep: 2
-# PackConstructorInitializers: CurrentLine
+PackConstructorInitializers: NextLine
 PointerAlignment: Right
-# ReferenceAlignment: Right
+ReferenceAlignment: Right
 ReflowComments: false
 SortIncludes: false
 SpaceAfterTemplateKeyword: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   LC_ALL: C
   ARDUINO_DIRECTORIES_USER: ${{ github.workspace }}/.arduino/user
-  CLANG_FORMAT_CMD: clang-format-12
+  CLANG_FORMAT_CMD: clang-format-14
 jobs:
   smoke-sketches:
     runs-on: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: KALEIDOSCOPE_CODE_FORMATTER=clang-format-12 make check-code-style
+    - run: KALEIDOSCOPE_CODE_FORMATTER=clang-format-14 make check-code-style
   check-shellcheck:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     - run: make setup
     - run: KALEIDOSCOPE_CCACHE=1 make -j $(nproc) --output-sync=recurse simulator-tests
   check-code-style:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - run: KALEIDOSCOPE_CODE_FORMATTER=clang-format-14 make check-code-style

--- a/src/kaleidoscope/MatrixAddr.h
+++ b/src/kaleidoscope/MatrixAddr.h
@@ -63,7 +63,7 @@ class MatrixAddr {
   //constexpr MatrixAddr(ThisType &&other) : offset_(other.offset_) {}
 
   ThisType &operator=(const ThisType &) = default;
-  ThisType &operator=(ThisType &&) = default;
+  ThisType &operator=(ThisType &&)      = default;
 
   template<typename MatrixAddr__>
   explicit constexpr MatrixAddr(const MatrixAddr__ &other)


### PR DESCRIPTION
Now that clang-format-15 is available on GitHub Actions, I think we can upgrade.  I've made the necessary changes to the clang-format config file, and run `make check-code-style` locally.