### PR TITLE
improve some Focus timeout behavior

### DIFF
--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -118,6 +118,23 @@ bool FocusSerial::inputMatchesCommand(const char *input, const char *expected) {
   return strcmp_P(input, expected) == 0;
 }
 
+bool FocusSerial::isEOL() {
+  int c = -1;
+  auto timeout = Runtime.serialPort().getTimeout();
+  auto start = millis();
+
+  // Duplicate some of Stream::timedPeek because it's protected
+  do {
+    c = Runtime.serialPort().peek();
+    if (c == NEWLINE) {
+      return true;
+    } else if (c >= 0) {
+      return false;
+    }
+  } while ((millis() - start) < timeout);
+  return false;
+}
+
 }  // namespace plugin
 }  // namespace kaleidoscope
 

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -128,12 +128,7 @@ class FocusSerial : public kaleidoscope::Plugin {
     u16 = Runtime.serialPort().parseInt();
   }
 
-  bool isEOL() {
-    int i = Runtime.serialPort().peek();
-
-    return (i == NEWLINE || i == -1);
-  }
-
+  bool isEOL();
 
   /* Hooks */
   EventHandlerResult afterEachCycle();

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -133,6 +133,9 @@ class FocusSerial : public kaleidoscope::Plugin {
   /* Hooks */
   EventHandlerResult afterEachCycle();
   EventHandlerResult onFocusEvent(const char *input);
+  EventHandlerResult onSetup() {
+    Runtime.serialPort().setTimeout(10);
+  }
 
  private:
   char input_[32];


### PR DESCRIPTION
Add a timeout to `Focus::isEOL` to mitigate truncation that might happen during chunked writes.

Change the timeout to 10ms, which is hopefully long enough that Chrysalis won't have a problem, and short enough to mitigate some of the lockups caused by probing by third-party software.
