### PR TITLE
IdleLEDs: Set the default limit in PersistentIdleLEDs correctly

### DIFF
--- a/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
+++ b/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.cpp
@@ -82,7 +82,7 @@ EventHandlerResult PersistentIdleLEDs::onSetup() {
   uint16_t idle_time;
   Runtime.storage().get(settings_base_, idle_time);
   if (idle_time == 0xffff) {
-    idle_time = idle_time_limit;
+    idle_time = idle_time_limit / 1000;
   }
   setIdleTimeoutSeconds(idle_time);
 


### PR DESCRIPTION
When the EEPROM is empty, and we're setting the default idle time limit, we need to set that in seconds, rather than millis, so divide the internal time limit (uint32_t, in millis) by 1000 so it fits into the uint16_t we use for persisting the time limit in seconds.

This correctly sets the default to 10 minutes, rather than a very awkward 2 hours, 49 minutes,  36 seconds (10176 seconds).
