### PR TITLE
IdleLEDs: Implement a .suspend() and a .resume() method

### DIFF
--- a/plugins/Kaleidoscope-IdleLEDs/README.md
+++ b/plugins/Kaleidoscope-IdleLEDs/README.md
@@ -91,6 +91,16 @@ the following properties and methods.
 > Setting the timeout to 0 will disable the plugin until it is set to a higher
 > value.
 
+### `.suspend()`, `.resume()`
+
+> Suspends or resumes `IdleLEDs`. When suspended, `IdleLEDs` will immediately
+> enter idle state, and turn LEDs off. When resuming, it will turn the LEDs back
+> on, and start checking idleness again.
+>
+> The intended use of these functions is when LEDs are turned on or off by other
+> means, such as part of host power management, and syncing that state with
+> `IdleLEDs` is desired.
+
 ## Focus commands
 
 The plugin provides a single [Focus][FocusSerial] command, but only when using

--- a/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.h
+++ b/plugins/Kaleidoscope-IdleLEDs/src/kaleidoscope/plugin/IdleLEDs.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-Idle-LEDs -- Turn off the LEDs when the keyboard's idle
- * Copyright (C) 2018, 2019, 2021  Keyboard.io, Inc
+ * Copyright (C) 2018, 2019, 2021, 2022  Keyboard.io, Inc
  * Copyright (C) 2019  Dygma, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -33,6 +33,8 @@ class IdleLEDs : public kaleidoscope::Plugin {
 
   static uint32_t idleTimeoutSeconds();
   static void setIdleTimeoutSeconds(uint32_t new_limit);
+  static void suspend();
+  static void resume();
 
   EventHandlerResult beforeEachCycle();
   EventHandlerResult onKeyEvent(KeyEvent &event);


### PR DESCRIPTION
Sometimes we want to control LEDs outside of `IdleLEDs`, like through `HostPowerManagement`, and in these cases, we would like `IdleLEDs` to have an up-to-date idea about what's going on. That is, if the host enters sleep, `IdleLEDs` should be aware of that, and enter idle state. Once the host wakes up, either via the keyboard or otherwise, `IdleLEDs` should resume its tasks.

With the new `.suspend()` and `.resume()` method, this becomes possible.

This addresses a big part of #1287.
