### PR TITLE
quiet Model 100 rainbow effects

### DIFF
--- a/examples/Devices/Keyboardio/Model100/Model100.ino
+++ b/examples/Devices/Keyboardio/Model100/Model100.ino
@@ -613,10 +613,10 @@ void setup() {
   // We configure the AlphaSquare effect to use RED letters
   AlphaSquare.color = CRGB(255, 0, 0);
 
-  // We set the brightness of the rainbow effects to 150 (on a scale of 0-255)
-  // This draws more than 500mA, but looks much nicer than a dimmer effect
-  LEDRainbowEffect.brightness(255);
-  LEDRainbowWaveEffect.brightness(255);
+  // Set the rainbow effects to be reasonably bright, but low enough
+  // to mitigate audible noise in some environments.
+  LEDRainbowEffect.brightness(170);
+  LEDRainbowWaveEffect.brightness(160);
 
   // Set the action key the test mode should listen for to Left Fn
   HardwareTestMode.setActionKey(R3C6);


### PR DESCRIPTION
Some users report an audible whine from the keyboard while displaying the rainbow modes. Set their brightness a bit lower to mitigate this somewhat.

This should probably also go in Chrysalis-Firmware-Bundle.