### PR TITLE
Add some cross-links for EEPROM stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you're just getting started with the Keyboardio Model 01, the [introductory d
 
 If you want to use Kaleidoscope to customize or compile a "sketch" to power a supported keyboard, the fastest way to get started is to use the Arduino IDE. You can find [setup instructions](https://kaleidoscope.readthedocs.io/en/latest/quick_start.html) on [kaleidoscope.readthedocs.io](https://kaleidoscope.readthedocs.io)
 
-If you prefer to work from the command line or intend to work on Kaleidscope itself, please follow the instructions below. It's important to note that the Arduino IDE needs the source code laid out in a slightly different arrangement than you'll find in this repository. If you want to use the Arduino IDE, you should follow [these instructions](https://kaleidoscope.readthedocs.io/en/latest/quick_start.html) instead.
+If you prefer to work from the command line or intend to work on Kaleidscope itself, please follow the instructions below. It's important to note that the Arduino IDE needs the source code laid out in a slightly different arrangement than you'll find in this repository. If you want to use the Arduino IDE, you should follow [these instructions](https://kaleidoscope.readthedocs.io/en/latest/quick_start.html) instead. Even if you're using the command line, you may want to refer to the docs for troubleshooting steps.
 
 # Use git to check out a copy of Kaleidoscope
 

--- a/docs/build_default_firmware.md
+++ b/docs/build_default_firmware.md
@@ -60,5 +60,5 @@ If the process is successful, Arduino will tell you that in the status area. Som
 
 On Windows, you may also see the message "the device Model 01 is undergoing additional configuration." 
 
-If you have any trouble flashing your keyboard's firmware, check to see if the issue is addressed on the [Troubleshooting Firmware Upload Issues](https://github.com/keyboardio/Kaleidoscope/wiki/Troubleshooting-Firmware-Upload-Issues)
+If you have any trouble flashing your keyboard's firmware, check to see if the issue is addressed on the [Troubleshooting Firmware Upload Issues](https://github.com/keyboardio/Kaleidoscope/wiki/Troubleshooting-Firmware-Upload-Issues) page. Note that if you already have any customized data in the keyboard's EEPROM, any layout differences between the keyboard's original and current firmware may cause issues. See [Using EEPROM](customization/eeprom.md) for ways to correct any problems.
 


### PR DESCRIPTION
This should make it a little more likely that newcomers find the documentation on how to deal with EEPROM layout changes. The current wording is the best my sleep-deprived brain can manage at the moment, but there's probably room for improvement. I also haven't built the docs yet since there's some messing around I'll have to do to get that working on my NixOS machine.