### PR TITLE
fix Model 100 flashing on Linux

### DIFF
--- a/etc/makefiles/sketch.mk
+++ b/etc/makefiles/sketch.mk
@@ -205,6 +205,6 @@ endif
 	$(info )
 	@$(shell read _)
 	$(QUIET) $(ARDUINO_CLI) upload --fqbn $(FQBN) \
-	$(shell $(ARDUINO_CLI) board list --format=text | grep $(FQBN) |cut -d' ' -f 1 | xargs -n 1 echo "--port" ) \
+	$(shell $(ARDUINO_CLI) board list --format=text | grep $(FQBN) | awk '{ print "--port", $$1; exit }' ) \
 	--input-dir "${OUTPUT_PATH}" \
 	$(ARDUINO_VERBOSE)


### PR DESCRIPTION
Flashing on Model 100 using `make flash` would fail with a cryptic message like
```
Error during Upload: main file missing from sketch
```
if the keyboard was already in bootloader mode.

The `$(shell)` function in `sketch.mk` that parsed the board listing for constructing the upload command line would produce `--port` without an argument, which meant that the `--input-dir` would get interpreted as the argument to `--port`. This was due to an OS-related behavior difference of `xargs` when given empty input.

The reason this wasn't happening when the keyboard was in application mode was that `make` expanded the `$(shell)` function before beginning to execute the recipe, so it would successfully get the port before the keyboard rebooted into bootloader mode.

Thanks to @dakkar and @Lilith-Daemon for help with troubleshooting and testing solutions.
