### PR TITLE
fix EEPROMSettings::isValid

### DIFF
--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.cpp
@@ -117,6 +117,8 @@ void EEPROMSettings::seal() {
     return;
   }
 
+  is_valid_ = true;
+
   /* If we have a default layer set, switch to it.
    *
    * We check if the layer is smaller than IGNORE_HARDCODED_LAYER (0x7e),


### PR DESCRIPTION
Actually set `is_valid_ = true` in `EEPROMSettings::seal()` if the CRC is valid. This will make it easier for plugins to check whether the EEPROM layout is valid.

Chrysalis will still need to check `settings.crc` for compatibility with older firmware.
