### PR TITLE
AutoShiftConfig: Better defaults

### DIFF
--- a/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShift.h
+++ b/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShift.h
@@ -276,6 +276,7 @@ class AutoShiftConfig : public Plugin {
  public:
   EventHandlerResult onSetup();
   EventHandlerResult onFocusEvent(const char *input);
+  void disableAutoShiftIfUnconfigured();
 
  private:
   // The base address in persistent storage for configuration data

--- a/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
+++ b/plugins/Kaleidoscope-AutoShift/src/kaleidoscope/plugin/AutoShiftConfig.cpp
@@ -45,6 +45,11 @@ EventHandlerResult AutoShiftConfig::onSetup() {
   return EventHandlerResult::OK;
 }
 
+void AutoShiftConfig::disableAutoShiftIfUnconfigured() {
+  if (Runtime.storage().isSliceUninitialized(settings_base_, sizeof(AutoShift::settings_)))
+    ::AutoShift.disable();
+}
+
 EventHandlerResult AutoShiftConfig::onFocusEvent(const char *input) {
   enum {
     ENABLED,


### PR DESCRIPTION
This PR does two things:

- It changes `AutoShiftConfig` to *not* write default settings back to EEPROM if it found its slice uninitialized. It will just use the default AutoShift configuration then, without persisting it back.
- Introduces an `AutoShiftConfig.disableAutoShiftIfUnconfigured()` method

These together make it possible to include AutoShift in sketches without having it enabled by default.