### PR TITLE
fallback keymap

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -442,6 +442,13 @@ As a developer, one can continue using `millis()`, but migrating to `Kaleidoscop
 
 ## Breaking changes
 
+### `EEPROMSettings` key layout fallback
+
+When detecting stored settings that might be incompatible with the current firmware, `EEPROMSettings` will attempt to fall back to a usable key layout by temporarily forcing `settings.defaultLayer 0` and `keymap.onlyCustom 0`.
+These have the effect of loading the hardcoded firmware key layout, regardless of what the previous settings were.
+This should reduce the incidence of scrambled key layouts when using Arduino to upgrade to custom firmware from Chrysalis firmware, for example.
+
+This fallback can be a breaking change for people who have relied on being able to use non-Chrysalis means to upgrade to firmware that has a different, but compatible layout.
 ### Sketch preprocssing system
 
 We used to support the ability to amend all compiled sketches by

--- a/plugins/Kaleidoscope-EEPROM-Keymap/README.md
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/README.md
@@ -6,7 +6,7 @@ In short, this plugin allows us to change our keymaps, without having to compile
 
  [plugin:focusSerial]: Kaleidoscope-FocusSerial.md
 
-By default, the plugin extends the keymap in PROGMEM: it will only look for keys in EEPROM if looking up from a layer that's higher than the last one in PROGMEM. This behaviour can be changed either via `Focus` (see below), or by calling `EEPROMSettings.use_eeprom_layers_only` (see the [EEPROMSettings](Kaleidoscope-EEPROM-Settings.md) documentation for more information).
+By default, the plugin extends the keymap in PROGMEM: it will only look for keys in EEPROM if looking up from a layer that's higher than the last one in PROGMEM. This behaviour can be changed either via `Focus` (see below), or by calling `EEPROMSettings.ignoreHardcodedLayers` (see the [EEPROMSettings](Kaleidoscope-EEPROM-Settings.md) documentation for more information).
 
 ## Using the plugin
 
@@ -39,7 +39,7 @@ The plugin provides the `EEPROMKeymap` object, which has the following method:
 
 ## Focus commands
 
-The plugin provides three Focus commands: `keymap.default`, `keymap.custom`, and `keymap.useCustom`.
+The plugin provides three Focus commands: `keymap.default`, `keymap.custom`, and `keymap.onlyCustom`.
 
 ### `keymap.default`
 
@@ -58,6 +58,8 @@ The plugin provides three Focus commands: `keymap.default`, `keymap.custom`, and
 > Without arguments, returns whether the firmware uses both the default and the custom layers (the default, `0`) or custom (EEPROM-stored) layers only (`1`).
 >
 > With an argument, sets whether to use custom layers only, or extend the built-in layers instead.
+>
+> This setting is forced to `0` (but not written to EEPROM) if invalid settings are detected.
 
 ## Dependencies
 

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.cpp
@@ -34,6 +34,7 @@ namespace plugin {
 uint16_t EEPROMKeymap::keymap_base_;
 uint8_t EEPROMKeymap::max_layers_;
 uint8_t EEPROMKeymap::progmem_layers_;
+bool EEPROMKeymap::ignore_hardcoded_;
 
 EventHandlerResult EEPROMKeymap::onSetup() {
   ::EEPROMSettings.onSetup();
@@ -45,20 +46,37 @@ EventHandlerResult EEPROMKeymap::onNameQuery() {
   return ::Focus.sendName(F("EEPROMKeymap"));
 }
 
-void EEPROMKeymap::setup(uint8_t max) {
-  layer_count = max;
-  if (::EEPROMSettings.ignoreHardcodedLayers()) {
+void EEPROMKeymap::set_layers(bool ignore_hardcoded) {
+  layer_count = max_layers_;
+  if (ignore_hardcoded) {
     Layer.getKey = getKey;
   } else {
     layer_count += progmem_layers_;
     Layer.getKey = getKeyExtended;
   }
+}
+
+void EEPROMKeymap::setup(uint8_t max) {
   max_layers(max);
+  ignore_hardcoded_ = ::EEPROMSettings.ignoreHardcodedLayers();
+  set_layers(ignore_hardcoded_);
 }
 
 void EEPROMKeymap::max_layers(uint8_t max) {
   max_layers_  = max;
   keymap_base_ = ::EEPROMSettings.requestSlice(max_layers_ * Runtime.device().numKeys() * 2);
+}
+
+/*
+ * EEPROMSettings.ignoreHardcodedLayers() might change, for example,
+ * if EEPROMSettings.seal() detects corruption. Force hardcoded layers
+ * to avoid scrambled keymaps in some firmware update situations.
+ */
+EventHandlerResult EEPROMKeymap::beforeEachCycle() {
+  if (::EEPROMSettings.ignoreHardcodedLayers() != ignore_hardcoded_) {
+    ignore_hardcoded_ = !ignore_hardcoded_;
+    set_layers(ignore_hardcoded_);
+  }
 }
 
 Key EEPROMKeymap::getKey(uint8_t layer, KeyAddr key_addr) {
@@ -117,14 +135,7 @@ EventHandlerResult EEPROMKeymap::onFocusEvent(const char *input) {
 
       ::Focus.read((uint8_t &)v);
       ::EEPROMSettings.ignoreHardcodedLayers(v);
-
-      layer_count = max_layers_;
-      if (v) {
-        Layer.getKey = getKey;
-      } else {
-        layer_count += progmem_layers_;
-        Layer.getKey = getKeyExtended;
-      }
+      set_layers(v);
     }
     return EventHandlerResult::EVENT_CONSUMED;
   }

--- a/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.h
+++ b/plugins/Kaleidoscope-EEPROM-Keymap/src/kaleidoscope/plugin/EEPROM-Keymap.h
@@ -36,6 +36,7 @@ class EEPROMKeymap : public kaleidoscope::Plugin {
   EventHandlerResult onSetup();
   EventHandlerResult onNameQuery();
   EventHandlerResult onFocusEvent(const char *input);
+  EventHandlerResult beforeEachCycle();
 
   static void setup(uint8_t max);
 
@@ -52,10 +53,12 @@ class EEPROMKeymap : public kaleidoscope::Plugin {
   static uint16_t keymap_base_;
   static uint8_t max_layers_;
   static uint8_t progmem_layers_;
+  static bool ignore_hardcoded_;
 
   static Key parseKey();
   static void printKey(Key key);
   static void dumpKeymap(uint8_t layers, Key (*getkey)(uint8_t, KeyAddr));
+  static void set_layers(bool ignore_hardcoded);
 };
 
 }  // namespace plugin

--- a/plugins/Kaleidoscope-EEPROM-Settings/README.md
+++ b/plugins/Kaleidoscope-EEPROM-Settings/README.md
@@ -65,6 +65,8 @@ The plugin provides the `EEPROMSettings` object, which has the following methods
 > any.
 >
 > Setting it to `126` or anything higher disables the automatic switching.
+>
+> This setting is forced to `0` (but not written to EEPROM) if invalid settings are detected, to ensure a usable key layout.
 
 ### `ignoreHardcodedLayers([true|false])`
 
@@ -80,6 +82,8 @@ The plugin provides the `EEPROMSettings` object, which has the following methods
 > implemented by the [EEPROM-Keymap][EEPROM-Keymap.md] plugin.
 >
 > Defaults to `false`.
+>
+> This setting is forced to `false` (but not written to EEPROM) if invalid settings are detected, to ensure a usable key layout.
 
 ### `seal()`
 
@@ -118,6 +122,11 @@ The plugin provides the `EEPROMSettings` object, which has the following methods
 >
 > This is for internal use only, end-users should not need to care about it.
 
+### `accept_invalid()`
+
+> Accepts and stores the calculated settings CRC as valid, even if different from the previously stored CRC.
+> Use this to allow a user to accept existing invalid settings, even if possibly corrupted by an EEPROM layout change.
+
 ### `crc()`
 
 > Returns the CRC checksum of the layout. Should only be used after calling
@@ -146,6 +155,8 @@ following commands:
 >
 > This is the Focus counterpart of the `default_layer()` method documented
 > above.
+>
+> This setting is forced to `0` (but not stored) if invalid settings are detected, to ensure a usable key layout.
 
 ### `settings.crc`
 
@@ -159,6 +170,12 @@ following commands:
 ### `settings.version`
 
 > Returns the version of the settings.
+
+### `settings.acceptInvalid 1`
+
+> Accepts the current settings as valid, regardless of whether the settings layout matches.
+> Also stores the current checksum, so it will be considered valid in the future.
+> The argument of `1` is required, to prevent accidental activation.
 
 ### `eeprom.contents`
 

--- a/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.h
+++ b/plugins/Kaleidoscope-EEPROM-Settings/src/kaleidoscope/plugin/EEPROM-Settings.h
@@ -59,6 +59,7 @@ class EEPROMSettings : public kaleidoscope::Plugin {
   uint8_t version() {
     return settings_.version;
   }
+  void accept_invalid();
 
   uint16_t requestSlice(uint16_t size);
   void seal();
@@ -80,6 +81,7 @@ class EEPROMSettings : public kaleidoscope::Plugin {
   uint16_t next_start_ = sizeof(EEPROMSettings::Settings);
   bool is_valid_;
   bool sealed_;
+  void fallback_layers();
 
   Settings settings_;
 };


### PR DESCRIPTION
Make `EEPROMSettings` fall back to a usable key map if it detects a possibly incompatible EEPROM layout. This forces `keymap.onlyCustom 0` and `settings.defaultLayer 0`, but does not write them to EEPROM.

A new `settings.acceptInvalid` Focus command may be used to accept the current settings as valid, updating the checksum.
