### PR TITLE
Further separate layer shifts and locks

### DIFF
--- a/src/kaleidoscope/layers.cpp
+++ b/src/kaleidoscope/layers.cpp
@@ -118,7 +118,19 @@ void Layer_::handleLayerKeyEvent(const KeyEvent &event) {
     // LockLayer()/UnlockLayer()
     target_layer = key_code;
 
-    if (stackPosition(target_layer) == active_layer_count_ - 1) {
+    // First, we find the top non-shifted layer in the stack:
+    int8_t top_locked_layer = -1;
+    for (uint8_t i = 0; i < active_layer_count_; ++i) {
+      if (active_layers_[i] < LAYER_SHIFT_OFFSET) {
+        top_locked_layer = active_layers_[i];
+      }
+    }
+
+    // If the top locked layer is the target layer, we remove it from the stack.
+    // Otherwise, we activate it.  We disregard shifted layers so that it's
+    // possible to set up a layer toggle key on a shifted layer that will
+    // actually deactivate the target layer as expected, with a single tap.
+    if (top_locked_layer == target_layer) {
       deactivate(target_layer);
     } else {
       activate(target_layer);

--- a/tests/issues/1337/1337.ino
+++ b/tests/issues/1337/1337.ino
@@ -1,0 +1,80 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2023  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        Key_0, ___, ___, ___, ___, ___, ___,
+        ShiftToLayer(1), ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+    [1] = KEYMAP_STACKED
+    (
+        Key_1, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        LockLayer(2), ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+    [2] = KEYMAP_STACKED
+    (
+        Key_2, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+//KALEIDOSCOPE_INIT_PLUGINS();
+
+void setup() {
+  Kaleidoscope.setup();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/issues/1337/sketch.json
+++ b/tests/issues/1337/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:virtual:model01",
+    "port": ""
+  }
+}

--- a/tests/issues/1337/sketch.yaml
+++ b/tests/issues/1337/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:virtual:model01

--- a/tests/issues/1337/test.ktest
+++ b/tests/issues/1337/test.ktest
@@ -1,0 +1,131 @@
+VERSION 1
+
+KEYSWITCH LAYER_NUMBER   0 0
+KEYSWITCH LAYER_SHIFT_1  1 0
+KEYSWITCH LAYER_LOCK_2   2 0
+
+# ==============================================================================
+NAME Layer Shift to Unlock
+
+# Verify that layer 0 is on top
+RUN 4 ms
+PRESS LAYER_NUMBER
+RUN 1 cycle
+EXPECT keyboard-report Key_0
+
+RUN 4 ms
+RELEASE LAYER_NUMBER
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+# Shift to layer 1
+RUN 4 ms
+PRESS LAYER_SHIFT_1
+RUN 1 cycle
+EXPECT no keyboard-report
+
+# Verify that layer 1 is active
+RUN 4 ms
+PRESS LAYER_NUMBER
+RUN 1 cycle
+EXPECT keyboard-report Key_1
+
+RUN 4 ms
+RELEASE LAYER_NUMBER
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+# Lock layer 2
+RUN 4 ms
+PRESS LAYER_LOCK_2
+RUN 1 cycle
+EXPECT no keyboard-report
+
+RUN 4 ms
+RELEASE LAYER_LOCK_2
+RUN 1 cycle
+EXPECT no keyboard-report
+
+# Verify that layer 2 is on top
+RUN 4 ms
+PRESS LAYER_NUMBER
+RUN 1 cycle
+EXPECT keyboard-report Key_2
+
+RUN 4 ms
+RELEASE LAYER_NUMBER
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+# Release layer shift
+RUN 4 ms
+RELEASE LAYER_SHIFT_1
+RUN 1 cycle
+EXPECT no keyboard-report
+
+# Verify that layer 2 is still on top
+RUN 4 ms
+PRESS LAYER_NUMBER
+RUN 1 cycle
+EXPECT keyboard-report Key_2
+
+RUN 4 ms
+RELEASE LAYER_NUMBER
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+# Shift to layer 1 again
+RUN 4 ms
+PRESS LAYER_SHIFT_1
+RUN 1 cycle
+EXPECT no keyboard-report
+
+# Verify that layer 1 is on top
+RUN 4 ms
+PRESS LAYER_NUMBER
+RUN 1 cycle
+EXPECT keyboard-report Key_1
+
+RUN 4 ms
+RELEASE LAYER_NUMBER
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+# Unlock layer 2
+RUN 4 ms
+PRESS LAYER_LOCK_2
+RUN 1 cycle
+EXPECT no keyboard-report
+
+RUN 4 ms
+RELEASE LAYER_LOCK_2
+RUN 1 cycle
+EXPECT no keyboard-report
+
+# Verify that layer 1 is still on top
+RUN 4 ms
+PRESS LAYER_NUMBER
+RUN 1 cycle
+EXPECT keyboard-report Key_1
+
+RUN 4 ms
+RELEASE LAYER_NUMBER
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+# Release layer shift
+RUN 4 ms
+RELEASE LAYER_SHIFT_1
+RUN 1 cycle
+EXPECT no keyboard-report
+
+# Verify that layer 0 is on top
+RUN 4 ms
+PRESS LAYER_NUMBER
+RUN 1 cycle
+EXPECT keyboard-report Key_0
+
+RUN 4 ms
+RELEASE LAYER_NUMBER
+RUN 1 cycle
+EXPECT keyboard-report empty


### PR DESCRIPTION
When a layer lock key is pressed, ignore shifted layers in the stack when determining if the target layer is on the top of the layer stack.  This lets users put a `LockLayer(N)` on a layer that is accessed by holding `ShiftToLayer(M)`, and have more consistent behaviour.  Previously, toggling layer `N` on worked as expected, but it couldn't be toggled off with a single tap because the shifted layer `M` would be on top when the `LockLayer(N)` was tapped.

For example: A user has a base layer `0` with a `ShiftToLayer(1)` key (<kbd>fn</kbd>).  On layer `1`, there is a `LockLayer(2)` key (<kbd>X</kbd>).   On layer `2`, there is the same `ShiftToLayer(1)` key.  The idea is to use the combination <kbd>fn</kbd> + <kbd>X</kbd> to toggle layer `1` on and off, but without this change, when the user tries to turn layer `1` off, the shifted version of layer `2` is on top of the stack by the time <kbd>X</kbd> toggles on, and that causes it to simply be put on the top of the stack.  With this change, the shifted layer `2` is ignored, and layer `1` is treated as if it were on top of the layer stack, and therefore deactivated.