### PR TITLE
Fix Model100 hardware plugin library name

### DIFF
--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/library.properties
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/library.properties
@@ -1,6 +1,6 @@
-name=Kaleidoscope-Hardware-Keyboardio-Model01
+name=Kaleidoscope-Hardware-Keyboardio-Model100
 version=0.0.0
-sentence=Keyboardio Model01 hardware support for Kaleidoscope
+sentence=Keyboardio Model100 hardware support for Kaleidoscope
 maintainer=Kaleidoscope's Developers <jesse@keyboard.io>
 url=https://github.com/keyboardio/Kaleidoscope
 author=Keyboardio


### PR DESCRIPTION
This was copied from the Model01 hardware plugin.  It doesn't seem to cause any problems, but it should still get corrected.
