### PR TITLE
Fix `KeyAddrEventQueue::shouldAbort()` (qukeys getting stuck)

### DIFF
--- a/tests/issues/1320/1320.ino
+++ b/tests/issues/1320/1320.ino
@@ -1,0 +1,56 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2022  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-Qukeys.h>
+
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        ___, SFT_T(X), SFT_T(A), ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+KALEIDOSCOPE_INIT_PLUGINS(Qukeys);
+
+void setup() {
+  Kaleidoscope.setup();
+
+  Qukeys.setHoldTimeout(10);
+  Qukeys.setOverlapThreshold(0);
+  Qukeys.setMinimumHoldTime(0);
+  Qukeys.setMinimumPriorInterval(0);
+  Qukeys.setMaxIntervalForTapRepeat(0);
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/issues/1320/sketch.json
+++ b/tests/issues/1320/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:virtual:model01",
+    "port": ""
+  }
+}

--- a/tests/issues/1320/test.ktest
+++ b/tests/issues/1320/test.ktest
@@ -1,0 +1,355 @@
+VERSION 1
+
+KEYSWITCH BLANK  0  0  # Key_NoKey
+KEYSWITCH QX     0  1  # SFT_T(X)
+KEYSWITCH QA     0  2  # SFT_T(A)
+
+# ==============================================================================
+NAME Event ID Overflow
+
+RUN 1 ms
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+PRESS BLANK
+RUN 1 cycle
+RELEASE BLANK
+RUN 1 cycle
+
+# This next event has an ID of 127 (at the time of writing, we're still using a
+# signed 8-bit ID, starting from zero).
+
+PRESS QA
+RUN 1 cycle
+
+# This event has an ID of -128 (integer overflow).
+
+PRESS QX # SFT_T(X)
+RUN 1 cycle
+
+# This next event will cause Qukeys to flush the first event(127) to get flushed
+# from the queue.  While it is being flushed (by calling
+# Runtime.handleKeyEvent() again), the first event in the queue will be (-128).
+# If we're not careful, integer type promotion will cause an incorrect result,
+# aborting that event.
+
+RELEASE QX
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift
+EXPECT keyboard-report Key_LeftShift Key_X
+EXPECT keyboard-report Key_LeftShift
+
+RUN 5 ms
+
+RELEASE QA
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+RUN 5 ms


### PR DESCRIPTION
This fixes a problem that was causing key events to get dropped in some cases when the event id rolled over from positive to negative values while a plugin had events queued spanning both sides of the overflow.  This would generally result in event `127` getting dropped.  If the dropped event was a keyswitch toggling on, the key would be unresponsive.  If it was a key release, the key would get "stuck on".

The problem was that the 8-bit integer `KeyEventId` values were getting promoted to 16-bit integers when computing the difference between the event being flushed from the queue and the event at the head of the queue.  The resulting 16-bit value (`-128 - 127`) would be negative, whereas its 8-bit counterpart would be positive, resulting in a false positive return value from `shouldAbort()`.   The fix is to convert the difference back to an 8-bit integer before doing the comparison with zero.

I've included a testcase that fails without the fix.