### PR TITLE
reset HID protocol on reset

### DIFF
--- a/src/kaleidoscope/Runtime.cpp
+++ b/src/kaleidoscope/Runtime.cpp
@@ -65,6 +65,9 @@ void Runtime_::setup(void) {
 void Runtime_::loop(void) {
   millis_at_cycle_start_ = millis();
 
+  if (device().pollUSBReset()) {
+    device().hid().onUSBReset();
+  }
   kaleidoscope::Hooks::beforeEachCycle();
 
   // Next, we scan the keyswitches. Any toggle-on or toggle-off events will

--- a/src/kaleidoscope/device/Base.h
+++ b/src/kaleidoscope/device/Base.h
@@ -305,6 +305,16 @@ class Base {
   /** @} */
 
   /**
+   * Poll the USB device for a USB reset.
+   *
+   * @return true if a USB reset has occurred
+   * @return false if a USB reset has not occurred
+   */
+  bool pollUSBReset() {
+    return mcu_.pollUSBReset();
+  }
+
+  /**
    * @defgroup kaleidoscope_hardware_keyswitch_state Kaleidoscope::Hardware/Key-switch state
    *
    * These methods offer a way to peek at the key switch states, for those cases

--- a/src/kaleidoscope/driver/hid/Base.h
+++ b/src/kaleidoscope/driver/hid/Base.h
@@ -48,6 +48,10 @@ class Base {
     keyboard().setup();
   }
 
+  void onUSBReset() {
+    keyboard().onUSBReset();
+  }
+
   auto keyboard() -> decltype(keyboard_) & {
     return keyboard_;
   }

--- a/src/kaleidoscope/driver/hid/base/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/base/Keyboard.h
@@ -66,6 +66,8 @@ class NoBootKeyboard {
   uint8_t getLeds() {
     return 0;
   }
+
+  void onUSBReset() {}
 };
 
 class NoNKROKeyboard {
@@ -279,6 +281,10 @@ class Keyboard {
   }
   void setDefaultProtocol(uint8_t protocol) {
     boot_keyboard_.setDefaultProtocol(protocol);
+  }
+
+  void onUSBReset() {
+    boot_keyboard_.onUSBReset();
   }
 
  private:

--- a/src/kaleidoscope/driver/hid/keyboardio/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/keyboardio/Keyboard.h
@@ -90,6 +90,10 @@ class BootKeyboardWrapper {
   uint8_t getLeds() {
     return BootKeyboard().getLeds();
   }
+
+  void onUSBReset() {
+    BootKeyboard().onUSBReset();
+  }
 };
 
 class NKROKeyboardWrapper {

--- a/src/kaleidoscope/driver/mcu/ATmega32U4.h
+++ b/src/kaleidoscope/driver/mcu/ATmega32U4.h
@@ -73,6 +73,10 @@ class ATmega32U4 : public kaleidoscope::driver::mcu::Base<_Props> {
     if (_Props::disable_clock_division)
       disableClockDivision();
   }
+
+  bool USBConfigured() {
+    return USBDevice.configured();
+  }
 };
 #else
 template<typename _Props>

--- a/src/kaleidoscope/driver/mcu/Base.h
+++ b/src/kaleidoscope/driver/mcu/Base.h
@@ -43,6 +43,31 @@ class Base {
    * Must restore the link detachFromHost severed.
    */
   void attachToHost() {}
+
+  virtual bool USBConfigured() {
+    return true;
+  }
+
+  /**
+   * Poll the USB device for a bus reset.
+   *
+   * This default implementation uses a change in USBConfigured() as a proxy
+   * for actually detecting a bus reset.
+   */
+  bool pollUSBReset() {
+    static bool was_configured;
+    if (was_configured) {
+      if (!USBConfigured()) {
+        was_configured = false;
+        return true;
+      }
+    } else {
+      if (USBConfigured()) {
+        was_configured = true;
+      }
+    }
+    return false;
+  }
 };
 
 }  // namespace mcu

--- a/src/kaleidoscope/driver/mcu/GD32.h
+++ b/src/kaleidoscope/driver/mcu/GD32.h
@@ -38,6 +38,9 @@ class GD32 : public kaleidoscope::driver::mcu::Base<_Props> {
   void attachToHost() {
     USBCore().connect();
   }
+  bool USBConfigured() {
+    return USBCore().configured();
+  }
 
 
   void setup() {

--- a/src/kaleidoscope/driver/mcu/SAMD.h
+++ b/src/kaleidoscope/driver/mcu/SAMD.h
@@ -34,6 +34,9 @@ class SAMD : public kaleidoscope::driver::mcu::Base<BaseProps> {
   void attachToHost() {
     USBDevice.attach();
   }
+  bool USBConfigured() {
+    return USBDevice.configured();
+  }
 };
 
 }  // namespace mcu


### PR DESCRIPTION
Poll the keyboard device to check for a USB bus reset, and reset the protocol if so. This is necessary because polling the USB configuration state is the most portable way to detect a bus reset.

This requires keyboardio/KeyboardioHID#93, and keyboardio/ArduinoCore-GD32-Keyboardio#20 on GD32. The CI will probably fail until those are merged.

Fixes #1314.