### PR TITLE
fix redundant setup code on Model 100

### DIFF
--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.cpp
@@ -46,6 +46,7 @@ driver::keyboardio::Model100Side Model100Hands::rightHand(3);
 
 void Model100Hands::setup() {
   Model100KeyScanner::enableScannerPower();
+  delay(70);
   Wire.begin();
   Wire.setClock(400000);
 }
@@ -146,8 +147,7 @@ void Model100KeyScanner::disableScannerPower() {
 
 
 void Model100KeyScanner::setup() {
-  enableScannerPower();
-  delay(250);
+  Model100Hands::setup();
 }
 
 void Model100KeyScanner::readMatrix() {
@@ -227,12 +227,6 @@ uint8_t Model100KeyScanner::previousPressedKeyswitchCount() {
 }
 
 /********* Hardware plugin *********/
-
-void Model100::setup() {
-  Model100KeyScanner::setup();
-  Model100Hands::setup();
-  kaleidoscope::device::Base<Model100Props>::setup();
-}
 
 void Model100::enableHardwareTestMode() {
   // Toggle the programming LEDS on

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.h
@@ -152,8 +152,6 @@ struct Model100Props : public kaleidoscope::device::BaseProps {
 
 class Model100 : public kaleidoscope::device::Base<Model100Props> {
  public:
-  void setup();
-
   auto serialPort() -> decltype(Serial) & {
     return Serial;
   }


### PR DESCRIPTION
Remove some redundant calls in `Model100::setup()` that caused `Model100KeyScanner::enableScannerPower()` to be called three times during startup. Reduce the startup delay to 70ms to allow the ATtinys to boot.

For some reason, the delay is still needed, because the I2C seems to hang, otherwise. The cause of the hang is still under investigation.
