### PR TITLE
Fix defining multiple prefix layers

### DIFF
--- a/plugins/Kaleidoscope-PrefixLayer/src/kaleidoscope/plugin/PrefixLayer.cpp
+++ b/plugins/Kaleidoscope-PrefixLayer/src/kaleidoscope/plugin/PrefixLayer.cpp
@@ -63,11 +63,6 @@ EventHandlerResult PrefixLayer::onAddToReport(Key key) {
   return EventHandlerResult::OK;
 }
 
-void PrefixLayer::setPrefixLayers(const PrefixLayer::Entry *prefix_layers) {
-  prefix_layers_        = prefix_layers;
-  prefix_layers_length_ = sizeof(prefix_layers) / sizeof(PrefixLayer::Entry);
-}
-
 const PrefixLayer::Entry *PrefixLayer::getPrefixLayers() {
   return prefix_layers_;
 }

--- a/plugins/Kaleidoscope-PrefixLayer/src/kaleidoscope/plugin/PrefixLayer.h
+++ b/plugins/Kaleidoscope-PrefixLayer/src/kaleidoscope/plugin/PrefixLayer.h
@@ -41,7 +41,12 @@ class PrefixLayer : public Plugin {
       : layer(layer), prefix(prefix) {}
   };
 
-  void setPrefixLayers(const Entry *prefix_layers);
+  template<uint8_t _prefix_layers_count>
+  void setPrefixLayers(Entry const (&prefix_layers)[_prefix_layers_count]) {
+    prefix_layers_        = prefix_layers;
+    prefix_layers_length_ = _prefix_layers_count;
+  }
+
   const Entry *getPrefixLayers();
   uint8_t getPrefixLayersLength();
 

--- a/tests/issues/1324/1324.ino
+++ b/tests/issues/1324/1324.ino
@@ -1,0 +1,99 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2023  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-PrefixLayer.h>
+
+// clang-format off
+KEYMAPS(
+  [0] = KEYMAP_STACKED
+  (ShiftToLayer(1), ShiftToLayer(2), ShiftToLayer(3), ___, ___, ___, ___,
+   Key_X, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___,
+   ___,
+
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___,
+   ___),
+
+  [1] = KEYMAP_STACKED
+  (___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___,
+   ___,
+
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___,
+   ___),
+
+  [2] = KEYMAP_STACKED
+  (___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___,
+   ___,
+
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___,
+   ___),
+
+  [3] = KEYMAP_STACKED
+  (___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___,
+   ___,
+
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___, ___, ___, ___,
+   ___, ___, ___, ___,
+   ___),
+)
+// clang-format on
+
+static const kaleidoscope::plugin::PrefixLayer::Entry prefix_layers[] PROGMEM = {
+  kaleidoscope::plugin::PrefixLayer::Entry(1, LCTRL(Key_A)),
+  kaleidoscope::plugin::PrefixLayer::Entry(2, LCTRL(Key_B)),
+  kaleidoscope::plugin::PrefixLayer::Entry(3, LCTRL(Key_C)),
+};
+
+KALEIDOSCOPE_INIT_PLUGINS(PrefixLayer);
+
+void setup() {
+  Kaleidoscope.setup();
+  PrefixLayer.setPrefixLayers(prefix_layers);
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/issues/1324/sketch.json
+++ b/tests/issues/1324/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:virtual:model01",
+    "port": ""
+  }
+}

--- a/tests/issues/1324/sketch.yaml
+++ b/tests/issues/1324/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:virtual:model01

--- a/tests/issues/1324/test.ktest
+++ b/tests/issues/1324/test.ktest
@@ -1,0 +1,87 @@
+VERSION 1
+
+KEYSWITCH PREFIX_A  0 0
+KEYSWITCH PREFIX_B  0 1
+KEYSWITCH PREFIX_C  0 2
+KEYSWITCH X         1 0
+
+# ==============================================================================
+NAME First prefix layer
+
+RUN 4 ms
+PRESS PREFIX_A
+RUN 1 cycle
+EXPECT no keyboard-report
+
+RUN 4 ms
+PRESS X
+RUN 1 cycle
+EXPECT keyboard-report Key_LCtrl
+EXPECT keyboard-report Key_LCtrl Key_A
+EXPECT keyboard-report Key_LCtrl
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+
+RUN 4 ms
+RELEASE X
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+RUN 4 ms
+RELEASE PREFIX_A
+RUN 1 cycle
+EXPECT no keyboard-report
+
+# ==============================================================================
+NAME Second prefix layer
+
+RUN 4 ms
+PRESS PREFIX_B
+RUN 1 cycle
+EXPECT no keyboard-report
+
+RUN 4 ms
+PRESS X
+RUN 1 cycle
+EXPECT keyboard-report Key_LCtrl
+EXPECT keyboard-report Key_LCtrl Key_B
+EXPECT keyboard-report Key_LCtrl
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+
+RUN 4 ms
+RELEASE X
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+RUN 4 ms
+RELEASE PREFIX_B
+RUN 1 cycle
+EXPECT no keyboard-report
+
+# ==============================================================================
+NAME Third prefix layer
+
+RUN 4 ms
+PRESS PREFIX_C
+RUN 1 cycle
+EXPECT no keyboard-report
+
+RUN 4 ms
+PRESS X
+RUN 1 cycle
+EXPECT keyboard-report Key_LCtrl
+EXPECT keyboard-report Key_LCtrl Key_C
+EXPECT keyboard-report Key_LCtrl
+EXPECT keyboard-report empty
+EXPECT keyboard-report Key_X
+
+RUN 4 ms
+RELEASE X
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+RUN 4 ms
+RELEASE PREFIX_C
+RUN 1 cycle
+EXPECT no keyboard-report


### PR DESCRIPTION
The function `setPrefixLayers()` had a flaw: its parameter was a pointer to an array, without a length, resulting in the `prefix_layers_length_` variable not being set correctly.  It was meant to compute the length by dividing the size of the whole user-defined `prefix_layers` array by the size of a single element, but was instead using the size of a pointer in place of the size of the whole array.  The included testcase needs three prefix layers in order to trigger the bug because the size of a pointer in the simulator is 8 bytes.  Using a template function that takes a fixed-size array reference instead allows setting the length correctly without requiring the user to supply it as a separate argument.

I'm still a bit uncertain how prefix layers were working at all before this change.  I'm pretty sure that the size of a pointer on AVR is 2 bytes, but the size of the `PrefixLayer::Entry` data structure is 3 bytes, which would have resulted in a computed length of zero regardless of how many prefix layers were defined.

Fixes #1324