### PR TITLE
Fix "next" and "previous" layer shift keys

### DIFF
--- a/src/kaleidoscope/layers.cpp
+++ b/src/kaleidoscope/layers.cpp
@@ -81,7 +81,7 @@ void Layer_::handleLayerKeyEvent(const KeyEvent &event) {
     case KEYMAP_NEXT:
     case KEYMAP_PREVIOUS:
       if (keyToggledOn(event.state)) {
-        uint8_t top_layer = active_layers_[active_layer_count_ - 1];
+        uint8_t top_layer = unshifted(active_layers_[active_layer_count_ - 1]);
         if (target_layer == KEYMAP_NEXT) {
           // Key_KeymapNext_Momentary
           target_layer = top_layer + 1;

--- a/tests/features/layers/use-cases/test.ktest
+++ b/tests/features/layers/use-cases/test.ktest
@@ -27,6 +27,9 @@ KEYSWITCH LAYER_MOVE_2       2  7
 KEYSWITCH LAYER_SHIFT_NEXT   0 10
 KEYSWITCH LAYER_SHIFT_PREV   0 11
 
+KEYSWITCH LAYER_SHIFT_NEXT1  1 10
+KEYSWITCH LAYER_SHIFT_PREV1  1 11
+
 # ==============================================================================
 NAME Startup layer state
 
@@ -1140,6 +1143,62 @@ RELEASE LAYER_SHIFT_NEXT
 RUN 1 cycle
 
 # ............................................................
+# verify layer 1 inactive
+RUN 4 ms
+PRESS L1
+RUN 1 cycle
+EXPECT no keyboard-report
+
+RUN 4 ms
+RELEASE L1
+RUN 1 cycle
+EXPECT no keyboard-report
+
+# ----------------------------------------------------------------------
+RUN 5 ms
+
+
+# ==============================================================================
+NAME Double layer shift next
+
+# ----------------------------------------------------------------------
+# press two `Key_KeymapNext_Momentary` keys
+PRESS LAYER_SHIFT_NEXT
+RUN 5 ms
+PRESS LAYER_SHIFT_NEXT1
+RUN 5 ms
+
+# ----------------------------------------------------------------------
+# verify that layer 2 is active
+PRESS L2
+RUN 1 cycle
+EXPECT keyboard-report Key_2
+
+RUN 4 ms
+RELEASE L2
+RUN 1 cycle
+EXPECT keyboard-report empty
+
+# ----------------------------------------------------------------------
+# release `Key_KeymapNext_Momentary` keys
+RUN 4 ms
+RELEASE LAYER_SHIFT_NEXT1
+RELEASE LAYER_SHIFT_NEXT
+RUN 1 cycle
+
+# ----------------------------------------------------------------------
+# verify layer 2 inactive
+RUN 4 ms
+PRESS L2
+RUN 1 cycle
+EXPECT no keyboard-report
+
+RUN 4 ms
+RELEASE L2
+RUN 1 cycle
+EXPECT no keyboard-report
+
+# ----------------------------------------------------------------------
 # verify layer 1 inactive
 RUN 4 ms
 PRESS L1

--- a/tests/features/layers/use-cases/use-cases.ino
+++ b/tests/features/layers/use-cases/use-cases.ino
@@ -28,7 +28,7 @@ KEYMAPS(
         ___,
 
         ___, Key_KeymapNext_Momentary, Key_KeymapPrevious_Momentary, ___, ___, ___, ___,
-        ___, ___, ___, ___, ___, ___, ___,
+        ___, Key_KeymapNext_Momentary, Key_KeymapPrevious_Momentary, ___, ___, ___, ___,
         ShiftToLayer(0), ShiftToLayer(1), ShiftToLayer(2), ___, ___, ___,
         ___, ___, ___, ___, ___, ___, ___,
         ___, ___, ___, ___,


### PR DESCRIPTION
When shifted layers were given an offset to separate them from locked layers on the layer stack, we neglected to apply that offset correctly to the "next" and "previous" layer shift keys, as well as the more common numbered layer shift keys.

Fixes #1333.