### PR TITLE
Fix premature release of OneShot keys

### DIFF
--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.cpp
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.cpp
@@ -279,6 +279,8 @@ EventHandlerResult OneShot::onKeyEvent(KeyEvent &event) {
 
 // ----------------------------------------------------------------------------
 EventHandlerResult OneShot::afterReportingState(const KeyEvent &event) {
+  if (keyIsInjected(event.state))
+    return EventHandlerResult::OK;
   return afterEachCycle();
 }
 

--- a/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.cpp
+++ b/plugins/Kaleidoscope-OneShot/src/kaleidoscope/plugin/OneShot.cpp
@@ -194,7 +194,7 @@ EventHandlerResult OneShot::onKeyEvent(KeyEvent &event) {
   // hook functions generate (by calling `injectNormalKey()` via one of the
   // `*OneShot()` functions). There are more robust ways to do this, but since
   // OneShot is intended to react to only physical keypresses, this is adequate.
-  if (keyIsInjected(event.state))
+  if (!event.addr.isValid() || keyIsInjected(event.state))
     return EventHandlerResult::OK;
 
   bool temp = temp_addrs_.read(event.addr);
@@ -279,7 +279,7 @@ EventHandlerResult OneShot::onKeyEvent(KeyEvent &event) {
 
 // ----------------------------------------------------------------------------
 EventHandlerResult OneShot::afterReportingState(const KeyEvent &event) {
-  if (keyIsInjected(event.state))
+  if (!event.addr.isValid() || keyIsInjected(event.state))
     return EventHandlerResult::OK;
   return afterEachCycle();
 }

--- a/tests/issues/1335/1335.ino
+++ b/tests/issues/1335/1335.ino
@@ -1,0 +1,63 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2023  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-Macros.h>
+#include <Kaleidoscope-OneShot.h>
+
+// *INDENT-OFF*
+KEYMAPS(
+    [0] = KEYMAP_STACKED
+    (
+        OSM(LeftShift), M(0), ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___,
+
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___, ___, ___, ___,
+        ___, ___, ___, ___,
+        ___
+    ),
+)
+// *INDENT-ON*
+
+const macro_t *macroAction(uint8_t macro_id, KeyEvent &event) {
+  if (keyToggledOn(event.state)) {
+    switch (macro_id) {
+    case 0:
+      return MACRO(T(X), T(Y));
+    }
+  }
+  return MACRO_NONE;
+}
+
+KALEIDOSCOPE_INIT_PLUGINS(OneShot, Macros);
+
+void setup() {
+  Kaleidoscope.setup();
+  OneShot.setTimeout(50);
+  OneShot.setHoldTimeout(20);
+  OneShot.setDoubleTapTimeout(20);
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/tests/issues/1335/sketch.json
+++ b/tests/issues/1335/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:virtual:model01",
+    "port": ""
+  }
+}

--- a/tests/issues/1335/sketch.yaml
+++ b/tests/issues/1335/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:virtual:model01

--- a/tests/issues/1335/test.ktest
+++ b/tests/issues/1335/test.ktest
@@ -1,0 +1,32 @@
+VERSION 1
+
+KEYSWITCH OS_shift  0 0
+KEYSWITCH M_xy      0 1
+
+# ==============================================================================
+NAME OneShot Macro
+
+RUN 4 ms
+
+PRESS OS_shift
+RUN 1 cycle
+EXPECT keyboard-report Key_LeftShift
+
+RUN 5 ms
+RELEASE OS_shift
+
+RUN 4 ms
+PRESS M_xy
+RUN 1 cycle
+# Macros key `xy` keypress is being processed
+EXPECT keyboard-report Key_LeftShift Key_X
+EXPECT keyboard-report Key_LeftShift
+EXPECT keyboard-report Key_LeftShift Key_Y
+EXPECT keyboard-report Key_LeftShift
+# The Macro is done playing, so now OneShot releases the one-shot shift key
+EXPECT keyboard-report empty
+
+RUN 4 ms
+RELEASE M_xy
+RUN 1 cycle
+EXPECT no keyboard-report


### PR DESCRIPTION
If either the Macros or DynamicMacros plugin was included after OneShot in `KALEIDOSCOPE_INIT_PLUGINS`, playback of a macro containing a sequence of key presses would result in keys in the one-shot state being released during macro playback, such that only the first key in a Macros sequence would have  one-shot modifier applied to it.

This was happening because OneShot's `afterReportingState()` handler was failing to perform any checks, but simply unconditionally calling the code that could release a key under certain conditions.  This change introduces more robust guards around both key event handlers such that OneShot will now only respond to events corresponding to physical key addresses, and without the `INJECTED` flag.

Fixes #1335.