### PR TITLE
Gitignore bin/arduino-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /_build/
 /results/
 generated-testcase.cpp
+bin/arduino-cli


### PR DESCRIPTION
Calling `make setup` creates the arduino-cli binary which is necessary for building Kaleidoscope. But as this file is not ignored by git it “taints” the local working copy as it looks like there are local changes which is not really the case.