### PR TITLE
The initialisation for ARDUINOTRACE_INIT uses DebugStderr, since

### DIFF
--- a/plugins/Kaleidoscope-Devel-ArduinoTrace/src/Kaleidoscope-Devel-ArduinoTrace.h
+++ b/plugins/Kaleidoscope-Devel-ArduinoTrace/src/Kaleidoscope-Devel-ArduinoTrace.h
@@ -19,7 +19,7 @@
 
 #ifndef ARDUINOTRACE_SERIAL
 #ifdef KALEIDOSCOPE_VIRTUAL_BUILD
-#define ARDUINOTRACE_SERIAL DebugStderr
+#define ARDUINOTRACE_SERIAL DebugStderr()
 #endif
 #endif
 


### PR DESCRIPTION
these are globals defined in different translation units their initialisation order is not defined. In my case they initialised the wrong way around which triggered the UBSAN warning.

FWIW I got rid of the warning using the below use of the C++ FAQ suggestion https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use

Fixes #1348. Depends on the related change in the kaleidoscope bundle.

diff --git
a/plugins/Kaleidoscope-Devel-ArduinoTrace/src/Kaleidoscope-Devel-ArduinoTrace.h b/plugins/Kaleidoscope-Devel-ArduinoTrace/src/Kaleidoscope-Devel-ArduinoTrace.h index 7119e7bd..26beab32 100644
---
a/plugins/Kaleidoscope-Devel-ArduinoTrace/src/Kaleidoscope-Devel-ArduinoTrace.h +++
b/plugins/Kaleidoscope-Devel-ArduinoTrace/src/Kaleidoscope-Devel-ArduinoTrace.h @@ -19,7 +19,7 @@

-#define ARDUINOTRACE_SERIAL DebugStderr
+#define ARDUINOTRACE_SERIAL DebugStderr()
and in the hardware repository:

diff --git a/virtual/cores/arduino/HardwareSerial.cpp b/virtual/cores/arduino/HardwareSerial.cpp
index 655d093..1e5d988 100644
--- a/virtual/cores/arduino/HardwareSerial.cpp
+++ b/virtual/cores/arduino/HardwareSerial.cpp
@@ -92,5 +92,8 @@ HardwareSerial Serial1;
HardwareSerial Serial2;
HardwareSerial Serial3;

-DebugStderrSerial DebugStderr;
+DebugStderrSerial& DebugStderr() {
+  static DebugStderrSerial* ans = new DebugStderrSerial();
+  return *ans; +}

diff --git a/virtual/cores/arduino/HardwareSerial.h b/virtual/cores/arduino/HardwareSerial.h
index 979fba3..816d170 100644
--- a/virtual/cores/arduino/HardwareSerial.h
+++ b/virtual/cores/arduino/HardwareSerial.h
@@ -56,7 +56,7 @@ extern HardwareSerial Serial2;
extern HardwareSerial Serial3;

-extern DebugStderrSerial DebugStderr;
+extern DebugStderrSerial& DebugStderr();

// end HardwareSerial
To Reproduce
Run simulator-tests issues/1042 with UBSAN.