### PR TITLE
A variety of focus-related fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - run: make setup
     - run: KALEIDOSCOPE_TEMP_PATH=${{ github.workspace}}/.kaleidoscope-temp make -j $(nproc) smoke-sketches
   run-google-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Cache arduino dep downloads

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -61,7 +61,7 @@ EventHandlerResult FocusSerial::afterEachCycle() {
 
   do {
     // If there's a newline pending, don't read it
-    if (Runtime.serialPort().peek() == NEWLINE) {
+    if (peek() == NEWLINE) {
       break;
     }
     c = Runtime.serialPort().read();
@@ -136,14 +136,16 @@ bool FocusSerial::inputMatchesCommand(const char *input, const char *expected) {
   return strcmp_P(input, expected) == 0;
 }
 
+
 bool FocusSerial::isEOL() {
   int c        = -1;
   auto timeout = Runtime.serialPort().getTimeout();
   auto start   = millis();
 
+
   // Duplicate some of Stream::timedPeek because it's protected
   do {
-    c = Runtime.serialPort().peek();
+    c = peek();
     if (c == NEWLINE) {
       return true;
     } else if (c >= 0) {

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -32,10 +32,28 @@
 namespace kaleidoscope {
 namespace plugin {
 
+bool xon = true;
+
+void FocusSerial::manageFlowControl() {
+  uint8_t avail = Runtime.serialPort().available();
+  if (xon == true) {
+    if (avail > RECV_BUFFER_THRESHOLD) {
+      Runtime.serialPort().write(XOFF);  // Send XOFF to stop data
+      xon = false;
+    }
+  } else {
+    if (avail < RECV_BUFFER_RESUME) {
+      Runtime.serialPort().write(XON);  // Send XON to resume data
+      xon = true;
+    }
+  }
+}
+
 EventHandlerResult FocusSerial::afterEachCycle() {
   int c;
   // GD32 doesn't currently autoflush the very last packet. So manually flush here
   Runtime.serialPort().flush();
+
   // If the serial buffer is empty, we don't have any work to do
   if (Runtime.serialPort().available() == 0) {
     return EventHandlerResult::OK;

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -109,26 +109,33 @@ class FocusSerial : public kaleidoscope::Plugin {
   }
 
   const char peek() {
+    manageFlowControl();
     return Runtime.serialPort().peek();
   }
 
   void read(Key &key) {
+    manageFlowControl();
     key.setRaw(Runtime.serialPort().parseInt());
   }
   void read(cRGB &color) {
+    manageFlowControl();
     color.r = Runtime.serialPort().parseInt();
     color.g = Runtime.serialPort().parseInt();
     color.b = Runtime.serialPort().parseInt();
   }
   void read(char &c) {
+    manageFlowControl();
     Runtime.serialPort().readBytes(&c, 1);
   }
   void read(uint8_t &u8) {
+    manageFlowControl();
     u8 = Runtime.serialPort().parseInt();
   }
   void read(uint16_t &u16) {
+    manageFlowControl();
     u16 = Runtime.serialPort().parseInt();
   }
+
 
   bool isEOL();
 

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -46,6 +46,8 @@ class FocusSerial : public kaleidoscope::Plugin {
   static constexpr char SEPARATOR = ' ';
   static constexpr char NEWLINE   = '\n';
 
+  void manageFlowControl();
+
 #ifndef NDEPRECATED
   DEPRECATED(FOCUS_HANDLEHELP)
   bool handleHelp(const char *input, const char *help_message);
@@ -135,6 +137,11 @@ class FocusSerial : public kaleidoscope::Plugin {
   EventHandlerResult onFocusEvent(const char *input);
 
  private:
+  static constexpr char XOFF                     = 0x13;
+  static constexpr char XON                      = 0x11;
+  static constexpr uint8_t RECV_BUFFER_RESUME    = 4;
+  static constexpr uint8_t RECV_BUFFER_THRESHOLD = 32;
+
   char input_[32];
   uint8_t buf_cursor_ = 0;
   void printBool(bool b);

--- a/plugins/Kaleidoscope-LayerNames/src/kaleidoscope/plugin/LayerNames.cpp
+++ b/plugins/Kaleidoscope-LayerNames/src/kaleidoscope/plugin/LayerNames.cpp
@@ -59,7 +59,7 @@ EventHandlerResult LayerNames::onFocusEvent(const char *input) {
   } else {
     uint16_t pos = 0;
 
-    while (pos < storage_size_) {
+    while (pos < storage_size_ && !::Focus.isEOL()) {
       uint8_t name_size;
       ::Focus.read(name_size);
 

--- a/src/kaleidoscope/driver/keyscanner/ATmega.h
+++ b/src/kaleidoscope/driver/keyscanner/ATmega.h
@@ -91,7 +91,7 @@ class ATmega : public kaleidoscope::driver::keyscanner::Base<_KeyScannerProps> {
     TIMSK1 = _BV(TOIE1);
   }
 
-  __attribute__((optimize(3))) void readMatrix(void) {
+  __attribute__((optimize(2))) void readMatrix(void) {
     typename _KeyScannerProps::RowState any_debounced_changes = 0;
 
     for (uint8_t current_row = 0; current_row < _KeyScannerProps::matrix_rows; current_row++) {
@@ -117,7 +117,7 @@ class ATmega : public kaleidoscope::driver::keyscanner::Base<_KeyScannerProps> {
     actOnMatrixScan();
   }
 
-  void __attribute__((optimize(3))) actOnMatrixScan() {
+  void __attribute__((optimize(2))) actOnMatrixScan() {
     for (uint8_t row = 0; row < _KeyScannerProps::matrix_rows; row++) {
       for (uint8_t col = 0; col < _KeyScannerProps::matrix_columns; col++) {
         uint8_t keyState = (bitRead(matrix_state_[row].previous, col) << 0) | (bitRead(matrix_state_[row].current, col) << 1);

--- a/testing/makefiles/shared.mk
+++ b/testing/makefiles/shared.mk
@@ -15,7 +15,7 @@ shared_includes := \
 		-I${top_dir} \
 		-I${top_dir}/src \
 		-I${top_dir}/plugins/Kaleidoscope-Hardware-Keyboardio-Model01/src \
-		-I${arduino_platform_path}/cores/arduino \
+		-I${arduino_platform_path}/cores/keyboardio \
 		-I${arduino_platform_path}/libraries/KeyboardioHID/src \
 		-I${top_dir}/testing/googletest/googlemock/include \
 		-I${top_dir}/testing/googletest/googletest/include \

--- a/tests/issues/1042/1042.ino
+++ b/tests/issues/1042/1042.ino
@@ -24,8 +24,6 @@
 #include "kaleidoscope/LiveKeys.h"
 #include "kaleidoscope/plugin.h"
 
-#include <Kaleidoscope-Devel-ArduinoTrace.h>
-
 // *INDENT-OFF*
 KEYMAPS(
   [0] = KEYMAP_STACKED


### PR DESCRIPTION
These fixes update Kaleidoscope to work with our updated Arduino cores for avr and virtual, add support for flow control in Focus, and fix a bug in the layernames plugin, all of which work together to dramatically improve the reliability of Focus, particularly on macOS.