### PR TITLE
Drop Colormap dependency for using the color palette

### DIFF
--- a/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/DefaultColormap.cpp
+++ b/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/DefaultColormap.cpp
@@ -18,21 +18,18 @@
 #include "kaleidoscope/plugin/Colormap.h"  // for Colormap
 #include "kaleidoscope/plugin/DefaultColormap.h"
 
-#include <Arduino.h>                         // for F, PSTR, __FlashStringHelper
-#include <Kaleidoscope-FocusSerial.h>        // for Focus, FocusSerial
-#include <Kaleidoscope-LEDControl.h>         // for LEDControl
-#include <Kaleidoscope-LED-Palette-Theme.h>  // for LEDPaletteTheme
-#include <stdint.h>                          // for uint8_t, uint16_t
+#include <Arduino.h>                   // for PSTR
+#include <Kaleidoscope-FocusSerial.h>  // for Focus
+#include <Kaleidoscope-LEDControl.h>   // for LEDControl
+#include <stdint.h>                    // for uint8_t
 
-#include "kaleidoscope/KeyAddr.h"  // for KeyAddr
-#include "kaleidoscope/Runtime.h"  // for Runtime, Runtime_
+#include "kaleidoscope/Runtime.h"  // for Runtime
+#include "kaleidoscope/plugin/DefaultPalette.h"
 
 namespace kaleidoscope {
 namespace plugin {
 
 namespace defaultcolormap {
-__attribute__((weak)) extern const cRGB palette[]                                                                                                = {};
-__attribute__((weak)) extern bool palette_defined                                                                                                = false;
 __attribute__((weak)) extern const uint8_t colormaps[][kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns] = {};
 __attribute__((weak)) extern uint8_t colormap_layers                                                                                             = 0;
 }  // namespace defaultcolormap
@@ -46,17 +43,7 @@ void DefaultColormap::setup() {
 }
 
 void DefaultColormap::install() {
-  if (!defaultcolormap::palette_defined) return;
-
-  for (uint8_t i = 0; i < 16; i++) {
-    cRGB color;
-
-    color.r = pgm_read_byte(&(defaultcolormap::palette[i].r));
-    color.g = pgm_read_byte(&(defaultcolormap::palette[i].g));
-    color.b = pgm_read_byte(&(defaultcolormap::palette[i].b));
-
-    ::LEDPaletteTheme.updatePaletteColor(i, color);
-  }
+  DefaultPalette::setup();
 
   if (defaultcolormap::colormap_layers == 0) return;
 

--- a/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/DefaultColormap.h
+++ b/plugins/Kaleidoscope-Colormap/src/kaleidoscope/plugin/DefaultColormap.h
@@ -21,7 +21,6 @@
 #include <stdint.h>   // for uint8_t
 
 #include "kaleidoscope_internal/device.h"       // for device
-#include "kaleidoscope/device/device.h"         // for cRGB
 #include "kaleidoscope/event_handler_result.h"  // for EventHandlerResult
 #include "kaleidoscope/plugin.h"                // for Plugin
 
@@ -59,25 +58,9 @@ namespace plugin {
   }
 #endif
 
-#define PALETTE(p0, p1, p2, p3, p4, p5, p6, p7,           \
-                p8, p9, pa, pb, pc, pd, pe, pf)           \
-  namespace kaleidoscope {                                \
-  namespace plugin {                                      \
-  namespace defaultcolormap {                             \
-    const cRGB palette[] PROGMEM = {                      \
-      p0, p1, p2, p3, p4, p5, p6, p7,                     \
-      p8, p9, pa, pb, pc, pd, pe, pf                      \
-    };                                                    \
-    bool palette_defined = true;                          \
-  } /* defaultcolormap */                                 \
-  } /* plugin */                                          \
-  } /* kaleidoscope */
-
 // clang-format on
 
 namespace defaultcolormap {
-extern bool palette_defined;
-extern const cRGB palette[];
 extern const uint8_t colormaps[][kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns];
 extern uint8_t colormap_layers;
 }  // namespace defaultcolormap

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/Kaleidoscope-LED-Palette-Theme.h
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/Kaleidoscope-LED-Palette-Theme.h
@@ -18,3 +18,4 @@
 #pragma once
 
 #include "kaleidoscope/plugin/LED-Palette-Theme.h"  // IWYU pragma: export
+#include "kaleidoscope/plugin/DefaultPalette.h"     // IWYU pragma: export

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/DefaultPalette.cpp
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/DefaultPalette.cpp
@@ -1,0 +1,48 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-Colormap -- Per-layer colormap effect
+ * Copyright (C) 2022  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "kaleidoscope/plugin/DefaultPalette.h"
+#include "kaleidoscope/plugin/LED-Palette-Theme.h"  // for LEDPaletteTheme
+
+#include <stdint.h>  // for uint8_t
+
+namespace kaleidoscope {
+namespace plugin {
+
+namespace ledpalette {
+__attribute__((weak)) extern const cRGB palette[] = {};
+__attribute__((weak)) extern bool palette_defined = false;
+}  // namespace ledpalette
+
+void DefaultPalette::setup() {
+  if (!ledpalette::palette_defined) return;
+
+  for (uint8_t i = 0; i < 16; i++) {
+    cRGB color;
+
+    color.r = pgm_read_byte(&(ledpalette::palette[i].r));
+    color.g = pgm_read_byte(&(ledpalette::palette[i].g));
+    color.b = pgm_read_byte(&(ledpalette::palette[i].b));
+
+    ::LEDPaletteTheme.updatePaletteColor(i, color);
+  }
+}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
+
+kaleidoscope::plugin::DefaultPalette DefaultPalette;

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/DefaultPalette.h
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/DefaultPalette.h
@@ -1,0 +1,59 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-Colormap -- Per-layer colormap effect
+ * Copyright (C) 2022  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <Arduino.h>  // for PROGMEM
+
+#include "kaleidoscope/device/device.h"  // for cRGB
+#include "kaleidoscope/plugin.h"         // for Plugin
+
+namespace kaleidoscope {
+namespace plugin {
+
+namespace ledpalette {
+extern bool palette_defined;
+extern const cRGB palette[];
+}  // namespace ledpalette
+
+class DefaultPalette : public Plugin {
+ public:
+  static void setup();
+};
+
+}  // namespace plugin
+}  // namespace kaleidoscope
+
+// clang-format off
+
+#define PALETTE(p0, p1, p2, p3, p4, p5, p6, p7,           \
+                p8, p9, pa, pb, pc, pd, pe, pf)           \
+  namespace kaleidoscope {                                \
+  namespace plugin {                                      \
+  namespace ledpalette {                                  \
+    const cRGB palette[] PROGMEM = {                      \
+      p0, p1, p2, p3, p4, p5, p6, p7,                     \
+      p8, p9, pa, pb, pc, pd, pe, pf                      \
+    };                                                    \
+    bool palette_defined = true;                          \
+  } /* defaultcolormap */                                 \
+  } /* plugin */                                          \
+  } /* kaleidoscope */
+
+// clang-format on
+
+extern kaleidoscope::plugin::DefaultPalette DefaultPalette;


### PR DESCRIPTION
As discussed on Discord, this PR moves the color palette to the `LED-Palette-Theme` plugin.

I've verified that this change has desired result of dropping the dependency on `Colormap` with my own sketch (which uses the LED-Palette-Theme and the palette, but doesn't otherwise use the `Colormap` plugin).
I also verified that all example schetches for Keyboardio devices still build and I did a quick test with an updated palette/colormap with the example M100 sketch and using Chrysalis to update the colormap.