### PR TITLE
testing: get link flags

### DIFF
--- a/testing/googletest/CMakeLists.txt
+++ b/testing/googletest/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Note: CMake support is community-based. The maintainers do not use CMake
 # internally.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/testing/googletest/googlemock/CMakeLists.txt
+++ b/testing/googletest/googlemock/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
   cmake_policy(SET CMP0048 NEW)
   project(gmock VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 endif()
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()

--- a/testing/googletest/googletest/CMakeLists.txt
+++ b/testing/googletest/googletest/CMakeLists.txt
@@ -53,7 +53,7 @@ else()
   cmake_policy(SET CMP0048 NEW)
   project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 endif()
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (POLICY CMP0063) # Visibility
   cmake_policy(SET CMP0063 NEW)

--- a/testing/makefiles/testcase.mk
+++ b/testing/makefiles/testcase.mk
@@ -83,7 +83,7 @@ compile-sketch: ${TEST_OBJS}
 		OUTPUT_PATH="${LIB_DIR}" \
 		_ARDUINO_CLI_COMPILE_CUSTOM_FLAGS='--build-property upload.maximum_size=""' \
 		$(MAKE) -f ${top_dir}/etc/makefiles/sketch.mk compile
-	$(QUIET) $(COMPILER_WRAPPER) $(call _arduino_prop,compiler.cpp.cmd) -o "${BIN_DIR}/${BIN_FILE}" \
+	$(QUIET) $(COMPILER_WRAPPER) $(call _arduino_prop,compiler.cpp.cmd) $(call _arduino_prop,compiler.cpp.elf.flags) -o "${BIN_DIR}/${BIN_FILE}" \
 		-lpthread -g -w ${TEST_OBJS} \
 		-L"${COMMON_LIB_DIR}" -lcommon \
 		"${LIB_DIR}/${LIB_FILE}" \


### PR DESCRIPTION
Get link flags from the Arduino platform config. This helps to work around an XCode bug on macOS, and requires a corresponding change to the platform.txt of the virtual platform. (keyboardio/Kaleidoscope-Bundle-Keyboardio#50)