### PR TITLE
ignore more install -d races

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,13 +19,13 @@ clean:
 	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 copy-plugin-readmes:
-	install -d plugins
+	-install -d plugins
 	(cd ../plugins; \
 		ls -d * |xargs -n 1 -I % cp %/README.md ../docs/plugins/%.md )
 
 
 examples:
-	install -d examples
+	-install -d examples
 	(cd ../examples; \
 		find . -type f \( -name \*ino -or -name \*h -or -name \*cpp \) \
 	) | \

--- a/testing/makefiles/libcommon.mk
+++ b/testing/makefiles/libcommon.mk
@@ -27,12 +27,12 @@ DEFAULT_GOAL: all
 all: ${OBJ_FILES} ${LIB_DIR}/${LIB_FILE}
 
 ${LIB_DIR}/${LIB_FILE}: ${OBJ_FILES}
-	$(QUIET) install -d "${LIB_DIR}"
+	-$(QUIET) install -d "${LIB_DIR}"
 	$(QUIET) $(call _arduino_prop,compiler.ar.cmd) $(call _arduino_prop,compiler.ar.flags) "${LIB_DIR}/${LIB_FILE}" ${OBJ_FILES}
 
 ${OBJ_DIR}/%.o: ${top_dir}/testing/%.cpp ${H_FILES}
 	$(info compile $@)
-	$(QUIET) install -d "${OBJ_DIR}"
+	-$(QUIET) install -d "${OBJ_DIR}"
 	$(QUIET) $(COMPILER_WRAPPER) $(call _arduino_prop,compiler.cpp.cmd) -o "$@" -c -std=c++14 ${shared_includes} ${shared_defines} $<
 
 clean:

--- a/testing/makefiles/testcase.mk
+++ b/testing/makefiles/testcase.mk
@@ -78,7 +78,7 @@ ${BIN_DIR}/${BIN_FILE}: compile-sketch
 # We force sketch recompiliation because otherwise, make won't pick up changes to...anything on the arduino side
 .PHONY: compile-sketch
 compile-sketch: ${TEST_OBJS}
-	@install -d "${BIN_DIR}" "${LIB_DIR}"
+	-@install -d "${BIN_DIR}" "${LIB_DIR}"
 	$(QUIET) env LIBONLY=yes VERBOSE=${VERBOSE}  \
 		OUTPUT_PATH="${LIB_DIR}" \
 		_ARDUINO_CLI_COMPILE_CUSTOM_FLAGS='--build-property upload.maximum_size=""' \
@@ -100,14 +100,14 @@ ifneq (,$(wildcard test.ktest))
 ifdef VERBOSE
 	$(QUIET) $(info Compiling ${testcase} ktest script into ${SRC_DIR}/generated-testcase.cpp)
 endif
-	$(QUIET) install -d "${SRC_DIR}"
+	-$(QUIET) install -d "${SRC_DIR}"
 	$(QUIET) perl ${top_dir}/testing/bin/ktest-to-cxx \
 		--ktest=test.ktest \
 		--cxx=${SRC_DIR}/generated-testcase.cpp
 endif
 
 ${OBJ_DIR}/%.o: ${SRC_DIR}/%.cpp
-	$(QUIET) install -d "${OBJ_DIR}"
+	-$(QUIET) install -d "${OBJ_DIR}"
 	$(QUIET) $(COMPILER_WRAPPER) $(call _arduino_prop,compiler.cpp.cmd) -o "$@" -c -std=c++14 \
 		${shared_includes} ${include_plugins_dir} ${shared_defines} $<
 


### PR DESCRIPTION
While testing a lot of simulator-test runs, I kept running into "file exists" errors on occasion. I went and tracked down all the remaining non-ignored invocations of `install -d` in Makefiles.