### PR TITLE
Focus sendbytes

### DIFF
--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -113,14 +113,16 @@ EventHandlerResult FocusSerial::onFocusEvent(const char *input) {
     return EventHandlerResult::EVENT_CONSUMED;
   }
   if (inputMatchesCommand(input, cmd_bytes)) {
+    uint8_t buf[64];
     uint16_t n;
     read(n);
-    for (uint16_t i = 0; i < n; i++) {
-      sendRaw('A');
+    memset(buf, 'A', sizeof(buf));
+    while (n > 0) {
+      size_t wrote = Runtime.serialPort().write(buf, min(sizeof(buf), n));
+      n -= wrote;
     }
     return EventHandlerResult::EVENT_CONSUMED;
   }
-
   return EventHandlerResult::OK;
 }
 

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -99,6 +99,7 @@ EventHandlerResult FocusSerial::onFocusEvent(const char *input) {
   const char *cmd_help    = PSTR("help");
   const char *cmd_reset   = PSTR("device.reset");
   const char *cmd_plugins = PSTR("plugins");
+  const char *cmd_bytes   = PSTR("sendbytes");
 
   if (inputMatchesHelp(input))
     return printHelp(cmd_help, cmd_reset, cmd_plugins);
@@ -109,6 +110,14 @@ EventHandlerResult FocusSerial::onFocusEvent(const char *input) {
   }
   if (inputMatchesCommand(input, cmd_plugins)) {
     kaleidoscope::Hooks::onNameQuery();
+    return EventHandlerResult::EVENT_CONSUMED;
+  }
+  if (inputMatchesCommand(input, cmd_bytes)) {
+    uint16_t n;
+    read(n);
+    for (uint16_t i = 0; i < n; i++) {
+      sendRaw('A');
+    }
     return EventHandlerResult::EVENT_CONSUMED;
   }
 


### PR DESCRIPTION
Not for merging! This is for testing purposes, and might make some sketches too large to fit on AVR platforms.

This adds a `sendbytes` command to test certain ZLP sending issues.

For example, `sendbytes 59` will send a 64-byte packet (subtract 5 bytes for the CR LF Period CR LF sent at command completion).
