### PR TITLE
Reduce the chances of xon/xoff causing comms to wedge

### DIFF
--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.cpp
@@ -39,11 +39,13 @@ void FocusSerial::manageFlowControl() {
   if (xon == true) {
     if (avail > RECV_BUFFER_THRESHOLD) {
       Runtime.serialPort().write(XOFF);  // Send XOFF to stop data
+      Runtime.serialPort().flush();
       xon = false;
     }
   } else {
     if (avail < RECV_BUFFER_RESUME) {
       Runtime.serialPort().write(XON);  // Send XON to resume data
+      Runtime.serialPort().flush();
       xon = true;
     }
   }
@@ -65,6 +67,7 @@ EventHandlerResult FocusSerial::afterEachCycle() {
       break;
     }
     c = Runtime.serialPort().read();
+    manageFlowControl();
     // Don't store the separator; just stash it
     if (c == SEPARATOR) {
       break;
@@ -82,6 +85,7 @@ EventHandlerResult FocusSerial::afterEachCycle() {
   Runtime.onFocusEvent(input_);
   while (Runtime.serialPort().available()) {
     c = Runtime.serialPort().read();
+    manageFlowControl();
     if (c == NEWLINE) {
       // newline serves as an end-of-command marker
       // don't drain the buffer past there

--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -116,24 +116,29 @@ class FocusSerial : public kaleidoscope::Plugin {
   void read(Key &key) {
     manageFlowControl();
     key.setRaw(Runtime.serialPort().parseInt());
+    manageFlowControl();
   }
   void read(cRGB &color) {
     manageFlowControl();
     color.r = Runtime.serialPort().parseInt();
     color.g = Runtime.serialPort().parseInt();
     color.b = Runtime.serialPort().parseInt();
+    manageFlowControl();
   }
   void read(char &c) {
     manageFlowControl();
     Runtime.serialPort().readBytes(&c, 1);
+    manageFlowControl();
   }
   void read(uint8_t &u8) {
     manageFlowControl();
     u8 = Runtime.serialPort().parseInt();
+    manageFlowControl();
   }
   void read(uint16_t &u16) {
     manageFlowControl();
     u16 = Runtime.serialPort().parseInt();
+    manageFlowControl();
   }
 
 


### PR DESCRIPTION
As previously implemented, it's possible that our xon/off flow control could send XOFF, do a read, and then...not send XON, leading to a stuck pipe