### PR TITLE
Remove xon/xoff flow control, now that we have more proper usb-level flow control

### DIFF
--- a/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
+++ b/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h
@@ -46,8 +46,6 @@ class FocusSerial : public kaleidoscope::Plugin {
   static constexpr char SEPARATOR = ' ';
   static constexpr char NEWLINE   = '\n';
 
-  void manageFlowControl();
-
 #ifndef NDEPRECATED
   DEPRECATED(FOCUS_HANDLEHELP)
   bool handleHelp(const char *input, const char *help_message);
@@ -109,38 +107,26 @@ class FocusSerial : public kaleidoscope::Plugin {
   }
 
   const char peek() {
-    manageFlowControl();
     return Runtime.serialPort().peek();
   }
 
   void read(Key &key) {
-    manageFlowControl();
     key.setRaw(Runtime.serialPort().parseInt());
-    manageFlowControl();
   }
   void read(cRGB &color) {
-    manageFlowControl();
     color.r = Runtime.serialPort().parseInt();
     color.g = Runtime.serialPort().parseInt();
     color.b = Runtime.serialPort().parseInt();
-    manageFlowControl();
   }
   void read(char &c) {
-    manageFlowControl();
     Runtime.serialPort().readBytes(&c, 1);
-    manageFlowControl();
   }
   void read(uint8_t &u8) {
-    manageFlowControl();
     u8 = Runtime.serialPort().parseInt();
-    manageFlowControl();
   }
   void read(uint16_t &u16) {
-    manageFlowControl();
     u16 = Runtime.serialPort().parseInt();
-    manageFlowControl();
   }
-
 
   bool isEOL();
 
@@ -149,11 +135,6 @@ class FocusSerial : public kaleidoscope::Plugin {
   EventHandlerResult onFocusEvent(const char *input);
 
  private:
-  static constexpr char XOFF                     = 0x13;
-  static constexpr char XON                      = 0x11;
-  static constexpr uint8_t RECV_BUFFER_RESUME    = 4;
-  static constexpr uint8_t RECV_BUFFER_THRESHOLD = 32;
-
   char input_[32];
   uint8_t buf_cursor_ = 0;
   void printBool(bool b);


### PR DESCRIPTION
Now that @tlyu has fixed bugs in the usb-level flow control implementations for avr *and* gd32 cores, it looks like we don't need the (flawed) xon/xoff support.


This reverts commit 81851f7878c9d3ca58bedbecaa16c3802fddf114. 
This reverts commit 601a0235879f0aa0679a7a4748e4760df12186f9. 
This reverts commit 92de6c0426d97d6db55563a4ae106f9c4cc1cea4. 
This reverts commit 3490984ce5df772238b5fa5b5c54e84f74c492ed.