### PR TITLE
Porting to a newer GCC, there are stricter constraints on constexpr functions

### DIFF
--- a/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.h
+++ b/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.h
@@ -46,9 +46,8 @@ namespace kaleidoscope {
 namespace plugin {
 
 constexpr Key ModTapKey(Key mod_key, Key tap_key) {
-  uint8_t mod = mod_key.getKeyCode() - HID_KEYBOARD_FIRST_MODIFIER;
   return Key(kaleidoscope::ranges::DUM_FIRST +
-             (mod << 8) + tap_key.getKeyCode());
+             ((mod_key.getKeyCode() - HID_KEYBOARD_FIRST_MODIFIER) << 8) + tap_key.getKeyCode());
 }
 
 constexpr Key LayerTapKey(uint8_t layer, Key tap_key) {

--- a/src/kaleidoscope/KeyAddrBitfield.h
+++ b/src/kaleidoscope/KeyAddrBitfield.h
@@ -50,7 +50,7 @@ class KeyAddrBitfield {
   static constexpr uint8_t bitIndex(KeyAddr k) {
     return k.toInt() % block_size;
   }
-  static constexpr KeyAddr index(uint8_t block_index, uint8_t bit_index) {
+  static KeyAddr index(uint8_t block_index, uint8_t bit_index) {
     uint8_t offset = (block_index * block_size) + bit_index;
     return KeyAddr(offset);
   }

--- a/src/kaleidoscope/key_defs.h
+++ b/src/kaleidoscope/key_defs.h
@@ -273,9 +273,7 @@ constexpr Key addFlags(Key k, uint8_t add_flags) {
 // =============================================================================
 /// Generate a ModLayer key (unchecked)
 constexpr Key modLayerKey(Key modifier, uint8_t layer) {
-  uint8_t mod  = modifier.getRaw() - Key_LeftControl.getRaw();
-  uint8_t code = mod + (layer * 8);
-  return Key(code, SYNTHETIC | SWITCH_TO_KEYMAP | IS_INTERNAL);
+  return Key(modifier.getRaw() - Key_LeftControl.getRaw() + (layer * 8), SYNTHETIC | SWITCH_TO_KEYMAP | IS_INTERNAL);
 }
 
 }  // namespace kaleidoscope


### PR DESCRIPTION

They now need to contain only a return statement