### PR TITLE
dota linkage no longer appears to provide a space advantage on AVR and breaks our link ordering for nrf52

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=
 category=Communication
 url=https://github.com/keyboardio/Kaleidoscope
 architectures=*
-dot_a_linkage=true
+dot_a_linkage=false


### PR DESCRIPTION
If this PR were to go wrong, it would do so by bloating the AVR build over the available storage size on our devices.