### PR TITLE
Use our HID abstraction in the codebase, to make code throughout not depend on KeyboardioHID

### DIFF
--- a/plugins/Kaleidoscope-HardwareTestMode/src/kaleidoscope/plugin/HardwareTestMode.cpp
+++ b/plugins/Kaleidoscope-HardwareTestMode/src/kaleidoscope/plugin/HardwareTestMode.cpp
@@ -18,12 +18,12 @@
 
 #include <stdint.h>  // for uint8_t
 
-#include "kaleidoscope/KeyAddr.h"                         // for MatrixAddr, MatrixAddr<>::Range
-#include "kaleidoscope/Runtime.h"                         // for Runtime, Runtime_
-#include "kaleidoscope/device/device.h"                   // for Device, cRGB, CRGB, Base<>::HID
-#include "kaleidoscope/driver/hid/keyboardio/Keyboard.h"  // for Keyboard
-#include "kaleidoscope/plugin/LEDControl.h"               // for LEDControl
-#include "kaleidoscope/plugin/LEDControl/LEDUtils.h"      // for hsvToRgb
+#include "kaleidoscope/KeyAddr.h"                     // for MatrixAddr, MatrixAddr<>::Range
+#include "kaleidoscope/Runtime.h"                     // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"               // for Device, cRGB, CRGB, Base<>::HID
+#include "kaleidoscope/driver/hid/base/Keyboard.h"    // for Keyboard
+#include "kaleidoscope/plugin/LEDControl.h"           // for LEDControl
+#include "kaleidoscope/plugin/LEDControl/LEDUtils.h"  // for hsvToRgb
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.cpp
+++ b/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/MouseKeys.cpp
@@ -20,16 +20,16 @@
 #include <Kaleidoscope-FocusSerial.h>  // for Focus, FocusSerial
 #include <stdint.h>                    // for uint8_t, uint16_t, int8_t
 
-#include "kaleidoscope/KeyEvent.h"                             // for KeyEvent
-#include "kaleidoscope/Runtime.h"                              // for Runtime, Runtime_
-#include "kaleidoscope/device/device.h"                        // for Base<>::HID, VirtualProps:...
-#include "kaleidoscope/driver/hid/keyboardio/AbsoluteMouse.h"  // for AbsoluteMouse
-#include "kaleidoscope/driver/hid/keyboardio/Mouse.h"          // for Mouse
-#include "kaleidoscope/event_handler_result.h"                 // for EventHandlerResult, EventH...
-#include "kaleidoscope/key_defs.h"                             // for Key, SYNTHETIC
-#include "kaleidoscope/keyswitch_state.h"                      // for keyToggledOn
-#include "kaleidoscope/plugin/mousekeys/MouseKeyDefs.h"        // for KEY_MOUSE_BUTTON, KEY_MOUS...
-#include "kaleidoscope/plugin/mousekeys/MouseWrapper.h"        // for MouseWrapper, WARP_DOWN
+#include "kaleidoscope/KeyEvent.h"                       // for KeyEvent
+#include "kaleidoscope/Runtime.h"                        // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"                  // for Base<>::HID, VirtualProps:...
+#include "kaleidoscope/driver/hid/base/AbsoluteMouse.h"  // for AbsoluteMouse
+#include "kaleidoscope/driver/hid/base/Mouse.h"          // for Mouse
+#include "kaleidoscope/event_handler_result.h"           // for EventHandlerResult, EventH...
+#include "kaleidoscope/key_defs.h"                       // for Key, SYNTHETIC
+#include "kaleidoscope/keyswitch_state.h"                // for keyToggledOn
+#include "kaleidoscope/plugin/mousekeys/MouseKeyDefs.h"  // for KEY_MOUSE_BUTTON, KEY_MOUS...
+#include "kaleidoscope/plugin/mousekeys/MouseWrapper.h"  // for MouseWrapper, WARP_DOWN
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/mousekeys/MouseWrapper.cpp
+++ b/plugins/Kaleidoscope-MouseKeys/src/kaleidoscope/plugin/mousekeys/MouseWrapper.cpp
@@ -19,9 +19,9 @@
 
 #include <stdint.h>  // for uint16_t, uint8_t
 
-#include "kaleidoscope/Runtime.h"                              // for Runtime, Runtime_
-#include "kaleidoscope/device/device.h"                        // for Base<>::HID, VirtualProps:...
-#include "kaleidoscope/driver/hid/keyboardio/AbsoluteMouse.h"  // for AbsoluteMouse
+#include "kaleidoscope/Runtime.h"                        // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"                  // for Base<>::HID, VirtualProps:...
+#include "kaleidoscope/driver/hid/base/AbsoluteMouse.h"  // for AbsoluteMouse
 
 namespace kaleidoscope {
 namespace plugin {

--- a/plugins/Kaleidoscope-USB-Quirks/src/kaleidoscope/plugin/USB-Quirks.cpp
+++ b/plugins/Kaleidoscope-USB-Quirks/src/kaleidoscope/plugin/USB-Quirks.cpp
@@ -20,11 +20,10 @@
 #include <Arduino.h>  // for delay
 #include <stdint.h>   // for uint8_t
 
-#include "kaleidoscope/Runtime.h"                         // for Runtime, Runtime_
-#include "kaleidoscope/device/device.h"                   // for Base<>::HID, VirtualProps::HID
-#include "kaleidoscope/driver/hid/keyboardio/Keyboard.h"  // for Keyboard
-#include "kaleidoscope/key_defs.h"                        // for Key
-#include "kaleidoscope/plugin/LEDControl.h"               // for LEDControl
+#include "kaleidoscope/Runtime.h"                   // for Runtime, Runtime_
+#include "kaleidoscope/device/device.h"             // for Base<>::HID, VirtualProps::HID
+#include "kaleidoscope/driver/hid/base/Keyboard.h"  // for Keyboard
+#include "kaleidoscope/plugin/LEDControl.h"         // for LEDControl
 
 namespace kaleidoscope {
 namespace plugin {

--- a/src/kaleidoscope/Runtime.cpp
+++ b/src/kaleidoscope/Runtime.cpp
@@ -19,13 +19,13 @@
 #include <Arduino.h>         // for millis
 #include <HardwareSerial.h>  // for HardwareSerial
 
-#include "kaleidoscope/KeyAddr.h"                         // for KeyAddr, MatrixAddr, MatrixAddr...
-#include "kaleidoscope/KeyEvent.h"                        // for KeyEvent
-#include "kaleidoscope/LiveKeys.h"                        // for LiveKeys, live_keys
-#include "kaleidoscope/device/device.h"                   // for Base<>::HID, VirtualProps::HID
-#include "kaleidoscope/driver/hid/keyboardio/Keyboard.h"  // for Keyboard
-#include "kaleidoscope/keyswitch_state.h"                 // for keyToggledOff, keyToggledOn
-#include "kaleidoscope/layers.h"                          // for Layer, Layer_
+#include "kaleidoscope/KeyAddr.h"                   // for KeyAddr, MatrixAddr, MatrixAddr...
+#include "kaleidoscope/KeyEvent.h"                  // for KeyEvent
+#include "kaleidoscope/LiveKeys.h"                  // for LiveKeys, live_keys
+#include "kaleidoscope/device/device.h"             // for Base<>::HID, VirtualProps::HID
+#include "kaleidoscope/driver/hid/base/Keyboard.h"  // for Keyboard
+#include "kaleidoscope/keyswitch_state.h"           // for keyToggledOff, keyToggledOn
+#include "kaleidoscope/layers.h"                    // for Layer, Layer_
 
 namespace kaleidoscope {
 


### PR DESCRIPTION
Instead of directly referencing the KeyboardioHID implementation of our HID facade, reference the base classes throughout the codebase to make it possible to build Kaleidoscope with another HID implementation.