### PR TITLE
Keyboardio Alto example.

### DIFF
--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/examples/Devices/Keyboardio/Alto/Alto.ino
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/examples/Devices/Keyboardio/Alto/Alto.ino
@@ -1,0 +1,386 @@
+// -*- mode: c++ -*-
+// Copyright 2016-2022 Keyboardio, inc. <jesse@keyboard.io>
+// See "LICENSE" for license details
+
+/**
+ * These #include directives pull in the Kaleidoscope firmware core,
+ * as well as the Kaleidoscope plugins we use in the Alto's Firmware
+ */
+
+// The Kaleidoscope core
+#include "Kaleidoscope.h"
+
+// Support for storing the keymap in EEPROM
+#include "Kaleidoscope-EEPROM-Settings.h"
+#include "Kaleidoscope-EEPROM-Keymap.h"
+
+// Support for communicating with the host via a simple Serial protocol
+#include "Kaleidoscope-FocusSerial.h"
+
+// Support for querying the firmware version via Focus
+#include "Kaleidoscope-FirmwareVersion.h"
+
+// Support for keys that move the mouse
+#include "Kaleidoscope-MouseKeys.h"
+
+// Support for macros
+#include "Kaleidoscope-Macros.h"
+
+// Support for host power management (suspend & wakeup)
+#include "Kaleidoscope-HostPowerManagement.h"
+
+// Support for magic combos (key chords that trigger an action)
+#include "Kaleidoscope-MagicCombo.h"
+
+// Support for USB quirks, like changing the key state report protocol
+#include "Kaleidoscope-USB-Quirks.h"
+
+// Support for secondary actions on keys
+#include "Kaleidoscope-Qukeys.h"
+
+// Support for one-shot modifiers and layer keys
+#include "Kaleidoscope-OneShot.h"
+#include "Kaleidoscope-Escape-OneShot.h"
+
+// Support for dynamic, Chrysalis-editable macros
+#include "Kaleidoscope-DynamicMacros.h"
+
+// Support for SpaceCadet keys
+#include "Kaleidoscope-SpaceCadet.h"
+
+// Support for editable layer names
+#include "Kaleidoscope-LayerNames.h"
+
+// Support for the GeminiPR Stenography protocol
+#include "Kaleidoscope-Steno.h"
+
+/** This 'enum' is a list of all the macros used by the Alto's firmware
+  * The names aren't particularly important. What is important is that each
+  * is unique.
+  *
+  * These are the names of your macros. They'll be used in two places.
+  * The first is in your keymap definitions. There, you'll use the syntax
+  * `M(MACRO_NAME)` to mark a specific keymap position as triggering `MACRO_NAME`
+  *
+  * The second usage is in the 'switch' statement in the `macroAction` function.
+  * That switch statement actually runs the code associated with a macro when
+  * a macro key is pressed.
+  */
+
+enum {
+  MACRO_VERSION_INFO,
+  MACRO_ANY,
+};
+
+
+/** The Alto's key layouts are defined as 'keymaps'. By default, there are three
+  * keymaps: The standard QWERTY keymap, the "Function layer" keymap and the "Numpad"
+  * keymap.
+  *
+  * Each keymap is defined as a list using the 'KEYMAP' macro, built
+  * of first the left hand's layout, followed by the right hand's layout.
+  *
+  * Keymaps typically consist mostly of `Key_` definitions. There are many, many keys
+  * defined as part of the USB HID Keyboard specification. You can find the names
+  * (if not yet the explanations) for all the standard `Key_` defintions offered by
+  * Kaleidoscope in these files:
+  *    https://github.com/keyboardio/Kaleidoscope/blob/master/src/kaleidoscope/key_defs/keyboard.h
+  *    https://github.com/keyboardio/Kaleidoscope/blob/master/src/kaleidoscope/key_defs/consumerctl.h
+  *    https://github.com/keyboardio/Kaleidoscope/blob/master/src/kaleidoscope/key_defs/sysctl.h
+  *    https://github.com/keyboardio/Kaleidoscope/blob/master/src/kaleidoscope/key_defs/keymaps.h
+  *
+  * Additional things that should be documented here include
+  *   using ___ to let keypresses fall through to the previously active layer
+  *   using XXX to mark a keyswitch as 'blocked' on this layer
+  *   using ShiftToLayer() and LockLayer() keys to change the active keymap.
+  *   keeping NUM and FN consistent and accessible on all layers
+  *
+  * The PROG key is special, since it is how you indicate to the board that you
+  * want to flash the firmware. However, it can be remapped to a regular key.
+  * When the keyboard boots, it first looks to see whether the PROG key is held
+  * down; if it is, it simply awaits further flashing instructions. If it is
+  * not, it continues loading the rest of the firmware and the keyboard
+  * functions normally, with whatever binding you have set to PROG. More detail
+  * here: https://community.keyboard.io/t/how-the-prog-key-gets-you-into-the-bootloader/506/8
+  *
+  * The "keymaps" data structure is a list of the keymaps compiled into the firmware.
+  * The order of keymaps in the list is important, as the ShiftToLayer(#) and LockLayer(#)
+  * macros switch to key layers based on this list.
+  *
+  *
+
+  * A key defined as 'ShiftToLayer(FUNCTION)' will switch to FUNCTION while held.
+  * Similarly, a key defined as 'LockLayer(NUMPAD)' will switch to NUMPAD when tapped.
+  */
+
+/**
+  * Layers are "0-indexed" -- That is the first one is layer 0. The second one is layer 1.
+  * The third one is layer 2.
+  * This 'enum' lets us use names like QWERTY, FUNCTION, and NUMPAD in place of
+  * the numbers 0, 1 and 2.
+  *
+  */
+
+enum {
+  PRIMARY,
+};  // layers
+
+
+/**
+  * To change your keyboard's layout from QWERTY to DVORAK or COLEMAK, comment out the line
+  *
+  * #define PRIMARY_KEYMAP_QWERTY
+  *
+  * by changing it to
+  *
+  * // #define PRIMARY_KEYMAP_QWERTY
+  *
+  * Then uncomment the line corresponding to the layout you want to use.
+  *
+  */ \
+#define PRIMARY_KEYMAP_QWERTY  // #define PRIMARY_KEYMAP_DVORAK
+// #define PRIMARY_KEYMAP_COLEMAK
+// #define PRIMARY_KEYMAP_CUSTOM
+
+
+/* This comment temporarily turns off astyle's indent enforcement
+ *   so we can make the keymaps actually resemble the physical key layout better
+ */
+// clang-format off
+KEYMAPS( [PRIMARY] = KEYMAP (
+Key_Esc, Key_1, Key_2, Key_3, Key_4, Key_5, Key_6, Key_7, Key_8, Key_9, Key_0, Key_Minus, Key_Equals, Key_Backslash, Key_DownArrow, Key_Delete,
+Key_Tab, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Y, Key_U, Key_I, Key_O, Key_P, Key_LeftBracket, Key_RightBracket, Key_LeftArrow, Key_Backspace, Key_F1,
+Key_LeftControl, Key_A, Key_S, Key_D, Key_F, Key_G, Key_H, Key_J, Key_K, Key_L, Key_Semicolon, Key_Quote, Key_Enter, Key_F2,
+Key_F4, Key_LeftShift, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_N, Key_M, Key_Comma, Key_Period, Key_Slash, Key_RightShift, Key_F3,
+	Key_Space) 
+
+
+
+
+) // KEYMAPS(
+/* Re-enable astyle's indent enforcement */
+// clang-format on
+
+/** versionInfoMacro handles the 'firmware version info' macro
+ *  When a key bound to the macro is pressed, this macro
+ *  prints out the firmware build information as virtual keystrokes
+ */
+
+static void versionInfoMacro(uint8_t key_state) {
+  if (keyToggledOn(key_state)) {
+    Macros.type(PSTR("Keyboardio Alto - Firmware version "));
+    Macros.type(PSTR(KALEIDOSCOPE_FIRMWARE_VERSION));
+  }
+}
+
+/** anyKeyMacro is used to provide the functionality of the 'Any' key.
+ *
+ * When the 'any key' macro is toggled on, a random alphanumeric key is
+ * selected. While the key is held, the function generates a synthetic
+ * keypress event repeating that randomly selected key.
+ *
+ */
+
+static void anyKeyMacro(KeyEvent &event) {
+  if (keyToggledOn(event.state)) {
+    event.key.setKeyCode(Key_A.getKeyCode() + (uint8_t)(millis() % 36));
+    event.key.setFlags(0);
+  }
+}
+
+
+/** macroAction dispatches keymap events that are tied to a macro
+    to that macro. It takes two uint8_t parameters.
+
+    The first is the macro being called (the entry in the 'enum' earlier in this file).
+    The second is the state of the keyswitch. You can use the keyswitch state to figure out
+    if the key has just been toggled on, is currently pressed or if it's just been released.
+
+    The 'switch' statement should have a 'case' for each entry of the macro enum.
+    Each 'case' statement should call out to a function to handle the macro in question.
+
+ */
+
+const macro_t *macroAction(uint8_t macro_id, KeyEvent &event) {
+  switch (macro_id) {
+
+  case MACRO_VERSION_INFO:
+    versionInfoMacro(event.state);
+    break;
+
+  case MACRO_ANY:
+    anyKeyMacro(event);
+    break;
+  }
+  return MACRO_NONE;
+}
+
+
+/** This 'enum' is a list of all the magic combos used by the Alto's
+ * firmware The names aren't particularly important. What is important is that
+ * each is unique.
+ *
+ * These are the names of your magic combos. They will be used by the
+ * `USE_MAGIC_COMBOS` call below.
+ */
+enum {
+  // Toggle between Boot (6-key rollover; for BIOSes and early boot) and NKRO
+  // mode.
+  COMBO_TOGGLE_NKRO_MODE,
+};
+
+/** Wrappers, to be used by MagicCombo. **/
+
+/**
+ * This simply toggles the keyboard protocol via USBQuirks, and wraps it within
+ * a function with an unused argument, to match what MagicCombo expects.
+ */
+static void toggleKeyboardProtocol(uint8_t combo_index) {
+  USBQuirks.toggleKeyboardProtocol();
+}
+
+/**
+ * Toggles between using the built-in keymap, and the EEPROM-stored one.
+ */
+static void toggleKeymapSource(uint8_t combo_index) {
+  if (Layer.getKey == Layer.getKeyFromPROGMEM) {
+    Layer.getKey = EEPROMKeymap.getKey;
+  } else {
+    Layer.getKey = Layer.getKeyFromPROGMEM;
+  }
+}
+
+
+/** Magic combo list, a list of key combo and action pairs the firmware should
+ * recognise.
+ */
+USE_MAGIC_COMBOS({.action = toggleKeyboardProtocol,
+                  // Left Fn + Prog + LED
+                  .keys = {R3C6, R0C0, R0C6}},
+                 {.action = toggleKeymapSource,
+                  // Left Fn + Prog + Shift
+                  .keys = {R3C6, R0C0, R3C7}});
+
+// First, tell Kaleidoscope which plugins you want to use.
+// The order can be important. For example, LED effects are
+// added in the order they're listed here.
+KALEIDOSCOPE_INIT_PLUGINS(
+  // The EEPROMSettings & EEPROMKeymap plugins make it possible to have an
+  // editable keymap in EEPROM.
+  EEPROMSettings,
+  EEPROMKeymap,
+
+  // SpaceCadet can turn your shifts into parens on tap, while keeping them as
+  // Shifts when held. SpaceCadetConfig lets Chrysalis configure some aspects of
+  // the plugin.
+  SpaceCadet,
+  SpaceCadetConfig,
+
+  // Focus allows bi-directional communication with the host, and is the
+  // interface through which the keymap in EEPROM can be edited.
+  Focus,
+
+  // FocusSettingsCommand adds a few Focus commands, intended to aid in
+  // changing some settings of the keyboard, such as the default layer (via the
+  // `settings.defaultLayer` command)
+  FocusSettingsCommand,
+
+  // FocusEEPROMCommand adds a set of Focus commands, which are very helpful in
+  // both debugging, and in backing up one's EEPROM contents.
+  FocusEEPROMCommand,
+
+  // The macros plugin adds support for macros
+  Macros,
+
+  // The MouseKeys plugin lets you add keys to your keymap which move the mouse.
+  // The MouseKeysConfig plugin lets Chrysalis configure some aspects of the
+  // plugin.
+  MouseKeys,
+  MouseKeysConfig,
+
+  // The HostPowerManagement plugin allows us to turn LEDs off when then host
+  // goes to sleep, and resume them when it wakes up.
+  HostPowerManagement,
+
+  // The MagicCombo plugin lets you use key combinations to trigger custom
+  // actions - a bit like Macros, but triggered by pressing multiple keys at the
+  // same time.
+  MagicCombo,
+
+  // The USBQuirks plugin lets you do some things with USB that we aren't
+  // comfortable - or able - to do automatically, but can be useful
+  // nevertheless. Such as toggling the key report protocol between Boot (used
+  // by BIOSes) and Report (NKRO).
+  USBQuirks,
+
+  // The Qukeys plugin enables the "Secondary action" functionality in
+  // Chrysalis. Keys with secondary actions will have their primary action
+  // performed when tapped, but the secondary action when held.
+  Qukeys,
+
+  // Enables the "Sticky" behavior for modifiers, and the "Layer shift when
+  // held" functionality for layer keys.
+  OneShot,
+  OneShotConfig,
+  EscapeOneShot,
+  EscapeOneShotConfig,
+
+  // Enables dynamic, Chrysalis-editable macros.
+  DynamicMacros,
+
+  // The FirmwareVersion plugin lets Chrysalis query the version of the firmware
+  // programmatically.
+  FirmwareVersion,
+
+  // The LayerNames plugin allows Chrysalis to display - and edit - custom layer
+  // names, to be shown instead of the default indexes.
+  LayerNames,
+
+  // Enables the GeminiPR Stenography protocol. Unused by default, but with the
+  // plugin enabled, it becomes configurable - and then usable - via Chrysalis.
+  GeminiPR);
+
+/** The 'setup' function is one of the two standard Arduino sketch functions.
+ * It's called when your keyboard first powers up. This is where you set up
+ * Kaleidoscope and any plugins.
+ */
+void setup() {
+  // First, call Kaleidoscope's internal setup function
+  Kaleidoscope.setup();
+
+  // To make the keymap editable without flashing new firmware, we store
+  // additional layers in EEPROM. For now, we reserve space for eight layers. If
+  // one wants to use these layers, just set the default layer to one in EEPROM,
+  // by using the `settings.defaultLayer` Focus command, or by using the
+  // `keymap.onlyCustom` command to use EEPROM layers only.
+  EEPROMKeymap.setup(8);
+
+  // For Dynamic Macros, we need to reserve storage space for the editable
+  // macros. A kilobyte is a reasonable default.
+  DynamicMacros.reserve_storage(1024);
+
+  // If there's a default layer set in EEPROM, we should set that as the default
+  // here.
+  Layer.move(EEPROMSettings.default_layer());
+
+  // To avoid any surprises, SpaceCadet is turned off by default. However, it
+  // can be permanently enabled via Chrysalis, so we should only disable it if
+  // no configuration exists.
+  SpaceCadetConfig.disableSpaceCadetIfUnconfigured();
+
+  // Editable layer names are stored in EEPROM too, and we reserve 16 bytes per
+  // layer for them. We need one extra byte per layer for bookkeeping, so we
+  // reserve 17 / layer in total.
+  LayerNames.reserve_storage(17 * 8);
+}
+
+/** loop is the second of the standard Arduino sketch functions.
+  * As you might expect, it runs in a loop, never exiting.
+  *
+  * For Kaleidoscope-based keyboard firmware, you usually just want to
+  * call Kaleidoscope.loop(); and not do anything custom here.
+  */
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/examples/Devices/Keyboardio/Alto/Makefile
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/examples/Devices/Keyboardio/Alto/Makefile
@@ -1,0 +1,48 @@
+# This makefile for a Kaleidoscope sketch pulls in all the targets
+# required to build the example
+
+
+
+
+ifneq ($(KALEIDOSCOPE_DIR),)
+search_path += $(KALEIDOSCOPE_DIR)
+endif
+
+ifneq ($(ARDUINO_DIRECTORIES_USER),)
+search_path += $(ARDUINO_DIRECTORIES_USER)/hardware/keyboardio/avr/libraries/Kaleidoscope
+endif
+
+ifeq ($(shell uname -s),Darwin)
+search_path += $(HOME)/Documents/Arduino/hardware/keyboardio/avr/libraries/Kaleidoscope
+else
+search_path += $(HOME)/Arduino/hardware/keyboardio/avr/libraries/Kaleidoscope
+endif
+
+sketch_makefile := etc/makefiles/sketch.mk
+
+$(foreach candidate, $(search_path), $(if $(wildcard $(candidate)/$(sketch_makefile)), $(eval ks_dir ?= $(candidate))))
+
+ifneq ($(ks_dir),)
+
+$(info Using Kaleidoscope from $(ks_dir))
+
+export KALEIDOSCOPE_DIR := $(ks_dir)
+include $(ks_dir)/$(sketch_makefile)
+
+else
+
+$(info I can't find your Kaleidoscope installation.)
+$(info )
+$(info I tried looking in:)
+$(info )
+$(foreach candidate, $(search_path), $(info $(candidate)))
+$(info )
+$(info The easiest way to fix this is to set the 'KALEIDOSCOPE_DIR' environment)
+$(info variable to the location of your Kaleidoscope directory.)
+
+endif
+
+
+null-target:
+	$(info You should never see this message)
+	@:

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/examples/Devices/Keyboardio/Alto/sketch.json
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/examples/Devices/Keyboardio/Alto/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:gd32:keyboardio_alto",
+    "port": ""
+  }
+}

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/examples/Devices/Keyboardio/Alto/sketch.yaml
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/examples/Devices/Keyboardio/Alto/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:gd32:keyboardio_alto

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/library.properties
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/library.properties
@@ -1,0 +1,7 @@
+name=Kaleidoscope-Hardware-Keyboardio-Alto
+version=0.0.0
+sentence=Keyboardio Alto hardware support for Kaleidoscope
+maintainer=Kaleidoscope's Developers <jesse@keyboard.io>
+url=https://github.com/keyboardio/Kaleidoscope
+author=Keyboardio
+paragraph=

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/src/Kaleidoscope-Hardware-Keyboardio-Alto.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/src/Kaleidoscope-Hardware-Keyboardio-Alto.h
@@ -1,0 +1,20 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-Hardware-Keyboardio-Alto -- Keyboardio Alto hardware support for Kaleidoscope
+ * Copyright (C) 2021  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "kaleidoscope/device/keyboardio/Alto.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/src/kaleidoscope/device/keyboardio/Alto.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/src/kaleidoscope/device/keyboardio/Alto.cpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-Hardware-Alto -- Keyboardio Alto hardware support for Kaleidoscope
+ * Copyright (C) 2021  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef ARDUINO_keyboardio_alto
+
+#include "kaleidoscope/driver/keyscanner/Base_Impl.h"  // For Base<>
+
+#include "kaleidoscope/device/keyboardio/Alto.h"
+#include "kaleidoscope/Runtime.h"
+
+
+// Here, we set up aliases to the device's KeyScanner and KeyScannerProps
+// in the global namespace within the scope of this file. We'll use these
+// aliases to simplify some template initialization code below.
+using KeyScannerProps = typename kaleidoscope::device::keyboardio::AltoProps::KeyScannerProps;
+using KeyScanner      = typename kaleidoscope::device::keyboardio::AltoProps::KeyScanner;
+
+
+namespace kaleidoscope {
+namespace device {
+namespace keyboardio {
+
+// `KeyScannerProps` here refers to the alias set up above. We do not need to
+// prefix the `matrix_rows` and `matrix_columns` names within the array
+// declaration, because those are resolved within the context of the class, so
+// the `matrix_rows` in `KeyScannerProps::matrix_row_pins[matrix_rows]` gets
+// resolved as `KeyScannerProps::matrix_rows`.
+const uint8_t KeyScannerProps::matrix_rows;
+const uint8_t KeyScannerProps::matrix_columns;
+constexpr uint8_t KeyScannerProps::matrix_row_pins[matrix_rows];
+constexpr uint8_t KeyScannerProps::matrix_col_pins[matrix_columns];
+//
+//// `KeyScanner` here refers to the alias set up above, just like in the
+//// `KeyScannerProps` case above.
+template<>
+KeyScanner::row_state_t KeyScanner::matrix_state_[KeyScannerProps::matrix_rows] = {};
+
+template<>
+uint32_t KeyScanner::next_scan_at_ = 0;
+
+
+#ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+
+/********* Hardware plugin *********/
+
+void Alto::rebootBootloader() {
+  USBCore().disconnect();
+  NVIC_SystemReset();
+}
+
+#endif
+
+}  // namespace keyboardio
+}  // namespace device
+}  // namespace kaleidoscope
+
+#endif

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/src/kaleidoscope/device/keyboardio/Alto.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Alto/src/kaleidoscope/device/keyboardio/Alto.h
@@ -1,0 +1,124 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-Hardware-Alto -- Keyboardio Alto hardware support for Kaleidoscope
+ * Copyright (C) 2017-2021  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef ARDUINO_keyboardio_alto
+
+#include <Arduino.h>
+
+#define CRGB(r, g, b) \
+  (cRGB) {            \
+    b, g, r           \
+  }
+
+struct cRGB {
+  uint8_t b;
+  uint8_t g;
+  uint8_t r;
+};
+
+
+#include "kaleidoscope/device/Base.h"
+#include "kaleidoscope/driver/bootloader/gd32/Base.h"
+#include "kaleidoscope/driver/hid/Base.h"
+#include "kaleidoscope/driver/hid/Keyboardio.h"
+#include "kaleidoscope/driver/keyscanner/Simple.h"
+#include "kaleidoscope/driver/led/Base.h"
+#include "kaleidoscope/driver/mcu/GD32.h"
+#include "kaleidoscope/driver/storage/GD32Flash.h"
+
+
+namespace kaleidoscope {
+namespace device {
+namespace keyboardio {
+
+struct AltoStorageProps : public kaleidoscope::driver::storage::GD32FlashProps {
+  static constexpr uint16_t length = 16384;
+};
+
+struct AltoKeyScannerProps : public kaleidoscope::driver::keyscanner::SimpleProps {
+
+  static constexpr uint8_t matrix_rows    = 4;
+  static constexpr uint8_t matrix_columns = 16;
+  typedef MatrixAddr<matrix_rows, matrix_columns> KeyAddr;
+#ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+  static constexpr uint8_t matrix_row_pins[matrix_rows]    = {PB15, PB14, PB13, PB12};
+  static constexpr uint8_t matrix_col_pins[matrix_columns] = {PB11, PB10, PB9, PB8, PB7, PB6, PB5, PC15, PC14, PC13, PA0, PA1, PA2, PA3, PA4, PA5};
+
+#endif  // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+};
+
+
+// If we need to override HID props:
+struct AltoHIDProps : public kaleidoscope::driver::hid::KeyboardioProps {
+  //typedef kaleidoscope::driver::hid::base::AbsoluteMouseProps AbsoluteMouseProps;
+  //typedef kaleidoscope::driver::hid::base::AbsoluteMouse<AbsoluteMouseProps> AbsoluteMouse;
+};
+
+
+struct AltoProps : public kaleidoscope::device::BaseProps {
+  typedef AltoHIDProps HIDProps;
+  typedef kaleidoscope::driver::hid::Keyboardio<HIDProps> HID;
+
+  typedef AltoKeyScannerProps KeyScannerProps;
+  typedef kaleidoscope::driver::keyscanner::Simple<KeyScannerProps> KeyScanner;
+
+  typedef AltoStorageProps StorageProps;
+  typedef kaleidoscope::driver::storage::GD32Flash<StorageProps> Storage;
+
+  typedef kaleidoscope::driver::bootloader::gd32::Base Bootloader;
+  static constexpr const char *short_name = "alto";
+
+  typedef kaleidoscope::driver::mcu::GD32Props MCUProps;
+  typedef kaleidoscope::driver::mcu::GD32<MCUProps> MCU;
+};
+
+#ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+
+class Alto : public kaleidoscope::device::Base<AltoProps> {
+ public:
+  auto serialPort() -> decltype(Serial) & {
+    return Serial;
+  }
+  static void rebootBootloader();
+};
+
+#endif  // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+
+}  // namespace keyboardio
+}  // namespace device
+
+EXPORT_DEVICE(kaleidoscope::device::keyboardio::Alto)
+
+}  // namespace kaleidoscope
+
+// clang-format off
+
+
+#define PER_KEY_DATA(dflt,                                                                                 \
+   r0c0, r0c1, r0c2, r0c3, r0c4, r0c5, r0c6, r0c7, r0c8, r0c9, r0c10, r0c11, r0c12, r0c13, r0c14, r0c15, \
+   r1c0, r1c1, r1c2, r1c3, r1c4, r1c5, r1c6, r1c7, r1c8, r1c9, r1c10, r1c11, r1c12, r1c13, r1c14, r1c15, \
+   r2c0, r2c1, r2c2, r2c3, r2c4, r2c5, r2c6, r2c7, r2c8, r2c9, r2c10, r2c11, r2c12, r2c14,  \
+   r3c0, r3c1, r3c2, r3c3, r3c4, r3c5, r3c6, r3c8, r3c9, r3c10, r3c11, r3c12, r3c13, r3c14, \
+    						r3c7, ...)\
+    r0c0, r0c1, r0c2, r0c3, r0c4, r0c5, r0c6, r0c7, r0c8, r0c9, r0c10, r0c11, r0c12, r0c13, r0c14, r0c15, \
+    r1c0, r1c1, r1c2, r1c3, r1c4, r1c5, r1c6, r1c7, r1c8, r1c9, r1c10, r1c11, r1c12, r1c13, r1c14, r1c15, \
+    r2c0, r2c1, r2c2, r2c3, r2c4, r2c5, r2c6, r2c7, r2c8, r2c9, r2c10, r2c11, r2c12, XXX, r2c14, XXX, \
+    r3c0, r3c1, r3c2, r3c3, r3c4, r3c5, r3c6, r3c7, r3c8, r3c9, r3c10, r3c11, r3c12, r3c13, RESTRICT_ARGS_COUNT((r3c14), 61, KEYMAP, ##__VA_ARGS__)
+
+#endif


### PR DESCRIPTION
Add an implementation of the Alto keyboard recreation created with Trevor Flowers for possible deployment at the Computer History Museum and Bletchley Park.

This code serves as an example for how to build a keyboard with the simple keyscanner and a GD32 microcontroller.