### PR TITLE
PrefixLayer: read layers from PROGMEM

### DIFF
--- a/plugins/Kaleidoscope-PrefixLayer/src/kaleidoscope/plugin/PrefixLayer.cpp
+++ b/plugins/Kaleidoscope-PrefixLayer/src/kaleidoscope/plugin/PrefixLayer.cpp
@@ -44,8 +44,8 @@ EventHandlerResult PrefixLayer::onKeyEvent(KeyEvent &event) {
     return EventHandlerResult::OK;
 
   for (uint8_t i = 0; i < prefix_layers_length_; i++) {
-    if (Layer.isActive(prefix_layers_[i].layer)) {
-      current_prefix_ = prefix_layers_[i].prefix;
+    if (Layer.isActive(pgm_read_byte(&prefix_layers_[i].layer))) {
+      current_prefix_ = prefix_layers_[i].prefix.readFromProgmem();
       Runtime.handleKeyEvent(KeyEvent{KeyAddr::none(), IS_PRESSED | INJECTED, current_prefix_});
       Runtime.handleKeyEvent(KeyEvent{KeyAddr::none(), WAS_PRESSED | INJECTED, current_prefix_});
       current_prefix_ = Key_NoKey;


### PR DESCRIPTION
The documentation and examples for the plugin specify that the prefix layers are PROGMEM, but we didn't actually read from PROGMEM, resulting in the plugin working improperly on AVR hardware.

Tested on a Model 01.

Fixes #1351.