### PR TITLE
Stalker: keep LED bright while key is held

### DIFF
--- a/plugins/Kaleidoscope-LED-Stalker/src/kaleidoscope/plugin/LED-Stalker.h
+++ b/plugins/Kaleidoscope-LED-Stalker/src/kaleidoscope/plugin/LED-Stalker.h
@@ -45,8 +45,6 @@ class StalkerEffect : public Plugin,
   static uint16_t step_length;
   static cRGB inactive_color;
 
-  EventHandlerResult onKeyEvent(KeyEvent &event);
-
   // This class' instance has dynamic lifetime
   //
   class TransientLEDMode : public LEDMode {


### PR DESCRIPTION
This closes #1342.

Thanks to @algernon for guidance. But any bugs are mine not his.

Questions:

- Is it worth removing the event handler? If we are setting the intensity to max while the key is held, I'm not sure whether the event handler (which sets it to max on press and again on release) is adding anything. Maybe it adds a fraction more responsiveness?
- Is `update` the right place for this? I've read also of `beforeSyncingLeds` and `afterEachCycle`, and I don't know which is most appropriate.