### PR TITLE
Add warning about needing Rosetta2 on Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ $ cd examples/Devices/Keyboardio/Atreus
 $ make compile
 ```
 
+If you're running an Apple Silicon Mac and you get an error on this step about "bad CPU type in executable", install Rosetta2 by running `softwareupdate --install-rosetta` and try again.
+
 5.  Install your firmware
 
 ```sh


### PR DESCRIPTION
When attempting to build on an Apple Silicon mac that does not have Rosetta2 installed, attempting to build gives a somewhat inscrutable error message, so trying to head that off by giving people a heads-up here. Maybe there's a better place for it though?