### PR TITLE
Corrupted eeprom led to a frozen keyboard.

### DIFF
--- a/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/plugins/Kaleidoscope-DynamicMacros/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -68,7 +68,7 @@ uint8_t DynamicMacros::updateDynamicMacroCache() {
       do {
         flags   = Runtime.storage().read(pos++);
         keyCode = Runtime.storage().read(pos++);
-      } while (!(flags == 0 && keyCode == 0));
+      } while (!(flags == 0 && keyCode == 0) && (pos < storage_base_ + storage_size_));
       break;
     }
 


### PR DESCRIPTION
If storage was corrupted, DynamicMacros could loop forever while calculating macro metadata.