### PR TITLE
Remove the factory test mode from the Model 01 sketch.

### DIFF
--- a/examples/Devices/Keyboardio/Model01/Model01.ino
+++ b/examples/Devices/Keyboardio/Model01/Model01.ino
@@ -26,6 +26,9 @@
 // Support for querying the firmware version via Focus
 #include "Kaleidoscope-FirmwareVersion.h"
 
+// Support for setting the names of layers via Chrysalis
+// #include "Kaleidoscope-LayerNames.h"
+
 // Support for keys that move the mouse
 #include "Kaleidoscope-MouseKeys.h"
 
@@ -35,6 +38,9 @@
 
 // Support for controlling the keyboard's LEDs
 #include "Kaleidoscope-LEDControl.h"
+
+// Support for setting and saving the default LED mode
+// #include "Kaleidoscope-DefaultLEDModeConfig.h"
 
 // Support for "Numpad" mode, which is mostly just the Numpad specific LED mode
 #include "Kaleidoscope-NumPad.h"
@@ -61,9 +67,6 @@
 // Support for an LED mode that lets one configure per-layer color maps
 #include "Kaleidoscope-Colormap.h"
 
-// Support for Keyboardio's internal keyboard testing mode
-#include "Kaleidoscope-HardwareTestMode.h"
-
 // Support for host power management (suspend & wakeup)
 #include "Kaleidoscope-HostPowerManagement.h"
 
@@ -72,6 +75,13 @@
 
 // Support for secondary actions (one action when tapped, another when held)
 #include "Kaleidoscope-Qukeys.h"
+
+// Support for SpaceCadet keys
+// #include "Kaleidoscope-SpaceCadet.h"
+
+// Support for one-shot modifiers and layer keys
+// #include "Kaleidoscope-OneShot.h"
+// #include "Kaleidoscope-Escape-OneShot.h"
 
 // Support for USB quirks, like changing the key state report protocol
 #include "Kaleidoscope-USB-Quirks.h"
@@ -398,23 +408,12 @@ static void toggleKeyboardProtocol(uint8_t combo_index) {
   USBQuirks.toggleKeyboardProtocol();
 }
 
-/**
- *  This enters the hardware test mode
- */
-static void enterHardwareTestMode(uint8_t combo_index) {
-  HardwareTestMode.runTests();
-}
-
-
 /** Magic combo list, a list of key combo and action pairs the firmware should
  * recognise.
  */
 USE_MAGIC_COMBOS({.action = toggleKeyboardProtocol,
                   // Left Fn + Esc + Shift
-                  .keys = {R3C6, R2C6, R3C7}},
-                 {.action = enterHardwareTestMode,
-                  // Left Fn + Prog + LED
-                  .keys = {R3C6, R0C0, R0C6}});
+                  .keys = {R3C6, R2C6, R3C7}});
 
 // First, tell Kaleidoscope which plugins you want to use.
 // The order can be important. For example, LED effects are
@@ -563,12 +562,7 @@ KALEIDOSCOPE_INIT_PLUGINS(
   // comfortable - or able - to do automatically, but can be useful
   // nevertheless. Such as toggling the key report protocol between Boot (used
   // by BIOSes) and Report (NKRO).
-  USBQuirks,
-
-  // The hardware test mode, which can be invoked by tapping Prog, LED and the
-  // left Fn button at the same time.
-  HardwareTestMode  //,
-);
+  USBQuirks);
 
 /** The 'setup' function is one of the two standard Arduino sketch functions.
  * It's called when your keyboard first powers up. This is where you set up
@@ -586,9 +580,6 @@ void setup() {
   // This draws more than 500mA, but looks much nicer than a dimmer effect
   LEDRainbowEffect.brightness(150);
   LEDRainbowWaveEffect.brightness(150);
-
-  // Set the action key the test mode should listen for to Left Fn
-  HardwareTestMode.setActionKey(R3C6);
 
   // We want to make sure that the firmware starts with LED effects off
   // This avoids over-taxing devices that don't have a lot of power to share


### PR DESCRIPTION
We're quite space-constrained on the Model 01 and the factory test mode takes up a lot of space.