### PR TITLE
implement TinyUSB HID driver back end

### DIFF
--- a/src/kaleidoscope/driver/hid/HIDDefs.h
+++ b/src/kaleidoscope/driver/hid/HIDDefs.h
@@ -17,4 +17,8 @@
 
 #pragma once
 
+#ifndef USE_TINYUSB
 #include "tusb_hid.h"
+#else
+#include "class/hid/hid.h"
+#endif

--- a/src/kaleidoscope/driver/hid/TinyUSB.h
+++ b/src/kaleidoscope/driver/hid/TinyUSB.h
@@ -1,0 +1,45 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "kaleidoscope/driver/hid/Base.h"                      // for Base, BaseProps
+#include "kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.h"     // for AbsoluteMouse, AbsoluteMou...
+
+#ifdef USE_TINYUSB
+
+namespace kaleidoscope {
+namespace driver {
+namespace hid {
+
+struct TinyUSBProps : public BaseProps {
+  typedef base::KeyboardProps KeyboardProps;
+  typedef base::Keyboard<KeyboardProps> Keyboard;
+  typedef base::MouseProps MouseProps;
+  typedef base::Mouse<MouseProps> Mouse;
+  typedef tinyusb::AbsoluteMouseProps AbsoluteMouseProps;
+  typedef tinyusb::AbsoluteMouse<AbsoluteMouseProps> AbsoluteMouse;
+};
+
+template<typename _Props>
+class TinyUSB : public Base<_Props> {};
+
+}  // namespace hid
+}  // namespace driver
+}  // namespace kaleidoscope
+
+#endif /* USE_TINY_USB */

--- a/src/kaleidoscope/driver/hid/TinyUSB.h
+++ b/src/kaleidoscope/driver/hid/TinyUSB.h
@@ -1,6 +1,6 @@
 // -*- mode: c++ -*-
 /* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ * Copyright (C) 2013-2024  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/kaleidoscope/driver/hid/TinyUSB.h
+++ b/src/kaleidoscope/driver/hid/TinyUSB.h
@@ -19,6 +19,7 @@
 
 #include "kaleidoscope/driver/hid/Base.h"                   // for Base, BaseProps
 #include "kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.h"  // for AbsoluteMouse, AbsoluteMou...
+#include "kaleidoscope/driver/hid/tinyusb/Keyboard.h"
 #include "kaleidoscope/driver/hid/tinyusb/MultiReport.h"
 
 #ifdef USE_TINYUSB
@@ -32,8 +33,12 @@ struct TinyUSBProps : public BaseProps {
   typedef tinyusb::Keyboard<KeyboardProps> Keyboard;
   typedef tinyusb::MouseProps MouseProps;
   typedef tinyusb::Mouse<MouseProps> Mouse;
+#if CFG_TUD_HID > 2
   typedef tinyusb::AbsoluteMouseProps AbsoluteMouseProps;
   typedef tinyusb::AbsoluteMouse<AbsoluteMouseProps> AbsoluteMouse;
+#else
+#warning "omitting AbsoluteMouse because CFG_TUD_HID is too small"
+#endif
 };
 
 template<typename _Props>

--- a/src/kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.cpp
+++ b/src/kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.cpp
@@ -1,6 +1,6 @@
 // -*- mode: c++ -*-
 /* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ * Copyright (C) 2013-2024  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.cpp
+++ b/src/kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.cpp
@@ -1,0 +1,44 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef USE_TINYUSB
+
+#include "AbsoluteMouse.h"
+
+namespace kaleidoscope {
+namespace driver {
+namespace hid {
+namespace tinyusb {
+
+static const uint8_t AbsoluteMouseDesc[] = {
+  DESCRIPTOR_ABSOLUTE_MOUSE(),
+};
+
+TUSBAbsoluteMouse_::TUSBAbsoluteMouse_()
+  : HIDD(AbsoluteMouseDesc, sizeof(AbsoluteMouseDesc), HID_ITF_PROTOCOL_NONE, 1) {}
+
+TUSBAbsoluteMouse_ &TUSBAbsoluteMouse() {
+  static TUSBAbsoluteMouse_ obj;
+  return obj;
+}
+
+}  // namespace tinyusb
+}  // namespace hid
+}  // namespace driver
+}  // namespace kaleidoscope
+
+#endif /* USE_TINYUSB */

--- a/src/kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.h
+++ b/src/kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.h
@@ -22,6 +22,7 @@
 #include <stdint.h>  // for uint8_t, int8_t, uint16_t
 
 #include "Adafruit_TinyUSB.h"
+#include "HIDD.h"
 #include "kaleidoscope/driver/hid/apis/AbsoluteMouseAPI.h"  // for AbsoluteMouse, AbsoluteMouseProps
 
 // IWYU pragma: no_include "DeviceAPIs/AbsoluteMouseAPI.hpp"
@@ -35,16 +36,16 @@ static const uint8_t AbsoluteMouseDesc[] = {
   DESCRIPTOR_ABSOLUTE_MOUSE(),
 };
 
-class TUSBAbsoluteMouse : public AbsoluteMouseAPI, public Adafruit_USBD_HID {
+class TUSBAbsoluteMouse : public AbsoluteMouseAPI, public HIDD {
  public:
   TUSBAbsoluteMouse()
-    : Adafruit_USBD_HID(AbsoluteMouseDesc, sizeof(AbsoluteMouseDesc), HID_ITF_PROTOCOL_NONE, 1) {}
+    : HIDD(AbsoluteMouseDesc, sizeof(AbsoluteMouseDesc), HID_ITF_PROTOCOL_NONE, 1) {}
   void begin() {
-    (void)Adafruit_USBD_HID::begin();
+    (void)HIDD::begin();
     AbsoluteMouseAPI::begin();
   }
   void sendReport(void *data, int length) override {
-    (void)Adafruit_USBD_HID::sendReport(0, data, length);
+    (void)HIDD::sendReport(0, data, length);
   }
 };
 

--- a/src/kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.h
+++ b/src/kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.h
@@ -1,0 +1,63 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef USE_TINYUSB
+
+#include <stdint.h>  // for uint8_t, int8_t, uint16_t
+
+#include "Adafruit_TinyUSB.h"
+#include "kaleidoscope/driver/hid/apis/AbsoluteMouseAPI.h"  // for AbsoluteMouse, AbsoluteMouseProps
+
+// IWYU pragma: no_include "DeviceAPIs/AbsoluteMouseAPI.hpp"
+
+namespace kaleidoscope {
+namespace driver {
+namespace hid {
+namespace tinyusb {
+
+static const uint8_t AbsoluteMouseDesc[] = {
+  DESCRIPTOR_ABSOLUTE_MOUSE(),
+};
+
+class TUSBAbsoluteMouse : public AbsoluteMouseAPI, public Adafruit_USBD_HID {
+ public:
+  TUSBAbsoluteMouse()
+    : Adafruit_USBD_HID(AbsoluteMouseDesc, sizeof(AbsoluteMouseDesc), HID_ITF_PROTOCOL_NONE, 1) {}
+  void begin() {
+    (void)Adafruit_USBD_HID::begin();
+    AbsoluteMouseAPI::begin();
+  }
+  void sendReport(void *data, int length) override {
+    (void)Adafruit_USBD_HID::sendReport(0, data, length);
+  }
+};
+
+struct AbsoluteMouseProps : public base::AbsoluteMouseProps {
+  typedef TUSBAbsoluteMouse AbsoluteMouse;
+};
+
+template<typename _Props>
+class AbsoluteMouse : public base::AbsoluteMouse<_Props> {};
+
+}  // namespace tinyusb
+}  // namespace hid
+}  // namespace driver
+}  // namespace kaleidoscope
+
+#endif /* USE_TINYUSB */

--- a/src/kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.h
+++ b/src/kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.h
@@ -1,6 +1,6 @@
 // -*- mode: c++ -*-
 /* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ * Copyright (C) 2013-2024  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.h
+++ b/src/kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.h
@@ -32,14 +32,9 @@ namespace driver {
 namespace hid {
 namespace tinyusb {
 
-static const uint8_t AbsoluteMouseDesc[] = {
-  DESCRIPTOR_ABSOLUTE_MOUSE(),
-};
-
-class TUSBAbsoluteMouse : public AbsoluteMouseAPI, public HIDD {
+class TUSBAbsoluteMouse_ : public AbsoluteMouseAPI, public HIDD {
  public:
-  TUSBAbsoluteMouse()
-    : HIDD(AbsoluteMouseDesc, sizeof(AbsoluteMouseDesc), HID_ITF_PROTOCOL_NONE, 1) {}
+  TUSBAbsoluteMouse_();
   void begin() {
     (void)HIDD::begin();
     AbsoluteMouseAPI::begin();
@@ -49,8 +44,35 @@ class TUSBAbsoluteMouse : public AbsoluteMouseAPI, public HIDD {
   }
 };
 
+extern TUSBAbsoluteMouse_ &TUSBAbsoluteMouse();
+
+class AbsoluteMouseWrapper {
+ public:
+  AbsoluteMouseWrapper() {}
+
+  void begin() {
+    TUSBAbsoluteMouse().begin();
+  }
+  void move(int8_t x, int8_t y, int8_t wheel) {
+    TUSBAbsoluteMouse().move(x, y, wheel);
+  }
+  void moveTo(uint16_t x, uint16_t y, uint8_t wheel) {
+    TUSBAbsoluteMouse().moveTo(x, y, wheel);
+  }
+
+  void click(uint8_t buttons) {
+    TUSBAbsoluteMouse().click(buttons);
+  }
+  void press(uint8_t buttons) {
+    TUSBAbsoluteMouse().press(buttons);
+  }
+  void release(uint8_t buttons) {
+    TUSBAbsoluteMouse().release(buttons);
+  }
+};
+
 struct AbsoluteMouseProps : public base::AbsoluteMouseProps {
-  typedef TUSBAbsoluteMouse AbsoluteMouse;
+  typedef AbsoluteMouseWrapper AbsoluteMouse;
 };
 
 template<typename _Props>

--- a/src/kaleidoscope/driver/hid/tinyusb/HIDD.h
+++ b/src/kaleidoscope/driver/hid/tinyusb/HIDD.h
@@ -1,6 +1,6 @@
 // -*- mode: c++ -*-
 /* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ * Copyright (C) 2013-2024  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/kaleidoscope/driver/hid/tinyusb/Keyboard.cpp
+++ b/src/kaleidoscope/driver/hid/tinyusb/Keyboard.cpp
@@ -1,0 +1,87 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef USE_TINYUSB
+
+#include "kaleidoscope/driver/hid/tinyusb/Keyboard.h"
+
+namespace kaleidoscope {
+namespace driver {
+namespace hid {
+namespace tinyusb {
+
+static uint8_t BootKeyboardDesc[] = {
+  DESCRIPTOR_BOOT_KEYBOARD(),
+};
+
+static uint8_t HybridKeyboardDesc[] = {
+  DESCRIPTOR_HYBRID_KEYBOARD(),
+};
+
+uint8_t BootKeyboard_::leds     = 0;
+uint8_t BootKeyboard_::protocol = HID_PROTOCOL_REPORT;
+
+void boot_keyboard_set_report_cb(
+  uint8_t report_id,
+  hid_report_type_t report_type,
+  uint8_t const *buffer,
+  uint16_t bufsize) {
+  if (report_id != 0) {
+    return;
+  }
+  if (report_type != HID_REPORT_TYPE_OUTPUT) {
+    return;
+  }
+  if (bufsize != 1) {
+    return;
+  }
+  BootKeyboard_::leds = buffer[0];
+}
+
+BootKeyboard_::BootKeyboard_(uint8_t bootkb_only_)
+  : BootKeyboardAPI(bootkb_only_),
+    Adafruit_USBD_HID(bootkb_only_ ? BootKeyboardDesc : HybridKeyboardDesc,
+                      bootkb_only_ ? sizeof(BootKeyboardDesc) : sizeof(HybridKeyboardDesc),
+                      HID_ITF_PROTOCOL_KEYBOARD,
+                      1) {
+  setReportCallback(NULL, boot_keyboard_set_report_cb);
+}
+
+void BootKeyboard_::setReportDescriptor(uint8_t bootkb_only) {
+  if (bootkb_only) {
+    Adafruit_USBD_HID::setReportDescriptor(BootKeyboardDesc, sizeof(BootKeyboardDesc));
+  } else {
+    Adafruit_USBD_HID::setReportDescriptor(HybridKeyboardDesc, sizeof(HybridKeyboardDesc));
+  }
+}
+
+BootKeyboard_ &BootKeyboard() {
+  static BootKeyboard_ obj;
+  return obj;
+}
+
+void tud_hid_set_protocol_cb(uint8_t instance, uint8_t protocol) {
+  /* Adafruit_USBD_HID doesn't have a good way to check this now */
+  (void)instance;
+  BootKeyboard_::protocol = protocol;
+}
+
+}  // namespace tinyusb
+}  // namespace hid
+}  // namespace driver
+}  // namespace kaleidoscope
+#endif

--- a/src/kaleidoscope/driver/hid/tinyusb/Keyboard.cpp
+++ b/src/kaleidoscope/driver/hid/tinyusb/Keyboard.cpp
@@ -53,10 +53,10 @@ void boot_keyboard_set_report_cb(
 
 BootKeyboard_::BootKeyboard_(uint8_t bootkb_only_)
   : BootKeyboardAPI(bootkb_only_),
-    Adafruit_USBD_HID(bootkb_only_ ? BootKeyboardDesc : HybridKeyboardDesc,
-                      bootkb_only_ ? sizeof(BootKeyboardDesc) : sizeof(HybridKeyboardDesc),
-                      HID_ITF_PROTOCOL_KEYBOARD,
-                      1) {
+    HIDD(bootkb_only_ ? BootKeyboardDesc : HybridKeyboardDesc,
+         bootkb_only_ ? sizeof(BootKeyboardDesc) : sizeof(HybridKeyboardDesc),
+         HID_ITF_PROTOCOL_KEYBOARD,
+         1) {
   setReportCallback(NULL, boot_keyboard_set_report_cb);
 }
 

--- a/src/kaleidoscope/driver/hid/tinyusb/Keyboard.cpp
+++ b/src/kaleidoscope/driver/hid/tinyusb/Keyboard.cpp
@@ -1,6 +1,6 @@
 // -*- mode: c++ -*-
 /* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ * Copyright (C) 2013-2024  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/kaleidoscope/driver/hid/tinyusb/Keyboard.cpp
+++ b/src/kaleidoscope/driver/hid/tinyusb/Keyboard.cpp
@@ -32,8 +32,7 @@ static uint8_t HybridKeyboardDesc[] = {
   DESCRIPTOR_HYBRID_KEYBOARD(),
 };
 
-uint8_t BootKeyboard_::leds     = 0;
-uint8_t BootKeyboard_::protocol = HID_PROTOCOL_REPORT;
+uint8_t BootKeyboard_::leds = 0;
 
 void boot_keyboard_set_report_cb(
   uint8_t report_id,
@@ -72,12 +71,6 @@ void BootKeyboard_::setReportDescriptor(uint8_t bootkb_only) {
 BootKeyboard_ &BootKeyboard() {
   static BootKeyboard_ obj;
   return obj;
-}
-
-void tud_hid_set_protocol_cb(uint8_t instance, uint8_t protocol) {
-  /* Adafruit_USBD_HID doesn't have a good way to check this now */
-  (void)instance;
-  BootKeyboard_::protocol = protocol;
 }
 
 }  // namespace tinyusb

--- a/src/kaleidoscope/driver/hid/tinyusb/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/tinyusb/Keyboard.h
@@ -40,11 +40,11 @@ void tud_hid_set_protocol_cb(uint8_t instance, uint8_t protocol);
 void boot_keyboard_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const *buffer, uint16_t bufsize);
 }
 
-class BootKeyboard_ : public BootKeyboardAPI, public Adafruit_USBD_HID {
+class BootKeyboard_ : public BootKeyboardAPI, public HIDD {
  public:
   explicit BootKeyboard_(uint8_t bootkb_only_ = 0);
   void begin() {
-    (void)Adafruit_USBD_HID::begin();
+    (void)HIDD::begin();
     BootKeyboardAPI::begin();
   }
   void sendReport() {
@@ -52,7 +52,7 @@ class BootKeyboard_ : public BootKeyboardAPI, public Adafruit_USBD_HID {
   }
   void onUSBReset() override {}
   uint8_t getProtocol() override {
-    return Adafruit_USBD_HID::getProtocol();
+    return HIDD::getProtocol();
   }
   uint8_t getLeds() {
     return leds;
@@ -60,7 +60,7 @@ class BootKeyboard_ : public BootKeyboardAPI, public Adafruit_USBD_HID {
 
  protected:
   int SendHIDReport(const void *data, int len) override {
-    if (Adafruit_USBD_HID::sendReport(0, data, len)) {
+    if (HIDD::sendReport(0, data, len)) {
       return len;
     } else {
       return -1;

--- a/src/kaleidoscope/driver/hid/tinyusb/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/tinyusb/Keyboard.h
@@ -1,6 +1,6 @@
 // -*- mode: c++ -*-
 /* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ * Copyright (C) 2013-2024  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/kaleidoscope/driver/hid/tinyusb/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/tinyusb/Keyboard.h
@@ -59,7 +59,7 @@ class BootKeyboard_ : public BootKeyboardAPI, public Adafruit_USBD_HID {
   }
 
  protected:
-  int SendReport(const void *data, int len) override {
+  int SendHIDReport(const void *data, int len) override {
     if (Adafruit_USBD_HID::sendReport(0, data, len)) {
       return len;
     } else {

--- a/src/kaleidoscope/driver/hid/tinyusb/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/tinyusb/Keyboard.h
@@ -52,7 +52,7 @@ class BootKeyboard_ : public BootKeyboardAPI, public Adafruit_USBD_HID {
   }
   void onUSBReset() override {}
   uint8_t getProtocol() override {
-    return protocol;
+    return Adafruit_USBD_HID::getProtocol();
   }
   uint8_t getLeds() {
     return leds;
@@ -68,10 +68,8 @@ class BootKeyboard_ : public BootKeyboardAPI, public Adafruit_USBD_HID {
   }
   void setReportDescriptor(uint8_t bootkb_only) override;
 
-  static uint8_t protocol;
   static uint8_t leds;
 
-  friend void tud_hid_set_protocol_cb(uint8_t instance, uint8_t protocol);
   friend void boot_keyboard_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const *buffer, uint16_t bufsize);
 };
 

--- a/src/kaleidoscope/driver/hid/tinyusb/Keyboard.h
+++ b/src/kaleidoscope/driver/hid/tinyusb/Keyboard.h
@@ -1,0 +1,151 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef USE_TINYUSB
+
+#include <stdint.h>  // for uint8_t, uint16_t
+#include "Adafruit_TinyUSB.h"
+
+#include "kaleidoscope/driver/hid/apis/BootKeyboardAPI.h"
+
+// From Kaleidoscope:
+#include "kaleidoscope/driver/hid/base/Keyboard.h"  // for Keyboard, KeyboardProps
+#include "kaleidoscope/driver/hid/tinyusb/MultiReport.h"
+
+namespace kaleidoscope {
+namespace driver {
+namespace hid {
+namespace tinyusb {
+
+extern "C" {
+/* TinyUSB callback on SetReport */
+void tud_hid_set_protocol_cb(uint8_t instance, uint8_t protocol);
+
+void boot_keyboard_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const *buffer, uint16_t bufsize);
+}
+
+class BootKeyboard_ : public BootKeyboardAPI, public Adafruit_USBD_HID {
+ public:
+  explicit BootKeyboard_(uint8_t bootkb_only_ = 0);
+  void begin() {
+    (void)Adafruit_USBD_HID::begin();
+    BootKeyboardAPI::begin();
+  }
+  void sendReport() {
+    BootKeyboardAPI::sendReport();
+  }
+  void onUSBReset() override {}
+  uint8_t getProtocol() override {
+    return protocol;
+  }
+  uint8_t getLeds() {
+    return leds;
+  }
+
+ protected:
+  int SendReport(const void *data, int len) override {
+    if (Adafruit_USBD_HID::sendReport(0, data, len)) {
+      return len;
+    } else {
+      return -1;
+    }
+  }
+  void setReportDescriptor(uint8_t bootkb_only) override;
+
+  static uint8_t protocol;
+  static uint8_t leds;
+
+  friend void tud_hid_set_protocol_cb(uint8_t instance, uint8_t protocol);
+  friend void boot_keyboard_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const *buffer, uint16_t bufsize);
+};
+
+extern BootKeyboard_ &BootKeyboard();
+
+class BootKeyboardWrapper {
+ public:
+  BootKeyboardWrapper() {}
+  void begin() {
+    BootKeyboard().begin();
+  }
+
+  uint8_t getProtocol() {
+    return BootKeyboard().getProtocol();
+  }
+
+  uint8_t getBootOnly() {
+    return BootKeyboard().getBootOnly();
+  }
+  void setBootOnly(uint8_t bootonly) {
+    BootKeyboard().setBootOnly(bootonly);
+  }
+
+  void sendReport() {
+    BootKeyboard().sendReport();
+  }
+
+  void press(uint8_t code) {
+    BootKeyboard().press(code);
+  }
+  void release(uint8_t code) {
+    BootKeyboard().release(code);
+  }
+  void releaseAll() {
+    BootKeyboard().releaseAll();
+  }
+
+  bool isKeyPressed(uint8_t code) {
+    return BootKeyboard().isKeyPressed(code);
+  }
+  bool isModifierActive(uint8_t code) {
+    return BootKeyboard().isModifierActive(code);
+  }
+  bool wasModifierActive(uint8_t code) {
+    return BootKeyboard().wasModifierActive(code);
+  }
+  bool isAnyModifierActive() {
+    return BootKeyboard().isAnyModifierActive();
+  }
+  bool wasAnyModifierActive() {
+    return BootKeyboard().wasAnyModifierActive();
+  }
+
+  uint8_t getLeds() {
+    return BootKeyboard().getLeds();
+  }
+
+  void onUSBReset() {
+    BootKeyboard().onUSBReset();
+  }
+};
+
+struct KeyboardProps : public base::KeyboardProps {
+  typedef BootKeyboardWrapper BootKeyboard;
+  typedef TUSBConsumerControl ConsumerControl;
+  typedef TUSBSystemControl SystemControl;
+};
+
+template<typename _Props>
+class Keyboard : public base::Keyboard<_Props> {};
+
+}  // namespace tinyusb
+}  // namespace hid
+}  // namespace driver
+}  // namespace kaleidoscope
+
+#endif

--- a/src/kaleidoscope/driver/hid/tinyusb/MultiReport.cpp
+++ b/src/kaleidoscope/driver/hid/tinyusb/MultiReport.cpp
@@ -15,32 +15,38 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
-
-#include "kaleidoscope/driver/hid/Base.h"                   // for Base, BaseProps
-#include "kaleidoscope/driver/hid/tinyusb/AbsoluteMouse.h"  // for AbsoluteMouse, AbsoluteMou...
-#include "kaleidoscope/driver/hid/tinyusb/MultiReport.h"
-
 #ifdef USE_TINYUSB
+
+#include <stdint.h>  // for uint8_t, int8_t, uint16_t
+
+#include "Adafruit_TinyUSB.h"
+#include "MultiReport.h"
 
 namespace kaleidoscope {
 namespace driver {
 namespace hid {
+namespace tinyusb {
 
-struct TinyUSBProps : public BaseProps {
-  typedef tinyusb::KeyboardProps KeyboardProps;
-  typedef tinyusb::Keyboard<KeyboardProps> Keyboard;
-  typedef tinyusb::MouseProps MouseProps;
-  typedef tinyusb::Mouse<MouseProps> Mouse;
-  typedef tinyusb::AbsoluteMouseProps AbsoluteMouseProps;
-  typedef tinyusb::AbsoluteMouse<AbsoluteMouseProps> AbsoluteMouse;
+static const uint8_t TUSBMultiReportDesc[] = {
+  DESCRIPTOR_CONSUMER_CONTROL(HID_REPORT_ID(RID_CONSUMER_CONTROL)),
+  DESCRIPTOR_MOUSE(HID_REPORT_ID(RID_MOUSE)),
+  DESCRIPTOR_SYSTEM_CONTROL(HID_REPORT_ID(RID_SYSTEM_CONTROL)),
 };
 
-template<typename _Props>
-class TinyUSB : public Base<_Props> {};
 
+TUSBMultiReport_::TUSBMultiReport_()
+  : Adafruit_USBD_HID(TUSBMultiReportDesc, sizeof(TUSBMultiReportDesc), HID_ITF_PROTOCOL_NONE, 1) {
+}
+
+
+TUSBMultiReport_ &TUSBMultiReport() {
+  static TUSBMultiReport_ obj;
+  return obj;
+}
+
+}  // namespace tinyusb
 }  // namespace hid
 }  // namespace driver
 }  // namespace kaleidoscope
 
-#endif /* USE_TINY_USB */
+#endif /* USE_TINYUSB */

--- a/src/kaleidoscope/driver/hid/tinyusb/MultiReport.cpp
+++ b/src/kaleidoscope/driver/hid/tinyusb/MultiReport.cpp
@@ -1,6 +1,6 @@
 // -*- mode: c++ -*-
 /* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ * Copyright (C) 2013-2024  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/kaleidoscope/driver/hid/tinyusb/MultiReport.h
+++ b/src/kaleidoscope/driver/hid/tinyusb/MultiReport.h
@@ -27,6 +27,7 @@
 #include "kaleidoscope/driver/hid/apis/ConsumerControlAPI.h"
 #include "kaleidoscope/driver/hid/apis/MouseAPI.h"
 #include "kaleidoscope/driver/hid/apis/SystemControlAPI.h"
+#include "HIDD.h"
 
 // IWYU pragma: no_include "DeviceAPIs/AbsoluteMouseAPI.hpp"
 
@@ -41,11 +42,11 @@ enum MultiReportIDs {
   RID_SYSTEM_CONTROL,
 };
 
-class TUSBMultiReport_ : public Adafruit_USBD_HID {
+class TUSBMultiReport_ : public HIDD {
  public:
   TUSBMultiReport_();
   void sendReport(uint8_t report_id, const void *data, uint8_t len) {
-    (void)Adafruit_USBD_HID::sendReport(report_id, data, len);
+    (void)HIDD::sendReport(report_id, data, len);
   }
 };
 

--- a/src/kaleidoscope/driver/hid/tinyusb/MultiReport.h
+++ b/src/kaleidoscope/driver/hid/tinyusb/MultiReport.h
@@ -1,6 +1,6 @@
 // -*- mode: c++ -*-
 /* Kaleidoscope - Firmware for computer input devices
- * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ * Copyright (C) 2013-2024  Keyboard.io, Inc.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/kaleidoscope/driver/hid/tinyusb/MultiReport.h
+++ b/src/kaleidoscope/driver/hid/tinyusb/MultiReport.h
@@ -1,0 +1,117 @@
+// -*- mode: c++ -*-
+/* Kaleidoscope - Firmware for computer input devices
+ * Copyright (C) 2013-2019  Keyboard.io, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef USE_TINYUSB
+
+#include <stdint.h>  // for uint8_t, int8_t, uint16_t
+
+#include "Adafruit_TinyUSB.h"
+#include "kaleidoscope/driver/hid/Base.h"
+#include "kaleidoscope/driver/hid/base/Keyboard.h"
+#include "kaleidoscope/driver/hid/apis/ConsumerControlAPI.h"
+#include "kaleidoscope/driver/hid/apis/MouseAPI.h"
+#include "kaleidoscope/driver/hid/apis/SystemControlAPI.h"
+
+// IWYU pragma: no_include "DeviceAPIs/AbsoluteMouseAPI.hpp"
+
+namespace kaleidoscope {
+namespace driver {
+namespace hid {
+namespace tinyusb {
+
+enum MultiReportIDs {
+  RID_CONSUMER_CONTROL = 1,
+  RID_MOUSE,
+  RID_SYSTEM_CONTROL,
+};
+
+class TUSBMultiReport_ : public Adafruit_USBD_HID {
+ public:
+  TUSBMultiReport_();
+  void sendReport(uint8_t report_id, const void *data, uint8_t len) {
+    (void)Adafruit_USBD_HID::sendReport(report_id, data, len);
+  }
+};
+
+extern TUSBMultiReport_ &TUSBMultiReport();
+
+class TUSBConsumerControl : public ConsumerControlAPI {
+ public:
+  TUSBConsumerControl() {
+    (void)TUSBMultiReport();
+  }
+  void begin() {
+    (void)TUSBMultiReport().begin();
+    ConsumerControlAPI::begin();
+  }
+
+ protected:
+  void sendReportUnchecked() {
+    TUSBMultiReport().sendReport(RID_CONSUMER_CONTROL, &report_, sizeof(report_));
+  }
+};
+
+class TUSBMouse : public MouseAPI {
+ public:
+  TUSBMouse() {
+    (void)TUSBMultiReport();
+  }
+
+ protected:
+  void sendReportUnchecked() {
+    TUSBMultiReport().sendReport(RID_MOUSE, &report_, sizeof(report_));
+  }
+};
+
+class TUSBSystemControl : public SystemControlAPI {
+ public:
+  TUSBSystemControl() {
+    (void)TUSBMultiReport();
+  }
+
+ protected:
+  void sendReport(void *data, int length) override {
+    TUSBMultiReport().sendReport(RID_SYSTEM_CONTROL, data, length);
+  }
+  bool wakeupHost(uint8_t s) override {
+    return false;
+  }
+};
+
+struct KeyboardProps : public base::KeyboardProps {
+  typedef TUSBConsumerControl ConsumerControl;
+  typedef TUSBSystemControl SystemControl;
+};
+
+template<typename _Props>
+class Keyboard : public base::Keyboard<_Props> {};
+
+struct MouseProps : public base::MouseProps {
+  typedef TUSBMouse Mouse;
+};
+
+template<typename _Props>
+class Mouse : public base::Mouse<_Props> {};
+
+}  // namespace tinyusb
+}  // namespace hid
+}  // namespace driver
+}  // namespace kaleidoscope
+
+#endif /* USE_TINYUSB */

--- a/src/kaleidoscope/driver/hid/tinyusb/MultiReport.h
+++ b/src/kaleidoscope/driver/hid/tinyusb/MultiReport.h
@@ -94,14 +94,6 @@ class TUSBSystemControl : public SystemControlAPI {
   }
 };
 
-struct KeyboardProps : public base::KeyboardProps {
-  typedef TUSBConsumerControl ConsumerControl;
-  typedef TUSBSystemControl SystemControl;
-};
-
-template<typename _Props>
-class Keyboard : public base::Keyboard<_Props> {};
-
 struct MouseProps : public base::MouseProps {
   typedef TUSBMouse Mouse;
 };

--- a/src/kaleidoscope/driver/mcu/TinyUSB.h
+++ b/src/kaleidoscope/driver/mcu/TinyUSB.h
@@ -1,5 +1,5 @@
 /* -*- mode: c++ -*-
- * Copyright (C) 2019, 2020  Keyboard.io, Inc
+ * Copyright (C) 2019-2024  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/kaleidoscope/driver/mcu/TinyUSB.h
+++ b/src/kaleidoscope/driver/mcu/TinyUSB.h
@@ -1,0 +1,64 @@
+/* -*- mode: c++ -*-
+ * Copyright (C) 2019, 2020  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Shared "MCU" definition for platforms with TinyUSB device driver */
+
+#pragma once
+
+#include <Arduino.h>  // NVIC_Reset
+#include "Adafruit_TinyUSB.h"
+#include "kaleidoscope/driver/mcu/Base.h"  // for Base, BaseProps
+
+namespace kaleidoscope {
+namespace driver {
+namespace mcu {
+
+struct TinyUSBProps : public kaleidoscope::driver::mcu::BaseProps {
+};
+
+#ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+template<typename _Props>
+class TinyUSB : public kaleidoscope::driver::mcu::Base<_Props> {
+ public:
+  void detachFromHost() {
+    TinyUSBDevice.detach();
+  }
+  void attachToHost() {
+    TinyUSBDevice.attach();
+  }
+  bool USBConfigured() {
+    /* "mounted" is how TinyUSB spells "configured" */
+    return TinyUSBDevice.mounted();
+  }
+  bool pollUSBReset() {
+    return false;
+  }
+  void setUSBResetHook(void (*hook)()) {
+    (void)hook;
+  }
+
+
+  void setup() {
+  }
+};
+#else
+template<typename _Props>
+class TinyUSB : public kaleidoscope::driver::mcu::Base<_Props> {};
+#endif  // ifndef KALEIDOSCOPE_VIRTUAL_BUILD
+
+}  // namespace mcu
+}  // namespace driver
+}  // namespace kaleidoscope


### PR DESCRIPTION
Implement a TinyUSB HID driver back end. Some future work may need to happen around buffering HID reports when resuming from suspend.

This depends on the new getProtocol method of Adafruit_USBD_HID, which has been released in Adafruit_TinyUSB_HID, but not yet  incorporated into the Adafruit nRF52 core. (CI builds should succeed anyway, because no example sketch or hardware plugin uses this driver yet.)