### PR TITLE
Expand palette to 24 colors

### DIFF
--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/DefaultPalette.cpp
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/DefaultPalette.cpp
@@ -31,7 +31,7 @@ __attribute__((weak)) extern bool palette_defined = false;
 void DefaultPalette::setup() {
   if (!ledpalette::palette_defined) return;
 
-  for (uint8_t i = 0; i < 16; i++) {
+  for (uint8_t i = 0; i < 24; i++) {
     cRGB color;
 
     color.r = pgm_read_byte(&(ledpalette::palette[i].r));

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/DefaultPalette.h
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/DefaultPalette.h
@@ -40,14 +40,16 @@ class DefaultPalette : public Plugin {
 
 // clang-format off
 
-#define PALETTE(p0, p1, p2, p3, p4, p5, p6, p7,           \
-                p8, p9, pa, pb, pc, pd, pe, pf)           \
+#define PALETTE(p00, p01, p02, p03, p04, p05, p06, p07,   \
+                p08, p09, p0a, p0b, p0c, p0d, p0e, p0f,   \
+                p10, p11, p12, p13, p14, p15, p16, p17)   \
   namespace kaleidoscope {                                \
   namespace plugin {                                      \
   namespace ledpalette {                                  \
     const cRGB palette[] PROGMEM = {                      \
-      p0, p1, p2, p3, p4, p5, p6, p7,                     \
-      p8, p9, pa, pb, pc, pd, pe, pf                      \
+      p00, p01, p02, p03, p04, p05, p06, p07,             \
+      p08, p09, p0a, p0b, p0c, p0d, p0e, p0f,             \
+      p10, p11, p12, p13, p14, p15, p16, p17              \
     };                                                    \
     bool palette_defined = true;                          \
   } /* defaultcolormap */                                 \

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -35,7 +35,7 @@ uint16_t LEDPaletteTheme::palette_base_;
 
 uint16_t LEDPaletteTheme::reserveThemes(uint8_t max_themes) {
   if (!palette_base_)
-    palette_base_ = ::EEPROMSettings.requestSlice(16 * sizeof(cRGB));
+    palette_base_ = ::EEPROMSettings.requestSlice(24 * sizeof(cRGB));
 
   return ::EEPROMSettings.requestSlice(max_themes * Runtime.device().led_count / 2);
 }
@@ -116,7 +116,7 @@ void LEDPaletteTheme::updatePaletteColor(uint8_t palette_index, cRGB color) {
 }
 
 bool LEDPaletteTheme::isThemeUninitialized(uint16_t theme_base, uint8_t max_themes) {
-  bool paletteEmpty = Runtime.storage().isSliceUninitialized(palette_base_, 16 * sizeof(cRGB));
+  bool paletteEmpty = Runtime.storage().isSliceUninitialized(palette_base_, 24 * sizeof(cRGB));
   bool themeEmpty   = Runtime.storage().isSliceUninitialized(theme_base, max_themes * Runtime.device().led_count / 2);
 
   return paletteEmpty && themeEmpty;
@@ -135,7 +135,7 @@ EventHandlerResult LEDPaletteTheme::onFocusEvent(const char *input) {
     return EventHandlerResult::OK;
 
   if (::Focus.isEOL()) {
-    for (uint8_t i = 0; i < 16; i++) {
+    for (uint8_t i = 0; i < 24; i++) {
       cRGB color;
 
       color = lookupPaletteColor(i);
@@ -145,7 +145,7 @@ EventHandlerResult LEDPaletteTheme::onFocusEvent(const char *input) {
   }
 
   uint8_t i = 0;
-  while (i < 16 && !::Focus.isEOL()) {
+  while (i < 24 && !::Focus.isEOL()) {
     cRGB color;
 
     ::Focus.read(color);


### PR DESCRIPTION
Following up on https://github.com/keyboardio/Kaleidoscope/issues/1416, this PR updates the led palette to support 24 colors