### PR TITLE
Have ColormapOverlay behave more like Colormap

### DIFF
--- a/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
+++ b/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
@@ -87,7 +87,6 @@ class ColormapOverlay : public kaleidoscope::Plugin {
 #define COLORMAP_OVERLAYS_MAP(layers...)                                \
   namespace kaleidoscope {                                              \
   namespace plugin {                                                    \
-  namespace defaultcolormap {                                           \
   const uint8_t overlays_[][kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns] = { \
       layers                                                            \
   };                                                                    \

--- a/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
+++ b/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
@@ -24,6 +24,7 @@
 #include "kaleidoscope/key_defs.h"              // for Key, KEY_FLAGS, Key_NoKey, LockLayer
 #include "kaleidoscope/layers.h"                // for Layer, Layer_
 #include "kaleidoscope/plugin/LEDControl.h"     // for LEDControl
+#include <Kaleidoscope-LED-Palette-Theme.h>     // for LEDPaletteTheme
 
 namespace kaleidoscope {
 namespace plugin {
@@ -60,7 +61,8 @@ class ColormapOverlay : public kaleidoscope::Plugin {
     for (int layer_ = 0; layer_ < _layer_count; layer_++) {
       for (int key_index_ = 0; key_index_ < kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns; key_index_++) {
         int8_t color_index_ = overlays[layer_][key_index_];
-        if (color_index_ != no_color_overlay) {
+        if (color_index_ >= 0 && color_index_ < ::LEDPaletteTheme.getPaletteSize() &&
+            color_index_ != no_color_overlay) {
           overlays_[overlay_count_] = Overlay(layer_, KeyAddr(key_index_), color_index_);
           overlay_count_++;
         }

--- a/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
+++ b/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
@@ -53,6 +53,17 @@ class ColormapOverlay : public kaleidoscope::Plugin {
     overlay_count_ = _overlay_count;
   }
 
+  template<uint8_t _layer_count>
+  void configureOverlays(uint8_t const (&overlays)[_layer_count][kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns]) {
+    overlays_      = Overlay[];
+    overlay_count_ = 0;
+    for (int layer_ = 0; layer_ < _layer_count; layer_++) {
+      for (int key_index_ = 0; key_index_ < kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns; key_index_++) {
+        overlays_[overlay_count_] = Overlay(layer_, /* TODO(EvyBongers) */, overlays[layer_][key_index_]);
+        overlay_count_++;
+      }
+    }
+  }
   // A wildcard value for a qukey that exists on every layer.
   static constexpr int8_t layer_wildcard{-1};
 
@@ -68,6 +79,37 @@ class ColormapOverlay : public kaleidoscope::Plugin {
   bool hasOverlay(KeyAddr k);
   void setLEDOverlayColors();
 };
+
+// clang-format off
+
+#define COLORMAP_OVERLAYS_MAP(layers...)                                \
+  namespace kaleidoscope {                                              \
+  namespace plugin {                                                    \
+  namespace defaultcolormap {                                           \
+  const uint8_t overlays_[][kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns] = { \
+      layers                                                            \
+  };                                                                    \
+  ColormapOverlay.configureOverlays(overlays_);                         \
+  } /* plugin */                                                        \
+  } /* kaleidoscope */
+
+#define __IDENTITY__(X) X
+
+#ifdef PER_KEY_DATA_STACKED
+#define COLORMAP_OVERLAY_STACKED(...)                                   \
+  {                                                                     \
+    MAP_LIST(__IDENTITY__, PER_KEY_DATA_STACKED(0, __VA_ARGS__))        \
+  }
+#endif
+
+#ifdef PER_KEY_DATA
+#define COLORMAP_OVERLAY(...)                            \
+  {                                                      \
+    MAP_LIST(__IDENTITY__, PER_KEY_DATA(0, __VA_ARGS__)) \
+  }
+#endif
+
+// clang-format on
 
 }  // namespace plugin
 }  // namespace kaleidoscope

--- a/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
+++ b/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
@@ -59,7 +59,9 @@ class ColormapOverlay : public kaleidoscope::Plugin {
     overlay_count_ = 0;
     for (int layer_ = 0; layer_ < _layer_count; layer_++) {
       for (int key_index_ = 0; key_index_ < kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns; key_index_++) {
-        overlays_[overlay_count_] = Overlay(layer_, /* TODO(EvyBongers) */, overlays[layer_][key_index_]);
+        color_index_ = overlays[layer_][key_index_];
+        // TODO(EvyBongers): validate the color index?
+        overlays_[overlay_count_] = Overlay(layer_, /* TODO(EvyBongers) */, color_index_);
         overlay_count_++;
       }
     }

--- a/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
+++ b/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
@@ -55,8 +55,8 @@ class ColormapOverlay : public kaleidoscope::Plugin {
   }
 
   template<uint8_t _layer_count>
-  void configureOverlays(uint8_t const (&overlays)[_layer_count][kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns]) {
-    overlays_      = Overlay[];
+  void configureOverlays(uint8_t **overlays) {
+    overlays_      = nullptr;
     overlay_count_ = 0;
     for (int layer_ = 0; layer_ < _layer_count; layer_++) {
       for (int key_index_ = 0; key_index_ < kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns; key_index_++) {

--- a/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
+++ b/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
@@ -59,15 +59,17 @@ class ColormapOverlay : public kaleidoscope::Plugin {
     overlay_count_ = 0;
     for (int layer_ = 0; layer_ < _layer_count; layer_++) {
       for (int key_index_ = 0; key_index_ < kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns; key_index_++) {
-        uint8_t color_index_ = overlays[layer_][key_index_];
-        // TODO(EvyBongers): validate the color index?
-        overlays_[overlay_count_] = Overlay(layer_, KeyAddr(key_index_), color_index_);
-        overlay_count_++;
+        int8_t color_index_ = overlays[layer_][key_index_];
+        if (color_index_ != no_color_overlay) {
+          overlays_[overlay_count_] = Overlay(layer_, KeyAddr(key_index_), color_index_);
+          overlay_count_++;
+        }
       }
     }
   }
   // A wildcard value for an overlay that applies on every layer.
   static constexpr int8_t layer_wildcard{-1};
+  static constexpr int8_t no_color_overlay{-1};
 
   EventHandlerResult onSetup();
   EventHandlerResult beforeSyncingLeds();
@@ -87,7 +89,7 @@ class ColormapOverlay : public kaleidoscope::Plugin {
 #define COLORMAP_OVERLAYS_MAP(layers...)                                \
   namespace kaleidoscope {                                              \
   namespace plugin {                                                    \
-  const uint8_t overlays_[][kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns] = { \
+  const int8_t overlays_[][kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns] = { \
       layers                                                            \
   };                                                                    \
   ColormapOverlay.configureOverlays(overlays_);                         \

--- a/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
+++ b/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
@@ -59,14 +59,14 @@ class ColormapOverlay : public kaleidoscope::Plugin {
     overlay_count_ = 0;
     for (int layer_ = 0; layer_ < _layer_count; layer_++) {
       for (int key_index_ = 0; key_index_ < kaleidoscope_internal::device.matrix_rows * kaleidoscope_internal::device.matrix_columns; key_index_++) {
-        color_index_ = overlays[layer_][key_index_];
+        uint8_t color_index_ = overlays[layer_][key_index_];
         // TODO(EvyBongers): validate the color index?
-        overlays_[overlay_count_] = Overlay(layer_, /* TODO(EvyBongers) */, color_index_);
+        overlays_[overlay_count_] = Overlay(layer_, KeyAddr(key_index_), color_index_);
         overlay_count_++;
       }
     }
   }
-  // A wildcard value for a qukey that exists on every layer.
+  // A wildcard value for an overlay that applies on every layer.
   static constexpr int8_t layer_wildcard{-1};
 
   EventHandlerResult onSetup();

--- a/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
+++ b/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
@@ -30,7 +30,7 @@ namespace plugin {
 
 // Data structure for an individual qukey
 struct Overlay {
-  int8_t layer;
+  uint8_t layer;
   KeyAddr addr;
   uint8_t palette_index;
 


### PR DESCRIPTION
Adding support for specifying color overlays in a similar was as Colormap

Yet to do:
- [x] Find a way to convert key index to key address
- [x] Implement a way for ColormapOverlay to not override the led color
- [x] Implement validation of the colormap index specified (is that needed?)

Fixes #1424