### PR TITLE
Have ColormapOverlay support blank keys

### DIFF
--- a/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.cpp
+++ b/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.cpp
@@ -35,19 +35,24 @@ void ColormapOverlay::setup() {
 }
 
 bool ColormapOverlay::hasOverlay(KeyAddr k) {
+  uint8_t top_layer   = Layer.mostRecent();
   uint8_t layer_index = Layer.lookupActiveLayer(k);
+
+  bool found_match_on_lower_layer = false;
   for (uint8_t i{0}; i < overlay_count_; ++i) {
     Overlay overlay = overlays_[i];
     if (overlay.addr == k) {
-      if ((overlay.layer == layer_index) ||
-          (overlay.layer == layer_wildcard)) {
+      if ((overlay.layer == top_layer) || (overlay.layer == layer_wildcard)) {
         selectedColor = ::LEDPaletteTheme.lookupPaletteColor(overlay.palette_index);
         return true;
+      } else if (overlay.layer == layer_index) {
+        selectedColor              = ::LEDPaletteTheme.lookupPaletteColor(overlay.palette_index);
+        found_match_on_lower_layer = true;
       }
     }
   }
 
-  return false;
+  return found_match_on_lower_layer;
 }
 
 EventHandlerResult ColormapOverlay::onSetup() {


### PR DESCRIPTION
Apply color overlays regardless of the value of the key in the current (top most) layer.
This change aims to maintain backwards compatibility to apply color overlays on lower layers, provided that the top most layer does not specify a color for a key.

Due to limitations of the API, there is no guarantee that the color applied matches the highest layer matching the key except for the top most layer.

Fixes #1425