### PR TITLE
Add focus support to ColormapOverlay

### DIFF
--- a/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.cpp
+++ b/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.cpp
@@ -29,9 +29,10 @@
 namespace kaleidoscope {
 namespace plugin {
 uint16_t ColormapOverlay::map_base_;
+const uint8_t no_themes_ = 1;
 
 void ColormapOverlay::setup() {
-  map_base_ = ::LEDPaletteTheme.reserveThemes(1);
+  map_base_ = ::LEDPaletteTheme.reserveThemes(no_themes_);
 }
 
 bool ColormapOverlay::hasOverlay(KeyAddr k) {
@@ -71,6 +72,10 @@ EventHandlerResult ColormapOverlay::beforeSyncingLeds() {
   setLEDOverlayColors();
 
   return EventHandlerResult::OK;
+}
+
+EventHandlerResult ColormapOverlay::onFocusEvent(const char *input) {
+  return ::LEDPaletteTheme.themeFocusEvent(input, PSTR("colormap.overlay"), map_base_, no_themes_);
 }
 
 }  // namespace plugin

--- a/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
+++ b/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
@@ -58,6 +58,7 @@ class ColormapOverlay : public kaleidoscope::Plugin {
 
   EventHandlerResult onSetup();
   EventHandlerResult beforeSyncingLeds();
+  EventHandlerResult onFocusEvent(const char *input);
 
  private:
   static uint16_t map_base_;


### PR DESCRIPTION
Quick attempt to implement focus support in ColormapOverlay. I feel this should work, but I don't have my keyboard with me right now, so any debugging I'll have to do later.