### PR TITLE
Some build system cleanup

### DIFF
--- a/etc/makefiles/sketch.mk
+++ b/etc/makefiles/sketch.mk
@@ -204,6 +204,9 @@ endif
 
 flashing_instructions = $(call _arduino_prop,build.flashing_instructions)
 
+# Filter out board options from FQBN because board list omits them
+fqbn_no_opts := $(shell echo $(FQBN) | sed 's/:[a-z_][0-9a-z_.]*=.*$$//')
+
 flash: ${HEX_FILE_PATH}
 ifneq ($(flashing_instructions),)
 	$(info $(shell printf $(flashing_instructions)))
@@ -215,6 +218,6 @@ endif
 	$(info )
 	@$(shell read _)
 	$(QUIET) $(ARDUINO_CLI) upload --fqbn $(FQBN) \
-	$(shell $(ARDUINO_CLI) board list --format=text | grep $(FQBN) | awk '{ print "--port", $$1; exit }' ) \
+	$(shell $(ARDUINO_CLI) board list --format=text | grep $(fqbn_no_opts) | awk '{ print "--port", $$1; exit }' ) \
 	--input-dir "${OUTPUT_PATH}" \
 	$(ARDUINO_VERBOSE)

--- a/etc/makefiles/sketch.mk
+++ b/etc/makefiles/sketch.mk
@@ -173,13 +173,14 @@ endif
 
 compile: kaleidoscope-hardware-configured check-rosetta
 	-$(QUIET) install -d "${OUTPUT_PATH}"
-	$(QUIET) $(ARDUINO_CLI) compile --fqbn "${FQBN}" ${ARDUINO_VERBOSE} ${ccache_wrapper_property} ${local_cflags_property} \
+	$(QUIET) \
+	ARDUINO_BUILD_CACHE_EXTRA_PATHS="${BUILD_PATH}" \
+	$(ARDUINO_CLI) compile --fqbn "${FQBN}" ${ARDUINO_VERBOSE} ${ccache_wrapper_property} ${local_cflags_property} \
 	  ${_arduino_local_libraries_prop} ${_ARDUINO_CLI_COMPILE_CUSTOM_FLAGS} ${kaleidoscope_board_config}\
 	  --library "${KALEIDOSCOPE_DIR}" \
 	  --libraries "${KALEIDOSCOPE_DIR}/plugins/" \
 	  --build-path "${BUILD_PATH}" \
 	  --output-dir "${OUTPUT_PATH}" \
-	  --build-cache-path "${CORE_CACHE_PATH}" \
 	  "${SKETCH_FILE_PATH}"
 ifeq ($(LIBONLY),)
 	$(QUIET) cp "${BUILD_PATH}/${SKETCH_FILE_NAME}.hex" "${HEX_FILE_PATH}"

--- a/etc/makefiles/sketch.mk
+++ b/etc/makefiles/sketch.mk
@@ -180,7 +180,7 @@ compile: kaleidoscope-hardware-configured check-rosetta
 	  --library "${KALEIDOSCOPE_DIR}" \
 	  --libraries "${KALEIDOSCOPE_DIR}/plugins/" \
 	  --build-path "${BUILD_PATH}" \
-	  --output-dir "${OUTPUT_PATH}" \
+	  --output-dir "${OUTPUT_PATH}" -j 0 \
 	  "${SKETCH_FILE_PATH}"
 ifeq ($(LIBONLY),)
 	$(QUIET) cp "${BUILD_PATH}/${SKETCH_FILE_NAME}.hex" "${HEX_FILE_PATH}"

--- a/testing/makefiles/testcase.mk
+++ b/testing/makefiles/testcase.mk
@@ -92,7 +92,7 @@ ${BIN_DIR}/${BIN_FILE}: compile-sketch
 .PHONY: compile-sketch
 compile-sketch: ${libcommon_a} ${TEST_OBJS}
 	-@install -d "${BIN_DIR}" "${LIB_DIR}"
-	$(QUIET) env LIBONLY=yes VERBOSE=${VERBOSE}  \
+	$(QUIET) env LIBONLY=yes VERBOSE=${VERBOSE}  QUIET=$(QUIET) \
 		OUTPUT_PATH="${LIB_DIR}" \
 		_ARDUINO_CLI_COMPILE_CUSTOM_FLAGS='--build-property upload.maximum_size=""' \
 		$(MAKE) -f ${top_dir}/etc/makefiles/sketch.mk compile


### PR DESCRIPTION
Update arduino-cli invocations for the deprecation of the --build-cache-path directive.
Allow arduino-cli to build in parallel
Better pass a 'QUIET' setting into the test builder
Allow FQBN configurations that set arduino 'menu' options