### PR TITLE
Make the cache warmer that runs before the rest of the test suite not…

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -62,7 +62,7 @@ cmake-clean:
 run-all: run-cache-warmer run-other-tests aggregate-test-results
 
 .PHONY: run-cache-warmer
-run-cache-warmer: generate-all-plugins-header $(filter ./_cache-warmer/%,${TESTS})
+run-cache-warmer: $(filter ./_cache-warmer/%,${TESTS})
 
 .PHONY: run-other-tests
 run-other-tests: run-cache-warmer

--- a/tests/_cache-warmer/warm-cache/warm-cache.ino
+++ b/tests/_cache-warmer/warm-cache/warm-cache.ino
@@ -15,7 +15,6 @@
  */
 
 #include <Kaleidoscope.h>
-#include "generated-all-plugins.h"
 // *INDENT-OFF*
 KEYMAPS(
     [0] = KEYMAP_STACKED


### PR DESCRIPTION
… compile all our plugins, as we are not currently using a single shared build cache