### PR TITLE
Fix stalker docs link in Model100

### DIFF
--- a/examples/Devices/Keyboardio/Model100/Model100.ino
+++ b/examples/Devices/Keyboardio/Model100/Model100.ino
@@ -705,7 +705,7 @@ void setup() {
 
   // The LED Stalker mode has a few effects. The one we like is called
   // 'BlazingTrail'. For details on other options, see
-  // https://github.com/keyboardio/Kaleidoscope/blob/master/docs/plugins/LED-Stalker.md
+  // https://github.com/keyboardio/Kaleidoscope/blob/master/plugins/Kaleidoscope-LED-Stalker/README.md
   StalkerEffect.variant = STALKER(BlazingTrail);
 
   // To make the keymap editable without flashing new firmware, we store


### PR DESCRIPTION
I noticed that the previous link was broken

![image](https://github.com/user-attachments/assets/b507bed9-fa4e-4d03-b022-20c08a568553)


so I tracked down the [current link](https://github.com/keyboardio/Kaleidoscope/blob/master/plugins/Kaleidoscope-LED-Stalker/README.md) and figured I'd pass it on!


I also did a search and didn't see any other instances of this link, or others like it, in this repo.