### PR TITLE
Split reserving palette and reserving themes

### DIFF
--- a/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.cpp
+++ b/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.cpp
@@ -37,7 +37,7 @@ namespace plugin {
 uint16_t ColormapOverlay::map_base_;
 
 void ColormapOverlay::setup() {
-  map_base_ = ::LEDPaletteTheme.reserveThemes(1);
+  ::LEDPaletteTheme.reservePalette();
 }
 
 bool ColormapOverlay::hasOverlay(KeyAddr k) {

--- a/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.cpp
+++ b/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.cpp
@@ -34,8 +34,6 @@
 
 namespace kaleidoscope {
 namespace plugin {
-uint16_t ColormapOverlay::map_base_;
-
 void ColormapOverlay::setup() {
   ::LEDPaletteTheme.reservePalette();
 }

--- a/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
+++ b/plugins/Kaleidoscope-Colormap-Overlay/src/kaleidoscope/plugin/Colormap-Overlay.h
@@ -127,7 +127,6 @@ class ColormapOverlay : public kaleidoscope::Plugin {
   }
 
  private:
-  static uint16_t map_base_;
   Overlay *overlays_;
   uint8_t overlay_count_;
   cRGB selectedColor;

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.cpp
@@ -39,9 +39,13 @@ namespace plugin {
 uint16_t LEDPaletteTheme::palette_base_;
 uint8_t LEDPaletteTheme::palette_size_ = 24;
 
-uint16_t LEDPaletteTheme::reserveThemes(uint8_t max_themes) {
+void LEDPaletteTheme::reservePalette() {
   if (!palette_base_)
     palette_base_ = ::EEPROMSettings.requestSlice(palette_size_ * sizeof(cRGB));
+}
+
+uint16_t LEDPaletteTheme::reserveThemes(uint8_t max_themes) {
+  reservePalette();
 
   return ::EEPROMSettings.requestSlice(max_themes * Runtime.device().led_count / 2);
 }

--- a/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.h
+++ b/plugins/Kaleidoscope-LED-Palette-Theme/src/kaleidoscope/plugin/LED-Palette-Theme.h
@@ -34,6 +34,7 @@ namespace plugin {
 
 class LEDPaletteTheme : public kaleidoscope::Plugin {
  public:
+  static void reservePalette();
   static uint16_t reserveThemes(uint8_t max_themes);
   static void updateHandler(uint16_t theme_base, uint8_t theme);
   static void refreshAt(uint16_t theme_base, uint8_t theme, KeyAddr key_addr);


### PR DESCRIPTION
Follow-up from https://github.com/keyboardio/Kaleidoscope/pull/1434#pullrequestreview-2675574818

I haven't tested it on hardware yet. I hope to do that tomorrow.