### PR TITLE
Include examples in plugins in smoke_sketches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ cpplint:
 shellcheck:
 	bin/check-shell-scripts.sh
 
-SMOKE_SKETCHES := $(sort $(shell if [ -d ./examples ]; then find ./examples -type f -name \*ino | xargs -n 1 dirname; fi))
+SMOKE_SKETCHES := $(sort $(shell if [ -d ./examples ]; then find ./examples ./plugins/*/examples -type f -name \*ino | xargs -n 1 dirname; fi))
 
 smoke-sketches: $(SMOKE_SKETCHES)
 	@echo "Smoke-tested all the sketches"

--- a/plugins/Kaleidoscope-Colormap-Overlay/examples/Colormap-Overlay/Colormap-Overlay.ino
+++ b/plugins/Kaleidoscope-Colormap-Overlay/examples/Colormap-Overlay/Colormap-Overlay.ino
@@ -19,8 +19,10 @@
  * You should have received a copy of the GNU General Public License along with
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include <Kaleidoscope.h>
 #include <Kaleidoscope-LEDControl.h>
+#include <Kaleidoscope-EEPROM-Settings.h>
 #include <Kaleidoscope-LED-Palette-Theme.h>
 #include <Kaleidoscope-Colormap-Overlay.h>
 

--- a/plugins/Kaleidoscope-Colormap-Overlay/examples/Colormap-Overlay/sketch.json
+++ b/plugins/Kaleidoscope-Colormap-Overlay/examples/Colormap-Overlay/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:gd32:keyboardio_model_100",
+    "port": ""
+  }
+}

--- a/plugins/Kaleidoscope-Colormap-Overlay/examples/Colormap-Overlay/sketch.yaml
+++ b/plugins/Kaleidoscope-Colormap-Overlay/examples/Colormap-Overlay/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:gd32:keyboardio_model_100

--- a/plugins/Kaleidoscope-Keyclick/examples/Keyclick/Keyclick.ino
+++ b/plugins/Kaleidoscope-Keyclick/examples/Keyclick/Keyclick.ino
@@ -73,7 +73,7 @@ KEYMAPS(
 
 KALEIDOSCOPE_INIT_PLUGINS(
   EEPROMSettings,
-  FocusSerial,
+  Focus,
   Keyclick);
 
 void setup() {

--- a/plugins/Kaleidoscope-Keyclick/examples/Keyclick/sketch.json
+++ b/plugins/Kaleidoscope-Keyclick/examples/Keyclick/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:keyboardio_atreus",
+    "port": ""
+  }
+}

--- a/plugins/Kaleidoscope-Keyclick/examples/Keyclick/sketch.json
+++ b/plugins/Kaleidoscope-Keyclick/examples/Keyclick/sketch.json
@@ -1,6 +1,6 @@
 {
   "cpu": {
-    "fqbn": "keyboardio:avr:keyboardio_atreus",
+    "fqbn": "keyboardio:gd32:keyboardio_model_100",
     "port": ""
   }
 }

--- a/plugins/Kaleidoscope-Keyclick/examples/Keyclick/sketch.yaml
+++ b/plugins/Kaleidoscope-Keyclick/examples/Keyclick/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:avr:keyboardio_atreus

--- a/plugins/Kaleidoscope-Keyclick/examples/Keyclick/sketch.yaml
+++ b/plugins/Kaleidoscope-Keyclick/examples/Keyclick/sketch.yaml
@@ -1,1 +1,1 @@
-default_fqbn: keyboardio:avr:keyboardio_atreus
+default_fqbn: keyboardio:gd32:keyboardio_model_100

--- a/plugins/Kaleidoscope-LED-ActiveLayerKeys/examples/ActiveLayerKeys/ActiveLayerKeys.ino
+++ b/plugins/Kaleidoscope-LED-ActiveLayerKeys/examples/ActiveLayerKeys/ActiveLayerKeys.ino
@@ -23,6 +23,7 @@
 #include "Kaleidoscope.h"
 #include "Kaleidoscope-LEDControl.h"
 #include "Kaleidoscope-LED-ActiveLayerKeys.h"
+#include "Kaleidoscope-MouseKeys.h"
 
 // clang-format off
 
@@ -52,10 +53,10 @@ KEYMAPS(
    ___, ___, ___, ___,
    ___,
 
-   M(MACRO_VERSION_INFO),  ___, Key_7, Key_8,      Key_9,              Key_KeypadSubtract, ___,
-   ___,                    ___, Key_4, Key_5,      Key_6,              Key_KeypadAdd,      ___,
-                           ___, Key_1, Key_2,      Key_3,              Key_Equals,         ___,
-   ___,                    ___, Key_0, Key_Period, Key_KeypadMultiply, Key_KeypadDivide,   Key_Enter,
+   ___, ___, Key_7, Key_8,      Key_9,              Key_KeypadSubtract, ___,
+   ___, ___, Key_4, Key_5,      Key_6,              Key_KeypadAdd,      ___,
+        ___, Key_1, Key_2,      Key_3,              Key_Equals,         ___,
+   ___, ___, Key_0, Key_Period, Key_KeypadMultiply, Key_KeypadDivide,   Key_Enter,
    ___, ___, ___, ___,
    ___),
 

--- a/plugins/Kaleidoscope-LED-ActiveLayerKeys/examples/ActiveLayerKeys/sketch.json
+++ b/plugins/Kaleidoscope-LED-ActiveLayerKeys/examples/ActiveLayerKeys/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:keyboardio_atreus",
+    "port": ""
+  }
+}

--- a/plugins/Kaleidoscope-LED-ActiveLayerKeys/examples/ActiveLayerKeys/sketch.json
+++ b/plugins/Kaleidoscope-LED-ActiveLayerKeys/examples/ActiveLayerKeys/sketch.json
@@ -1,6 +1,6 @@
 {
   "cpu": {
-    "fqbn": "keyboardio:avr:keyboardio_atreus",
+    "fqbn": "keyboardio:gd32:keyboardio_model_100",
     "port": ""
   }
 }

--- a/plugins/Kaleidoscope-LED-ActiveLayerKeys/examples/ActiveLayerKeys/sketch.yaml
+++ b/plugins/Kaleidoscope-LED-ActiveLayerKeys/examples/ActiveLayerKeys/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:avr:keyboardio_atreus

--- a/plugins/Kaleidoscope-LED-ActiveLayerKeys/examples/ActiveLayerKeys/sketch.yaml
+++ b/plugins/Kaleidoscope-LED-ActiveLayerKeys/examples/ActiveLayerKeys/sketch.yaml
@@ -1,1 +1,1 @@
-default_fqbn: keyboardio:avr:keyboardio_atreus
+default_fqbn: keyboardio:gd32:keyboardio_model_100

--- a/plugins/Kaleidoscope-LEDEffect-DigitalRain/examples/DigitalRain/sketch.json
+++ b/plugins/Kaleidoscope-LEDEffect-DigitalRain/examples/DigitalRain/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:keyboardio_atreus",
+    "port": ""
+  }
+}

--- a/plugins/Kaleidoscope-LEDEffect-DigitalRain/examples/DigitalRain/sketch.json
+++ b/plugins/Kaleidoscope-LEDEffect-DigitalRain/examples/DigitalRain/sketch.json
@@ -1,6 +1,6 @@
 {
   "cpu": {
-    "fqbn": "keyboardio:avr:keyboardio_atreus",
+    "fqbn": "keyboardio:gd32:keyboardio_model_100",
     "port": ""
   }
 }

--- a/plugins/Kaleidoscope-LEDEffect-DigitalRain/examples/DigitalRain/sketch.yaml
+++ b/plugins/Kaleidoscope-LEDEffect-DigitalRain/examples/DigitalRain/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:avr:keyboardio_atreus

--- a/plugins/Kaleidoscope-LEDEffect-DigitalRain/examples/DigitalRain/sketch.yaml
+++ b/plugins/Kaleidoscope-LEDEffect-DigitalRain/examples/DigitalRain/sketch.yaml
@@ -1,1 +1,1 @@
-default_fqbn: keyboardio:avr:keyboardio_atreus
+default_fqbn: keyboardio:gd32:keyboardio_model_100

--- a/plugins/KeyboardioHID/examples/Consumer/sketch.json
+++ b/plugins/KeyboardioHID/examples/Consumer/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:keyboardio_atreus",
+    "port": ""
+  }
+}

--- a/plugins/KeyboardioHID/examples/Consumer/sketch.yaml
+++ b/plugins/KeyboardioHID/examples/Consumer/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:avr:keyboardio_atreus

--- a/plugins/KeyboardioHID/examples/Gamepad/sketch.json
+++ b/plugins/KeyboardioHID/examples/Gamepad/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:keyboardio_atreus",
+    "port": ""
+  }
+}

--- a/plugins/KeyboardioHID/examples/Gamepad/sketch.yaml
+++ b/plugins/KeyboardioHID/examples/Gamepad/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:avr:keyboardio_atreus

--- a/plugins/KeyboardioHID/examples/Keyboard/BootKeyboard/sketch.json
+++ b/plugins/KeyboardioHID/examples/Keyboard/BootKeyboard/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:keyboardio_atreus",
+    "port": ""
+  }
+}

--- a/plugins/KeyboardioHID/examples/Keyboard/BootKeyboard/sketch.yaml
+++ b/plugins/KeyboardioHID/examples/Keyboard/BootKeyboard/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:avr:keyboardio_atreus

--- a/plugins/KeyboardioHID/examples/Keyboard/KeyboardLed/sketch.json
+++ b/plugins/KeyboardioHID/examples/Keyboard/KeyboardLed/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:keyboardio_atreus",
+    "port": ""
+  }
+}

--- a/plugins/KeyboardioHID/examples/Keyboard/KeyboardLed/sketch.yaml
+++ b/plugins/KeyboardioHID/examples/Keyboard/KeyboardLed/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:avr:keyboardio_atreus

--- a/plugins/KeyboardioHID/examples/Keyboard/NKRO/sketch.json
+++ b/plugins/KeyboardioHID/examples/Keyboard/NKRO/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:keyboardio_atreus",
+    "port": ""
+  }
+}

--- a/plugins/KeyboardioHID/examples/Keyboard/NKRO/sketch.yaml
+++ b/plugins/KeyboardioHID/examples/Keyboard/NKRO/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:avr:keyboardio_atreus

--- a/plugins/KeyboardioHID/examples/Mouse/AbsoluteMouse/sketch.json
+++ b/plugins/KeyboardioHID/examples/Mouse/AbsoluteMouse/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:keyboardio_atreus",
+    "port": ""
+  }
+}

--- a/plugins/KeyboardioHID/examples/Mouse/AbsoluteMouse/sketch.yaml
+++ b/plugins/KeyboardioHID/examples/Mouse/AbsoluteMouse/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:avr:keyboardio_atreus

--- a/plugins/KeyboardioHID/examples/Mouse/ImprovedMouse/sketch.json
+++ b/plugins/KeyboardioHID/examples/Mouse/ImprovedMouse/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:keyboardio_atreus",
+    "port": ""
+  }
+}

--- a/plugins/KeyboardioHID/examples/Mouse/ImprovedMouse/sketch.yaml
+++ b/plugins/KeyboardioHID/examples/Mouse/ImprovedMouse/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:avr:keyboardio_atreus

--- a/plugins/KeyboardioHID/examples/System/sketch.json
+++ b/plugins/KeyboardioHID/examples/System/sketch.json
@@ -1,0 +1,6 @@
+{
+  "cpu": {
+    "fqbn": "keyboardio:avr:keyboardio_atreus",
+    "port": ""
+  }
+}

--- a/plugins/KeyboardioHID/examples/System/sketch.yaml
+++ b/plugins/KeyboardioHID/examples/System/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: keyboardio:avr:keyboardio_atreus


### PR DESCRIPTION
Just noticed that not all examples are built with the smoke sketches CI :)