### PR TITLE
Switch our battery monitor driver to use our fork of the Sparkfun MAX battery driver

### DIFF
--- a/src/kaleidoscope/driver/battery_gauge/MAX17048.h
+++ b/src/kaleidoscope/driver/battery_gauge/MAX17048.h
@@ -129,16 +129,88 @@ class MAX17048 : public Base<_Props> {
   }
 
   /**
-   * @brief Get the current battery level
+   * @brief Get the raw battery level directly from the gauge
    *
    * Returns the battery's state of charge as calculated by
-   * the MAX17048's ModelGauge algorithm.
+   * the MAX17048's ModelGauge algorithm without any compensation.
+   * Note that this value may never reach 100% even when fully charged.
    *
-   * @return Battery level as a percentage (0-100), returns 0 if uninitialized
+   * @return Raw battery level as a percentage (0-100), returns 0 if uninitialized
+   */
+  uint8_t getRawBatteryLevel() const {
+    if (!initialized_) return 0;
+    float soc = lipo_.getSOC();
+    // Convert to integer with rounding by adding 0.5 before truncation
+    uint8_t level = static_cast<uint8_t>(soc + 0.5f);
+    return (level > 100) ? 100 : level;
+  }
+
+  /**
+   * @brief Get the current battery level with compensation
+   *
+   * Returns the battery's state of charge with compensation applied
+   * to allow reporting 100% when the battery is fully charged.
+   * The compensation is applied only at higher charge levels.
+   *
+   * @return Compensated battery level as a percentage (0-100%), returns 0 if uninitialized
    */
   uint8_t getBatteryLevel() const override {
     if (!initialized_) return 0;
-    return static_cast<uint8_t>(lipo_.getSOC());
+    
+    // Get the raw battery level
+    uint8_t raw_level = getRawBatteryLevel();
+    
+    // Apply compensation only at higher charge levels
+    if (raw_level >= 95) {
+      // At 95% or higher, report as 100%
+      return 100;
+    } else if (raw_level >= 90) {
+      // Between 90-94%, add 5% to the reading
+      return raw_level + 5;
+    } else if (raw_level >= 85) {
+      // Between 85-89%, add 3% to the reading
+      return raw_level + 3;
+    } else if (raw_level >= 80) {
+      // Between 80-84%, add 2% to the reading
+      return raw_level + 2;
+    }
+    
+    // Below 80%, return the raw level without compensation
+    return raw_level;
+  }
+
+  /**
+   * @brief Get a compensated battery level that can reach 100%
+   * 
+   * This method applies compensation to the raw battery level reading
+   * to allow reporting 100% when the battery is fully charged.
+   * The compensation is applied only at higher charge levels.
+   * 
+   * @return uint8_t Compensated battery level (0-100%)
+   */
+  uint8_t getCompensatedBatteryLevel() const {
+    if (!initialized_) return 0;
+    
+    // Get the raw battery level
+    uint8_t raw_level = getBatteryLevel();
+    
+    // Apply compensation only at higher charge levels
+    if (raw_level >= 95) {
+      // At 95% or higher, report as 100%
+      return 100;
+    } else if (raw_level >= 90) {
+      // Between 90-94%, add 5% to the reading
+      return raw_level + 5;
+    } else if (raw_level >= 85) {
+      // Between 85-89%, add 3% to the reading
+      return raw_level + 3;
+    } else if (raw_level >= 80) {
+      // Between 80-84%, add 2% to the reading
+      return raw_level + 2;
+    }
+    
+    // Below 80%, return the raw level without compensation
+    return raw_level;
   }
 
   /**
@@ -153,7 +225,7 @@ class MAX17048 : public Base<_Props> {
     if (!initialized_) return 0;
     // The CRATE register LSB is 0.208%/hr
     // We want raw units, so no conversion needed
-    return static_cast<int16_t>(lipo_.getChangeRate() / 0.208f);  // TODO(jesse): Replace with direct register read
+    return static_cast<int16_t>(lipo_.getChangeRate() / 0.208f); 
   }
 
   /**

--- a/src/kaleidoscope/driver/battery_gauge/MAX17048.h
+++ b/src/kaleidoscope/driver/battery_gauge/MAX17048.h
@@ -125,7 +125,7 @@ class MAX17048 : public Base<_Props> {
    */
   uint16_t getVoltage() const override {
     if (!initialized_) return 0;
-    return static_cast<uint16_t>(lipo_.getVoltage() * 1000);
+    return lipo_.getVoltage();  // No conversion needed - now returns mV directly
   }
 
   /**
@@ -139,10 +139,8 @@ class MAX17048 : public Base<_Props> {
    */
   uint8_t getRawBatteryLevel() const {
     if (!initialized_) return 0;
-    float soc = lipo_.getSOC();
-    // Convert to integer with rounding by adding 0.5 before truncation
-    uint8_t level = static_cast<uint8_t>(soc + 0.5f);
-    return (level > 100) ? 100 : level;
+    uint8_t soc = lipo_.getSOC();
+    return (soc > 100) ? 100 : soc;
   }
 
   /**
@@ -156,10 +154,10 @@ class MAX17048 : public Base<_Props> {
    */
   uint8_t getBatteryLevel() const override {
     if (!initialized_) return 0;
-    
+
     // Get the raw battery level
     uint8_t raw_level = getRawBatteryLevel();
-    
+
     // Apply compensation only at higher charge levels
     if (raw_level >= 95) {
       // At 95% or higher, report as 100%
@@ -174,7 +172,7 @@ class MAX17048 : public Base<_Props> {
       // Between 80-84%, add 2% to the reading
       return raw_level + 2;
     }
-    
+
     // Below 80%, return the raw level without compensation
     return raw_level;
   }
@@ -190,10 +188,10 @@ class MAX17048 : public Base<_Props> {
    */
   uint8_t getCompensatedBatteryLevel() const {
     if (!initialized_) return 0;
-    
+
     // Get the raw battery level
     uint8_t raw_level = getBatteryLevel();
-    
+
     // Apply compensation only at higher charge levels
     if (raw_level >= 95) {
       // At 95% or higher, report as 100%
@@ -208,7 +206,7 @@ class MAX17048 : public Base<_Props> {
       // Between 80-84%, add 2% to the reading
       return raw_level + 2;
     }
-    
+
     // Below 80%, return the raw level without compensation
     return raw_level;
   }
@@ -224,8 +222,8 @@ class MAX17048 : public Base<_Props> {
   int16_t getChargeRate() const {
     if (!initialized_) return 0;
     // The CRATE register LSB is 0.208%/hr
-    // We want raw units, so no conversion needed
-    return static_cast<int16_t>(lipo_.getChangeRate() / 0.208f); 
+    // getChangeRate now returns the raw value directly
+    return lipo_.getChangeRate();
   }
 
   /**
@@ -301,11 +299,9 @@ class MAX17048 : public Base<_Props> {
    */
   void setVoltageAlertThresholds(uint16_t min_mv, uint16_t max_mv) {
     if (!initialized_) return;
-    // VALRT register uses 20mV per LSB
-    uint8_t min_bits = min_mv / 20;
-    uint8_t max_bits = max_mv / 20;
-    lipo_.setVALRTMin(min_bits);
-    lipo_.setVALRTMax(max_bits);
+    // library now accepts millivolts directly
+    lipo_.setVALRTMin(min_mv);
+    lipo_.setVALRTMax(max_mv);
   }
 
   /**
@@ -454,13 +450,13 @@ class MAX17048 : public Base<_Props> {
    * Configures the activity thresholds for entering and exiting
    * hibernate mode. Has no effect if device is uninitialized.
    *
-   * @param active_rate Activity threshold to exit hibernate (0.208%/hr units)
-   * @param hibernate_rate Inactivity threshold to enter hibernate (0.208%/hr units)
+   * @param active_rate Activity threshold to exit hibernate (in microvolts)
+   * @param hibernate_rate Inactivity threshold to enter hibernate (in hundredths of %/hr)
    */
-  void setHibernateThresholds(uint8_t active_rate, uint8_t hibernate_rate) {
+  void setHibernateThresholds(uint16_t active_uv, uint16_t hibernate_rate_scaled) {
     if (!initialized_) return;
-    lipo_.setHIBRTActThr(active_rate);
-    lipo_.setHIBRTHibThr(hibernate_rate);
+    lipo_.setHIBRTActThr(active_uv);
+    lipo_.setHIBRTHibThr(hibernate_rate_scaled);
   }
 
   /**
@@ -473,9 +469,8 @@ class MAX17048 : public Base<_Props> {
    */
   void setResetVoltage(uint16_t mv) {
     if (!initialized_) return;
-    // Reset voltage register uses 40mV per LSB
-    uint8_t bits = mv / 40;
-    lipo_.setResetVoltage(bits);  // TODO(jesse): Replace with direct register write
+    // Library now accepts millivolts directly
+    lipo_.setResetVoltage(mv);  // Updated to use millivolts
   }
 
   /**


### PR DESCRIPTION
The nrf52 gets a little bit squirrely when you put it to sleep after it does floating point math. And we don't really need floating point math.