### PR TITLE
An "LED Indicators" plugin for Kaleidoscope

### DIFF
--- a/plugins/Kaleidoscope-LEDIndicators/README.md
+++ b/plugins/Kaleidoscope-LEDIndicators/README.md
@@ -1,0 +1,86 @@
+# Kaleidoscope-LEDIndicators
+
+This plugin provides visual feedback through LEDs for various keyboard states and events, with a primary focus on connection status. It supports a variety of visual effects including solid colors, blinking, breathing, and transitions.
+
+## Using the plugin
+
+To use this plugin, include the header and activate it:
+
+```cpp
+#include "Kaleidoscope-LEDIndicators.h"
+
+KALEIDOSCOPE_INIT_PLUGINS(
+  LEDControl,
+  LEDIndicators
+);
+```
+
+The plugin will automatically handle connection status changes and display appropriate LED indicators:
+
+- **Connecting**: Blue blinking LED
+- **Connected**: Solid blue LED
+- **Disconnected**: LED off
+- **Pairing Success**: Brief green flash, then solid blue
+- **Pairing Failed**: Brief red flash, then LED off
+
+## LED Mapping
+
+By default, the plugin uses the first 5 LEDs in the top row for indicators. However, you should configure the LED mapping to use positions that make sense for your specific keyboard layout:
+
+```cpp
+void configureIndicators() {
+  // Configure LED mapping for your keyboard
+  static const KeyAddr indicator_leds[] = {
+    KeyAddr(3, 0),  // Top row, 4th key
+    KeyAddr(3, 1),  // Top row, 5th key
+    KeyAddr(3, 2),  // Top row, 6th key
+    KeyAddr(3, 3),  // Top row, 7th key
+    KeyAddr(3, 4)   // Top row, 8th key
+  };
+
+  // Try to configure the slots
+  if (!LEDIndicators.setSlots(5, indicator_leds)) {
+    // Configuration failed - LEDs invalid for this device
+  }
+}
+```
+
+The plugin supports up to 8 indicator slots (defined by MAX_SLOTS). Each slot needs a valid LED address for your keyboard. The setSlots() function will validate the LED addresses and return false if any are invalid.
+
+## Colors
+
+The default colors are:
+- Blue (0, 0, 255) for connection status
+- Red (255, 0, 0) for errors
+- Green (0, 255, 0) for success
+- Off (0, 0, 0)
+
+You can customize these colors:
+
+```cpp
+LEDIndicators.setColor(LEDIndicators.color_blue, {0, 0, 128});   // Dimmer blue
+LEDIndicators.setColor(LEDIndicators.color_red, {128, 0, 0});    // Dimmer red
+LEDIndicators.setColor(LEDIndicators.color_green, {0, 128, 0});  // Dimmer green
+```
+
+## Effects
+
+The plugin supports several visual effects:
+- **Solid**: Single color, constant brightness
+- **Blink**: Alternates between two colors
+- **Breathe**: Smoothly transitions between brightnesses
+- **Grow**: Starts dim, breathes to full brightness, stays bright
+- **Shrink**: Starts bright, breathes to dim, stays dim
+
+Each effect can be configured with:
+- Duration (how long to show the effect)
+- Number of cycles to repeat
+- Priority level (to handle conflicts between multiple indicators)
+
+## Dependencies
+
+* [Kaleidoscope-LEDControl](https://github.com/keyboardio/Kaleidoscope-LEDControl)
+
+## Further reading
+
+The [example](https://github.com/keyboardio/Kaleidoscope/blob/master/plugins/Kaleidoscope-LEDIndicators/examples) directory contains a fully working demonstration.

--- a/plugins/Kaleidoscope-LEDIndicators/examples/LEDIndicators/LEDIndicators.ino
+++ b/plugins/Kaleidoscope-LEDIndicators/examples/LEDIndicators/LEDIndicators.ino
@@ -1,0 +1,63 @@
+/* Kaleidoscope-LEDIndicators -- LED indicators for connection status and other events
+ * Copyright 2024-2025 Keyboard.io, inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * Additional Permissions:
+ * As an additional permission under Section 7 of the GNU General Public
+ * License Version 3, you may link this software against a Vendor-provided
+ * Hardware Specific Software Module under the terms of the MCU Vendor
+ * Firmware Library Additional Permission Version 1.0.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Kaleidoscope.h"
+#include "Kaleidoscope-LEDControl.h"
+#include "Kaleidoscope-LEDIndicators.h"
+
+// Configure LED indicators before setup
+void configureIndicators() {
+  // Configure colors (optional - these are the defaults)
+  LEDIndicators.setColor(LEDIndicators.color_blue, {0, 0, 255});   // Blue for connecting/connected
+  LEDIndicators.setColor(LEDIndicators.color_red, {255, 0, 0});    // Red for errors/disconnected
+  LEDIndicators.setColor(LEDIndicators.color_green, {0, 255, 0});  // Green for success
+  LEDIndicators.setColor(LEDIndicators.color_off, {0, 0, 0});      // Off state
+
+  // Configure LED mapping - use specific LED positions that make sense for your keyboard
+  // These should be LEDs that are visible and make sense as status indicators
+  static const KeyAddr indicator_leds[] = {
+    KeyAddr(3, 0),  // Top row, 4th key - typically visible
+    KeyAddr(3, 1),  // Top row, 5th key
+    KeyAddr(3, 2),  // Top row, 6th key
+    KeyAddr(3, 3),  // Top row, 7th key
+    KeyAddr(3, 4)   // Top row, 8th key
+  };
+
+  // Configure the slots
+  if (!LEDIndicators.setSlots(5, indicator_leds)) {
+    // Configuration failed - LEDs invalid for this device
+    // You should adjust the LED addresses above to match your keyboard
+  }
+}
+
+KALEIDOSCOPE_INIT_PLUGINS(
+  LEDControl,
+  LEDIndicators);
+
+void setup() {
+  Kaleidoscope.setup();
+  configureIndicators();
+}
+
+void loop() {
+  Kaleidoscope.loop();
+}

--- a/plugins/Kaleidoscope-LEDIndicators/library.properties
+++ b/plugins/Kaleidoscope-LEDIndicators/library.properties
@@ -1,0 +1,11 @@
+name=Kaleidoscope-LEDIndicators
+version=0.0.0
+author=Keyboardio
+maintainer=Keyboardio
+sentence=LED indicators for connection status and other events
+paragraph=A plugin that provides visual feedback through LEDs for various keyboard states and events, with a focus on connection status.
+category=Communication
+url=https://github.com/keyboardio/Kaleidoscope
+architectures=*
+dot_a_linkage=true
+depends=Kaleidoscope-LEDControl

--- a/plugins/Kaleidoscope-LEDIndicators/src/Kaleidoscope-LEDIndicators.h
+++ b/plugins/Kaleidoscope-LEDIndicators/src/Kaleidoscope-LEDIndicators.h
@@ -1,0 +1,25 @@
+/* Kaleidoscope-LEDIndicators -- LED indicators for connection status and other events
+ * Copyright 2024-2025 Keyboard.io, inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * Additional Permissions:
+ * As an additional permission under Section 7 of the GNU General Public
+ * License Version 3, you may link this software against a Vendor-provided
+ * Hardware Specific Software Module under the terms of the MCU Vendor
+ * Firmware Library Additional Permission Version 1.0.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "kaleidoscope/plugin/LEDIndicators.h"  // IWYU pragma: export

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
@@ -1,0 +1,337 @@
+/* Kaleidoscope-LEDIndicators -- LED indicators for connection status and other events
+ * Copyright 2024-2025 Keyboard.io, inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * Additional Permissions:
+ * As an additional permission under Section 7 of the GNU General Public
+ * License Version 3, you may link this software against a Vendor-provided
+ * Hardware Specific Software Module under the terms of the MCU Vendor
+ * Firmware Library Additional Permission Version 1.0.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "kaleidoscope/plugin/LEDIndicators.h"
+#include <Arduino.h>  // for delay()
+#include "kaleidoscope/plugin/LEDControl.h"
+#include "kaleidoscope/plugin/LEDControl/LEDUtils.h"
+
+namespace kaleidoscope {
+namespace plugin {
+
+// Initialize static members
+
+cRGB LEDIndicators::color_green = {0, 255, 0};
+cRGB LEDIndicators::color_red   = {255, 0, 0};
+cRGB LEDIndicators::color_off   = {0, 0, 0};
+cRGB LEDIndicators::color_blue  = {0, 0, 255};
+
+uint8_t LEDIndicators::num_indicator_slots  = 5;  // Default to 5 slots
+KeyAddr LEDIndicators::slot_leds[MAX_SLOTS] = {
+  KeyAddr(0, 0),
+  KeyAddr(0, 1),
+  KeyAddr(0, 2),
+  KeyAddr(0, 3),
+  KeyAddr(0, 4),
+};  // Default LED mapping
+
+// Initialize static indicator array
+kaleidoscope::plugin::LEDIndicators::Indicator LEDIndicators::indicators_[MAX_SLOTS] = {};
+
+// Setup the plugin
+EventHandlerResult LEDIndicators::onSetup() {
+  if (!Runtime.has_leds)
+    return EventHandlerResult::OK;
+
+  for (uint8_t i = 0; i < num_indicator_slots; i++) {
+    uint8_t led_index = Runtime.device().getLedIndex(slot_leds[i]);
+    if (led_index >= Runtime.device().led_count) {
+      // Invalid LED configuration - disable that slot
+      slot_leds[i] = KeyAddr::none();
+    }
+  }
+
+  // Initialize all indicators to inactive
+  clearAllIndicators();
+
+  return EventHandlerResult::OK;
+}
+
+// Show a temporary indicator
+void LEDIndicators::showIndicator(KeyAddr led_addr,
+                                  IndicatorEffect effect,
+                                  cRGB color1,
+                                  cRGB color2,
+                                  uint16_t duration_ms,
+                                  uint16_t effect_cycles) {
+  if (!Runtime.has_leds) {
+    return;
+  }
+  if (!led_addr.isValid()) {  // Valid LED
+    return;
+  }
+
+  // Find an available indicator slot
+  uint8_t slot = 0xFF;
+  for (uint8_t i = 0; i < MAX_SLOTS; i++) {
+    if (!indicators_[i].active || indicators_[i].key_addr == led_addr) {
+      slot = i;
+      break;
+    }
+  }
+
+  if (slot == 0xFF) {
+    return;
+  }
+
+  // Set up the indicator
+  indicators_[slot].active        = true;
+  indicators_[slot].key_addr      = led_addr;
+  indicators_[slot].effect        = effect;
+  indicators_[slot].color1        = color1;
+  indicators_[slot].color2        = color2;
+  indicators_[slot].start_time    = Runtime.millisAtCycleStart();
+  indicators_[slot].duration_ms   = duration_ms;
+  indicators_[slot].effect_cycles = effect_cycles;
+  indicators_[slot].current_cycle = 0;
+  indicators_[slot].last_update   = Runtime.millisAtCycleStart();
+
+  // Immediately update the indicator
+  updateIndicator(slot);
+}
+
+
+// Clear a specific indicator
+void LEDIndicators::clearIndicator(KeyAddr key_addr) {
+  if (!Runtime.has_leds)
+    return;
+
+  for (uint8_t i = 0; i < MAX_SLOTS; i++) {
+    if (indicators_[i].key_addr == key_addr && indicators_[i].active) {
+      indicators_[i].active = false;
+      ::LEDControl.refreshAt(key_addr);
+    }
+  }
+}
+
+// Clear all indicators
+void LEDIndicators::clearAllIndicators() {
+  if (!Runtime.has_leds)
+    return;
+
+  for (uint8_t i = 0; i < MAX_SLOTS; i++) {
+    indicators_[i].active = false;
+  }
+}
+
+// Called before LEDs are synchronized
+EventHandlerResult LEDIndicators::beforeSyncingLeds() {
+  if (!Runtime.has_leds) {
+    return EventHandlerResult::OK;
+  }
+
+  // Update and apply all active indicators
+  for (uint8_t i = 0; i < MAX_SLOTS; i++) {
+    if (indicators_[i].active) {
+      if (indicators_[i].duration_ms > 0 &&
+          (Runtime.millisAtCycleStart() - indicators_[i].start_time >= indicators_[i].duration_ms)) {
+        indicators_[i].active = false;
+        ::LEDControl.refreshAt(indicators_[i].key_addr);
+      } else {
+        updateIndicator(i);
+      }
+    }
+  }
+
+  return EventHandlerResult::OK;
+}
+
+// Update an indicator's state
+void LEDIndicators::updateIndicator(uint8_t index) {
+  if (index >= MAX_SLOTS)
+    return;
+
+  Indicator &indicator = indicators_[index];
+  if (!indicator.active)
+    return;
+
+  // Update the LED with the computed color
+  cRGB color = computeCurrentColor(indicator);
+  ::LEDControl.setCrgbAt(indicator.key_addr, color);
+}
+
+// Compute the current color for an indicator based on its effect
+cRGB LEDIndicators::computeCurrentColor(const Indicator &indicator) {
+  uint32_t elapsed = Runtime.millisAtCycleStart() - indicator.start_time;
+
+  switch (indicator.effect) {
+  case IndicatorEffect::Blink: {
+    // Simple 500ms on/off
+    bool on = (elapsed / 500) % 2 == 0;
+    return on ? indicator.color1 : indicator.color2;
+  }
+
+  case IndicatorEffect::Breathe: {
+    // Use 8-bit counter for brightness to avoid floating point
+    uint8_t brightness = ((elapsed / 8) % 256);
+    // Make it smooth by mirroring second half
+    if (brightness >= 128) {
+      brightness = 255 - brightness;
+    }
+    brightness = brightness * 2;  // Scale to full range
+
+    return {
+      static_cast<uint8_t>((indicator.color1.r * brightness) >> 8),
+      static_cast<uint8_t>((indicator.color1.g * brightness) >> 8),
+      static_cast<uint8_t>((indicator.color1.b * brightness) >> 8)};
+  }
+
+  case IndicatorEffect::Grow: {
+    // Simple linear growth over 1 second
+    uint16_t brightness = (elapsed > 1000) ? 255 : ((elapsed * 255) / 1000);
+    return {
+      static_cast<uint8_t>((indicator.color1.r * brightness) >> 8),
+      static_cast<uint8_t>((indicator.color1.g * brightness) >> 8),
+      static_cast<uint8_t>((indicator.color1.b * brightness) >> 8)};
+  }
+
+  case IndicatorEffect::Shrink: {
+    // Simple linear decay over 1 second
+    uint16_t brightness = (elapsed > 1000) ? 0 : (((1000 - elapsed) * 255) / 1000);
+    return {
+      static_cast<uint8_t>((indicator.color1.r * brightness) >> 8),
+      static_cast<uint8_t>((indicator.color1.g * brightness) >> 8),
+      static_cast<uint8_t>((indicator.color1.b * brightness) >> 8)};
+  }
+
+  default:
+    return indicator.color1;
+  }
+}
+
+// Handle connection status changes
+EventHandlerResult LEDIndicators::onHostConnectionStatusChanged(uint8_t device_id, HostConnectionStatus status) {
+  // device_id is 1-indexed (1-4) so adjust it to be zero-indexed for the slot
+  uint8_t slot = device_id - 1;
+  switch (status) {
+  case HostConnectionStatus::Connecting:
+    showIndicator(getLEDForSlot(slot),
+                  IndicatorEffect::Blink,
+                  color_blue,
+                  color_off,
+                  30000,  // 30 second duration
+                  10);    // 10 cycles
+    break;
+  case HostConnectionStatus::Connected:
+    showIndicator(getLEDForSlot(slot),
+                  IndicatorEffect::Grow,
+                  color_blue,
+                  color_off,
+                  5000,  // 5 second duration
+                  1);    // 1 cycle
+    break;
+  case HostConnectionStatus::PairingFailed:
+  case HostConnectionStatus::Disconnected:
+    showIndicator(getLEDForSlot(slot),
+                  IndicatorEffect::Shrink,
+                  color_red,
+                  color_off,
+                  10000,  // 10 second duration
+                  1);     // 1 cycle
+    break;
+  case HostConnectionStatus::PairingSuccess:
+    showIndicator(getLEDForSlot(slot),
+                  IndicatorEffect::Grow,
+                  color_blue,
+                  color_off,
+                  10000,  // 10 second duration
+                  1);     // 1 cycle
+    break;
+  case HostConnectionStatus::DeviceSelected:
+    showIndicator(getLEDForSlot(slot),
+                  IndicatorEffect::Grow,
+                  color_blue,
+                  color_off,
+                  2000,  // 2 second duration
+                  1);    // 1 cycle
+    break;
+  case HostConnectionStatus::DeviceUnselected:
+    clearIndicator(getLEDForSlot(slot));
+    break;
+  case HostConnectionStatus::Advertising:
+    showIndicator(getLEDForSlot(slot),
+                  IndicatorEffect::Blink,
+                  color_blue,
+                  color_off,
+                  30000,  // 30 second duration
+                  10);    // 10 cycles
+    break;
+  default:
+    break;
+  }
+  return EventHandlerResult::OK;
+}
+
+
+// Handle power events
+EventHandlerResult LEDIndicators::onPowerEvent(PowerEvent event, uint16_t voltage_mv) {
+  if (!Runtime.has_leds)
+    return EventHandlerResult::OK;
+
+  // Use all indicator slots for battery events
+  switch (event) {
+  case PowerEvent::BatteryWarningOn:
+    // Show red flashing on all LEDs for battery warning
+    for (uint8_t i = 0; i < num_indicator_slots; i++) {
+      KeyAddr led_addr = getLEDForSlot(i);
+      if (led_addr.isValid()) {
+        // Red solid for battery warning (all LEDs)
+        // Shows for 1 second every 10 seconds, as defined in the requirements
+        showIndicator(led_addr, IndicatorEffect::Solid, color_red, color_off, 1000, 0);
+      }
+    }
+    break;
+
+  case PowerEvent::BatteryWarningOff:
+    // Clear any battery warning indicators
+    for (uint8_t i = 0; i < num_indicator_slots; i++) {
+      KeyAddr led_addr = getLEDForSlot(i);
+      if (led_addr.isValid()) {
+        clearIndicator(led_addr);
+      }
+    }
+    break;
+
+  case PowerEvent::BatteryShutdown:
+    // Show solid red on all LEDs for shutdown (will stay on for 10 seconds before shutdown)
+    for (uint8_t i = 0; i < num_indicator_slots; i++) {
+      KeyAddr led_addr = getLEDForSlot(i);
+      if (led_addr.isValid()) {
+        // Solid red for battery critical shutdown
+        showIndicator(led_addr, IndicatorEffect::Solid, color_red, color_off, 10000, 0);
+      }
+    }
+    break;
+
+  case PowerEvent::PowerSourceUSB:
+  case PowerEvent::PowerSourceBattery:
+    // Power source changes don't need visual indicators
+    break;
+  }
+
+  return EventHandlerResult::OK;
+}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
+
+kaleidoscope::plugin::LEDIndicators LEDIndicators;

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
@@ -1,0 +1,176 @@
+/* Kaleidoscope-LEDIndicators -- LED indicators for connection status and other events
+ * Copyright 2024-2025 Keyboard.io, inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * Additional Permissions:
+ * As an additional permission under Section 7 of the GNU General Public
+ * License Version 3, you may link this software against a Vendor-provided
+ * Hardware Specific Software Module under the terms of the MCU Vendor
+ * Firmware Library Additional Permission Version 1.0.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include <stdint.h>  // for uint8_t
+
+#include "kaleidoscope/plugin.h"
+#include "kaleidoscope/host_connection_status.h"
+#include "kaleidoscope/Runtime.h"
+#include "kaleidoscope/power_event.h"  // for PowerEvent enum
+#include "kaleidoscope/plugin/LEDControl.h"
+#include "kaleidoscope/KeyAddr.h"  // for KeyAddr::none()
+
+namespace kaleidoscope {
+namespace plugin {
+
+/**
+ * @brief Enum for indicator effects
+ */
+enum class IndicatorEffect {
+  Solid,    ///< Single color, constant brightness
+  Blink,    ///< Alternates between two colors
+  Breathe,  ///< Smoothly transitions between two brightnesses of the same color
+  Grow,     ///< Starts dim, breathes to full brightness, stays bright
+  Shrink    ///< Starts bright, breathes to dim, stays dim
+};
+
+/**
+ * @brief Class for managing LED indicators
+ */
+class LEDIndicators : public kaleidoscope::Plugin {
+ public:
+  LEDIndicators() {}
+
+  // Colors can be configured by the user
+  static cRGB color_blue;
+  static cRGB color_red;
+  static cRGB color_off;
+  static cRGB color_green;
+
+  /** @brief Configure the number of indicator slots and their LED mapping
+   * @param num_slots Number of slots to use (must be <= MAX_SLOTS)
+   * @param leds Array of LED addresses to use for the slots
+   * @return true if configuration was successful, false if invalid parameters
+   * 
+   * Each LED address must be valid for the current device.
+   * The number of slots must not exceed MAX_SLOTS.
+   * Invalid configurations will be rejected and return false.
+   */
+  static bool setSlots(uint8_t num_slots, const KeyAddr *leds) {
+    if (num_slots > MAX_SLOTS || leds == nullptr)
+      return false;
+
+    for (uint8_t i = 0; i < num_slots; i++) {
+      uint8_t led_index = Runtime.device().getLedIndex(leds[i]);
+      if (led_index >= Runtime.device().led_count)
+        return false;
+    }
+
+    num_indicator_slots = num_slots;
+    for (uint8_t i = 0; i < num_slots; i++) {
+      slot_leds[i] = leds[i];
+    }
+
+    return true;
+  }
+
+  /** @brief Configure an indicator color
+   * @param target_color Reference to the color to configure
+   * @param new_color The new RGB color value
+   */
+  static void setColor(cRGB &target_color, const cRGB &new_color) {
+    target_color = new_color;
+  }
+
+  /** @brief Show a temporary indicator with optional duration
+   * @param key_addr The LED index to control
+   * @param effect The type of visual effect to show
+   * @param color1 Primary color for the effect
+   * @param color2 Secondary color for effects that use two colors
+   * @param duration_ms How long to show the indicator (0 for indefinite)
+   * @param effect_cycles Number of times to repeat the effect
+   */
+  void showIndicator(KeyAddr key_addr,
+                     IndicatorEffect effect = IndicatorEffect::Solid,
+                     cRGB color1            = {0, 0, 0},
+                     cRGB color2            = {0, 0, 0},
+                     uint16_t duration_ms   = 0,
+                     uint16_t effect_cycles = 0);
+
+  /** @brief Clear a specific indicator
+   * @param key_addr The LED index to clear
+   */
+  void clearIndicator(KeyAddr key_addr);
+
+  /** @brief Clear all active indicators */
+  void clearAllIndicators();
+
+  /** @brief Get the LED index for a given slot
+   * @param slot The slot number
+   * @return The LED index, or KeyAddr::none() if slot is invalid
+   */
+  KeyAddr getLEDForSlot(uint8_t slot) const {
+    // Check slot bounds
+    if (slot >= num_indicator_slots) {
+      return KeyAddr::none();
+    }
+
+    // Get the mapped LED address
+    KeyAddr led_addr = slot_leds[slot];
+
+    // Validate the LED exists on this device
+    uint8_t led_index = Runtime.device().getLedIndex(led_addr);
+
+    if (led_index >= Runtime.device().led_count) {
+      return KeyAddr::none();
+    }
+
+    return led_addr;
+  }
+
+  // Plugin hooks
+  EventHandlerResult onSetup();
+  EventHandlerResult beforeSyncingLeds();
+  EventHandlerResult onHostConnectionStatusChanged(uint8_t device_id, HostConnectionStatus status);
+  EventHandlerResult onPowerEvent(PowerEvent event, uint16_t voltage_mv);
+
+ private:
+  static constexpr uint8_t MAX_SLOTS = 8;  // Maximum number of slots supported
+  static uint8_t num_indicator_slots;      // Number of slots configured
+  static KeyAddr slot_leds[MAX_SLOTS];     // LED mapping for slots
+
+  struct Indicator {
+    bool active = false;
+    KeyAddr key_addr;
+    cRGB color1;
+    cRGB color2;
+    IndicatorEffect effect;
+    uint32_t start_time;
+    uint16_t duration_ms;
+    uint16_t effect_cycles;
+    uint32_t last_update;
+    uint16_t current_cycle;
+  };
+
+  void updateIndicator(uint8_t index);
+  cRGB computeCurrentColor(const Indicator &indicator);
+
+  static Indicator indicators_[MAX_SLOTS];
+};
+
+}  // namespace plugin
+}  // namespace kaleidoscope
+
+extern kaleidoscope::plugin::LEDIndicators LEDIndicators;


### PR DESCRIPTION
An "LED Indicators" plugin for Kaleidoscope, which can listen to various events and

signal them using the device's LEDs