### PR TITLE
WS2812 Neopixel driver - workaround parasitic current of 0.5mA on nRF…

### DIFF
--- a/src/kaleidoscope/driver/led/WS2812.h
+++ b/src/kaleidoscope/driver/led/WS2812.h
@@ -64,7 +64,13 @@ class WS2812 : public Base<_LEDDriverProps> {
 
   void syncLeds() {
     if (modified_) {
+      // On nRF52840, leaving the pin low as initialized in the neopixel library will cause a 500uA current leak
+      // Driving the pin high with digitalWrite() fixes this, but results in the Preonic's 4th led (top right)
+      // glowing a dull blue when other LEDs are lit and that one isn't
+      // Setting the output mode as output and unconnected when not in use appears to be a better fix.
+      pinMode(_LEDDriverProps::pin, OUTPUT);
       pixels.show();
+
       modified_ = false;
     }
   }


### PR DESCRIPTION
…52 when digital io pin is left driven low.

LED WS2812 undo early output pin disconnect - only flop our putput pin to disconnected as we go to sleep. This burns power while we are awake, but on MP keyboardio Preonic keyboards it leads to bright flashing lights for an as-yet-undiagnosable reason. This change needs additional support in the device's power management routines