### PR TITLE
Add USB/BLE auto-switching and improved LED indicators for Preonic

### DIFF
--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/examples/Devices/Keyboardio/Preonic/Preonic.ino
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/examples/Devices/Keyboardio/Preonic/Preonic.ino
@@ -315,7 +315,7 @@ KALEIDOSCOPE_INIT_PLUGINS(
   // LEDIndicators shows device status indicators using the LEDs
   // It should be listed after all other LED plugins
   LEDIndicators,
-  
+
   // USBAutoSwitcher handles automatic switching between USB and BLE
   // Should be listed after LEDIndicators to see connection status changes
   USBAutoSwitcher);

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/examples/Devices/Keyboardio/Preonic/Preonic.ino
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/examples/Devices/Keyboardio/Preonic/Preonic.ino
@@ -60,6 +60,9 @@
 // Support for showing device status with the LED Indicators
 #include "Kaleidoscope-LEDIndicators.h"
 
+// Support for automatic USB/BLE device switching
+#include "Kaleidoscope-USBAutoSwitcher.h"
+
 
 /** This 'enum' is a list of all the macros used by the Model 100's firmware
   * The names aren't particularly important. What is important is that each
@@ -311,7 +314,11 @@ KALEIDOSCOPE_INIT_PLUGINS(
   Keyclick,
   // LEDIndicators shows device status indicators using the LEDs
   // It should be listed after all other LED plugins
-  LEDIndicators);
+  LEDIndicators,
+  
+  // USBAutoSwitcher handles automatic switching between USB and BLE
+  // Should be listed after LEDIndicators to see connection status changes
+  USBAutoSwitcher);
 
 
 void configureIndicators() {

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/Kaleidoscope-USBAutoSwitcher.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/Kaleidoscope-USBAutoSwitcher.h
@@ -1,0 +1,25 @@
+/* Kaleidoscope-USBAutoSwitcher -- Automatic USB/BLE device switching for Preonic
+ * Copyright 2025 Keyboard.io, inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * Additional Permissions:
+ * As an additional permission under Section 7 of the GNU General Public
+ * License Version 3, you may link this software against a Vendor-provided
+ * Hardware Specific Software Module under the terms of the MCU Vendor
+ * Firmware Library Additional Permission Version 1.0.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "kaleidoscope/plugin/USBAutoSwitcher.h"

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/device/keyboardio/Preonic.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/device/keyboardio/Preonic.cpp
@@ -525,7 +525,7 @@ void Preonic::setupUSBWakeForSleep() {
   // Use SoftDevice API to enable VBUS detection for wake
   // This generates NRF_EVT_POWER_USB_DETECTED events that can be handled via sd_evt_get()
   uint32_t result = sd_power_usbdetected_enable(true);
-  
+
   // If SoftDevice call fails, continue without USB wake (key/encoder wake still works)
   if (result != NRF_SUCCESS) {
     // Graceful fallback - system will still wake on keys/encoders

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/device/keyboardio/Preonic.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/device/keyboardio/Preonic.cpp
@@ -84,7 +84,6 @@ constexpr uint8_t LEDDriverProps::key_led_map[];
 // Initialize static members
 uint32_t Preonic::last_activity_time_       = 0;
 volatile bool Preonic::input_event_pending_ = false;
-bool Preonic::initial_usb_check_done_       = false;
 uint32_t Preonic::last_battery_update_      = 0;  // Initialize to 0 to force first update
 
 // Battery state tracking

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/device/keyboardio/Preonic.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/device/keyboardio/Preonic.cpp
@@ -84,6 +84,7 @@ constexpr uint8_t LEDDriverProps::key_led_map[];
 // Initialize static members
 uint32_t Preonic::last_activity_time_       = 0;
 volatile bool Preonic::input_event_pending_ = false;
+bool Preonic::initial_usb_check_done_       = false;
 uint32_t Preonic::last_battery_update_      = 0;  // Initialize to 0 to force first update
 
 // Battery state tracking

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/device/keyboardio/Preonic.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/device/keyboardio/Preonic.cpp
@@ -517,4 +517,5 @@ void disablePWMForSleep() {
 }  // namespace device
 }  // namespace kaleidoscope
 
-#endif /* ARDUINO_ARCH_NRF52 */
+
+#endif /* ARDUINO_PREONIC */

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/device/keyboardio/Preonic.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/device/keyboardio/Preonic.h
@@ -289,7 +289,7 @@ struct PreonicProps : public kaleidoscope::device::BaseProps {
 class Preonic : public kaleidoscope::device::Base<PreonicProps> {
  private:
   // Deep sleep timers
-  static uint32_t last_activity_time_;                     // Used for deep sleep
+  static uint32_t last_activity_time_;                      // Used for deep sleep
   static constexpr uint32_t DEEP_SLEEP_TIMEOUT_MS = 10000;  // Enter deep sleep after 10s
   static volatile bool input_event_pending_;
   static uint32_t last_battery_update_;                        // Last battery level update time
@@ -432,7 +432,7 @@ class Preonic : public kaleidoscope::device::Base<PreonicProps> {
    * the standard GPIOTE interrupt handler as it's already used by the Arduino
    * core. Instead, we use PPI to route PORT events to a separate interrupt.
    */
-  
+
   /**
    * @brief Configure USB VBUS detection for wake-from-sleep
    * @details Uses SoftDevice API to enable hardware VBUS detection
@@ -813,7 +813,7 @@ class Preonic : public kaleidoscope::device::Base<PreonicProps> {
  public:
   Preonic() {
   }
-  
+
   /**
    * @brief Handle USB connection status changes for wake-from-sleep
    * @details This provides a safe way to detect USB connections that can wake the device
@@ -822,15 +822,15 @@ class Preonic : public kaleidoscope::device::Base<PreonicProps> {
     // Device 0 is USB - wake handling for data connections
     if (device_id == 0) {
       switch (status) {
-        case kaleidoscope::HostConnectionStatus::Connected:
-          // USB data connection established - signal activity
-          input_event_pending_ = true;
-          last_activity_time_ = millis();
-          break;
-        case kaleidoscope::HostConnectionStatus::Connecting:
-        case kaleidoscope::HostConnectionStatus::Disconnected:
-          // These are handled at the power event level
-          break;
+      case kaleidoscope::HostConnectionStatus::Connected:
+        // USB data connection established - signal activity
+        input_event_pending_ = true;
+        last_activity_time_  = millis();
+        break;
+      case kaleidoscope::HostConnectionStatus::Connecting:
+      case kaleidoscope::HostConnectionStatus::Disconnected:
+        // These are handled at the power event level
+        break;
       }
     }
     return kaleidoscope::EventHandlerResult::OK;
@@ -842,7 +842,7 @@ class Preonic : public kaleidoscope::device::Base<PreonicProps> {
     // Handle speaker updates
     // TODO(jesse): move this into a hook
     updateSpeaker();
-    
+
     // Check for USB power-only state on startup (delegated to MCU driver)
     mcu().checkUSBPowerOnlyStatus();
 
@@ -875,8 +875,7 @@ class Preonic : public kaleidoscope::device::Base<PreonicProps> {
       input_event_pending_ = false;
       last_activity_time_  = now;  // Update activity time on GPIOTE event
     }
-    
-    
+
 
     if (shouldEnterDeepSleep()) {
       // Check if we should enter deep sleep

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/device/keyboardio/Preonic.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/device/keyboardio/Preonic.h
@@ -290,7 +290,7 @@ class Preonic : public kaleidoscope::device::Base<PreonicProps> {
  private:
   // Deep sleep timers
   static uint32_t last_activity_time_;                     // Used for deep sleep
-  static constexpr uint32_t DEEP_SLEEP_TIMEOUT_MS = 2000;  // Enter deep sleep after 10s
+  static constexpr uint32_t DEEP_SLEEP_TIMEOUT_MS = 10000;  // Enter deep sleep after 10s
   static volatile bool input_event_pending_;
   static uint32_t last_battery_update_;                        // Last battery level update time
   static constexpr uint32_t BATTERY_UPDATE_INTERVAL = 300000;  // 5 minutes in milliseconds

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/device/keyboardio/Preonic.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/device/keyboardio/Preonic.h
@@ -292,7 +292,6 @@ class Preonic : public kaleidoscope::device::Base<PreonicProps> {
   static uint32_t last_activity_time_;                     // Used for deep sleep
   static constexpr uint32_t DEEP_SLEEP_TIMEOUT_MS = 2000;  // Enter deep sleep after 10s
   static volatile bool input_event_pending_;
-  static bool initial_usb_check_done_;                     // Track if we've checked USB power-only on startup
   static uint32_t last_battery_update_;                        // Last battery level update time
   static constexpr uint32_t BATTERY_UPDATE_INTERVAL = 300000;  // 5 minutes in milliseconds
 
@@ -843,9 +842,9 @@ class Preonic : public kaleidoscope::device::Base<PreonicProps> {
     // Handle speaker updates
     // TODO(jesse): move this into a hook
     updateSpeaker();
-
-    // Check for USB power-only state on startup (once after 2 seconds)
-    checkUSBPowerOnlyStatus();
+    
+    // Check for USB power-only state on startup (delegated to MCU driver)
+    mcu().checkUSBPowerOnlyStatus();
 
     // Manage LED power based on LED activity
     if (ledDriver().areAnyLEDsOn() || ((now - ledDriver().LEDsLastOn()) < 1000)) {
@@ -903,29 +902,6 @@ class Preonic : public kaleidoscope::device::Base<PreonicProps> {
   }
 
 
-  /**
-   * @brief Check for USB power-only status on startup and trigger LED indication
-   */
-  void checkUSBPowerOnlyStatus() {
-    if (initial_usb_check_done_) {
-      return;  // Already checked
-    }
-    
-    // Delay check slightly to let USB initialization complete
-    if (millis() < 2000) {
-      return;  // Too early to check reliably
-    }
-    
-    initial_usb_check_done_ = true;
-    
-    // Check if we have USB power but no data connection
-    if (mcu().USBPowerDetected() && !mcu().USBDataConnected()) {
-      // USB power only (no data) detected at startup
-      // Trigger the Connecting event for device 0 (USB) which will show orange LEDs
-      kaleidoscope::Runtime.handleHostConnectionStatusChanged(0, kaleidoscope::HostConnectionStatus::Connecting);
-    }
-  }
-
   void initializeSerialForDebugging() {
     Serial.begin(9600);
     while (!Serial) {
@@ -965,7 +941,6 @@ class Preonic : public kaleidoscope::device::Base<PreonicProps> {
     warning_active_          = false;
     shutdown_active_         = false;
     battery_status_          = BatteryStatus::Normal;
-    initial_usb_check_done_  = false;
     updateBatteryLevel();
   }
 

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/USBAutoSwitcher.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/USBAutoSwitcher.cpp
@@ -128,6 +128,11 @@ void USBAutoSwitcher::switchToFallbackBLE() {
 }
 
 void USBAutoSwitcher::switchToUSB() {
+  // Disconnect from BLE if connected
+  if (Runtime.device().ble().connected()) {
+    Runtime.device().ble().disconnect();
+  }
+  
   // Switch to USB mode
   Runtime.device().setHostConnectionMode(MODE_USB);
   current_host_mode_ = MODE_USB;

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/USBAutoSwitcher.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/USBAutoSwitcher.cpp
@@ -97,9 +97,8 @@ EventHandlerResult USBAutoSwitcher::onHostConnectionStatusChanged(uint8_t device
       // Other USB states don't trigger switching
       break;
     }
-  }
-  // Handle BLE device connection events (device_id 1-4)
-  else if (device_id >= 1 && device_id <= 4) {
+  } else if (device_id >= 1 && device_id <= 4) {
+    // Handle BLE device connection events (device_id 1-4)
     switch (status) {
     case HostConnectionStatus::Connected:
     case HostConnectionStatus::DeviceSelected:

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/USBAutoSwitcher.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/USBAutoSwitcher.cpp
@@ -1,0 +1,130 @@
+/* Kaleidoscope-USBAutoSwitcher -- Automatic USB/BLE device switching for Preonic
+ * Copyright 2025 Keyboard.io, inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * Additional Permissions:
+ * As an additional permission under Section 7 of the GNU General Public
+ * License Version 3, you may link this software against a Vendor-provided
+ * Hardware Specific Software Module under the terms of the MCU Vendor
+ * Firmware Library Additional Permission Version 1.0.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "kaleidoscope/plugin/USBAutoSwitcher.h"
+#include "kaleidoscope/Runtime.h"
+
+namespace kaleidoscope {
+namespace plugin {
+
+// Initialize static members
+uint8_t USBAutoSwitcher::fallback_ble_device_ = 1;     // Default to BLE device 1
+uint32_t USBAutoSwitcher::startup_time_ = 0;
+uint16_t USBAutoSwitcher::startup_delay_ms_ = 1000;    // 1 second startup delay
+bool USBAutoSwitcher::startup_switch_done_ = false;
+uint8_t USBAutoSwitcher::current_host_mode_ = MODE_USB; // Default to USB mode
+
+EventHandlerResult USBAutoSwitcher::onSetup() {
+  // Record startup time for delay calculation
+  startup_time_ = Runtime.millisAtCycleStart();
+  startup_switch_done_ = false;
+  
+  // Initialize current mode tracking
+  current_host_mode_ = getCurrentHostMode();
+  
+  return EventHandlerResult::OK;
+}
+
+EventHandlerResult USBAutoSwitcher::onHostConnectionStatusChanged(uint8_t device_id, HostConnectionStatus status) {
+  // Handle USB connection events (device_id 0)
+  if (device_id == 0) {
+    switch (status) {
+      case HostConnectionStatus::Connected:
+        // USB data connection established
+        if (current_host_mode_ != MODE_USB) {
+          switchToUSB();
+        }
+        break;
+        
+      case HostConnectionStatus::Disconnected:
+        // USB fully disconnected - switch to BLE if we were on USB
+        if (current_host_mode_ == MODE_USB) {
+          switchToFallbackBLE();
+        }
+        break;
+        
+      case HostConnectionStatus::Connecting:
+        // USB power only - handle startup switching
+        if (!startup_switch_done_ && !isStartupPeriod()) {
+          // Startup delay has passed and we only have USB power (no data)
+          switchToFallbackBLE();
+          startup_switch_done_ = true;
+        }
+        break;
+        
+      default:
+        // Other USB states don't trigger switching
+        break;
+    }
+  }
+  // Handle BLE device connection events (device_id 1-4)
+  else if (device_id >= 1 && device_id <= 4) {
+    switch (status) {
+      case HostConnectionStatus::Connected:
+      case HostConnectionStatus::DeviceSelected:
+        // BLE device connected or selected - update fallback
+        updateFallbackBLEDevice(device_id);
+        break;
+        
+      default:
+        // Other BLE states don't affect fallback tracking
+        break;
+    }
+  }
+  
+  return EventHandlerResult::OK;
+}
+
+bool USBAutoSwitcher::isStartupPeriod() {
+  return (Runtime.millisAtCycleStart() - startup_time_) < startup_delay_ms_;
+}
+
+void USBAutoSwitcher::switchToFallbackBLE() {
+  // Select the remembered BLE device and switch to BLE mode
+  Runtime.device().ble().selectDevice(fallback_ble_device_);
+  Runtime.device().setHostConnectionMode(MODE_BLE);
+  current_host_mode_ = MODE_BLE;
+}
+
+void USBAutoSwitcher::switchToUSB() {
+  // Switch to USB mode
+  Runtime.device().setHostConnectionMode(MODE_USB);
+  current_host_mode_ = MODE_USB;
+}
+
+void USBAutoSwitcher::updateFallbackBLEDevice(uint8_t device_id) {
+  // Only update if this is a valid BLE device ID
+  if (device_id >= 1 && device_id <= 4) {
+    fallback_ble_device_ = device_id;
+    current_host_mode_ = MODE_BLE;
+  }
+}
+
+uint8_t USBAutoSwitcher::getCurrentHostMode() {
+  // Query the device for current host connection mode
+  return Runtime.device().getHostConnectionMode();
+}
+
+}  // namespace plugin
+}  // namespace kaleidoscope
+
+kaleidoscope::plugin::USBAutoSwitcher USBAutoSwitcher;

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/USBAutoSwitcher.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/USBAutoSwitcher.h
@@ -67,11 +67,11 @@ class USBAutoSwitcher : public kaleidoscope::Plugin {
   EventHandlerResult onHostConnectionStatusChanged(uint8_t device_id, HostConnectionStatus status);
 
  private:
-  static uint8_t fallback_ble_device_;      // Last manually selected BLE device (1-4)
-  static uint32_t startup_time_;            // When the plugin was initialized
-  static uint16_t startup_delay_ms_;        // Delay before auto-switching starts
-  static bool startup_switch_done_;         // Prevent multiple startup switches
-  static uint8_t current_host_mode_;        // Track current connection mode
+  static uint8_t fallback_ble_device_;  // Last manually selected BLE device (1-4)
+  static uint32_t startup_time_;        // When the plugin was initialized
+  static uint16_t startup_delay_ms_;    // Delay before auto-switching starts
+  static bool startup_switch_done_;     // Prevent multiple startup switches
+  static uint8_t current_host_mode_;    // Track current connection mode
 
   /**
    * @brief Check if we're still within the startup delay period

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/USBAutoSwitcher.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/USBAutoSwitcher.h
@@ -1,0 +1,107 @@
+/* Kaleidoscope-USBAutoSwitcher -- Automatic USB/BLE device switching for Preonic
+ * Copyright 2025 Keyboard.io, inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * Additional Permissions:
+ * As an additional permission under Section 7 of the GNU General Public
+ * License Version 3, you may link this software against a Vendor-provided
+ * Hardware Specific Software Module under the terms of the MCU Vendor
+ * Firmware Library Additional Permission Version 1.0.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "kaleidoscope/plugin.h"
+#include "kaleidoscope/host_connection_status.h"
+#include "kaleidoscope/Runtime.h"
+
+namespace kaleidoscope {
+namespace plugin {
+
+/**
+ * @brief Automatic USB/BLE device switching for Keyboardio Preonic
+ * 
+ * This plugin automatically switches between USB and Bluetooth connections:
+ * - On startup without USB data: switch to last-used BLE device (default: device 1)
+ * - USB data connected while on BLE: switch to USB
+ * - USB data disconnected while on USB: switch to last-used BLE device
+ * 
+ * Manual device switching naturally overrides auto-switching since this plugin
+ * responds to connection status events regardless of their cause.
+ */
+class USBAutoSwitcher : public kaleidoscope::Plugin {
+ public:
+  USBAutoSwitcher() {}
+
+  /**
+   * @brief Configure startup delay before auto-switching begins
+   * @param delay_ms Milliseconds to wait after startup (default: 1000ms)
+   */
+  static void setStartupDelay(uint16_t delay_ms) {
+    startup_delay_ms_ = delay_ms;
+  }
+
+  /**
+   * @brief Get the current fallback BLE device number
+   * @return BLE device number (1-4) used for auto-switching
+   */
+  static uint8_t getFallbackBLEDevice() {
+    return fallback_ble_device_;
+  }
+
+  // Plugin hooks
+  EventHandlerResult onSetup();
+  EventHandlerResult onHostConnectionStatusChanged(uint8_t device_id, HostConnectionStatus status);
+
+ private:
+  static uint8_t fallback_ble_device_;      // Last manually selected BLE device (1-4)
+  static uint32_t startup_time_;            // When the plugin was initialized
+  static uint16_t startup_delay_ms_;        // Delay before auto-switching starts
+  static bool startup_switch_done_;         // Prevent multiple startup switches
+  static uint8_t current_host_mode_;        // Track current connection mode
+
+  /**
+   * @brief Check if we're still within the startup delay period
+   * @return true if startup delay is still active
+   */
+  bool isStartupPeriod();
+
+  /**
+   * @brief Switch to the remembered BLE device
+   */
+  void switchToFallbackBLE();
+
+  /**
+   * @brief Switch to USB mode
+   */
+  void switchToUSB();
+
+  /**
+   * @brief Update fallback BLE device based on current selection
+   * Called when BLE device connection status changes
+   */
+  void updateFallbackBLEDevice(uint8_t device_id);
+
+  /**
+   * @brief Get current host connection mode from device
+   * @return MODE_USB or MODE_BLE
+   */
+  uint8_t getCurrentHostMode();
+};
+
+}  // namespace plugin
+}  // namespace kaleidoscope
+
+extern kaleidoscope::plugin::USBAutoSwitcher USBAutoSwitcher;

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/USBAutoSwitcher.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/USBAutoSwitcher.h
@@ -63,6 +63,7 @@ class USBAutoSwitcher : public kaleidoscope::Plugin {
 
   // Plugin hooks
   EventHandlerResult onSetup();
+  EventHandlerResult afterEachCycle();
   EventHandlerResult onHostConnectionStatusChanged(uint8_t device_id, HostConnectionStatus status);
 
  private:

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
@@ -337,7 +337,7 @@ EventHandlerResult LEDIndicators::onHostConnectionStatusChanged(uint8_t device_i
       }
       break;
     case HostConnectionStatus::Disconnected:
-      // USB fully disconnected - show red shrink effect on all LEDs
+      // USB fully disconnected - show orange shrink effect on all LEDs
       // First clear any existing indicators
       for (uint8_t i = 0; i < num_indicator_slots; i++) {
         KeyAddr led_addr = getLEDForSlot(i);
@@ -345,13 +345,13 @@ EventHandlerResult LEDIndicators::onHostConnectionStatusChanged(uint8_t device_i
           clearIndicator(led_addr);
         }
       }
-      // Now show red on all LEDs
+      // Now show orange on all LEDs (less alarming than red)
       for (uint8_t i = 0; i < num_indicator_slots; i++) {
         KeyAddr led_addr = getLEDForSlot(i);
         if (led_addr.isValid()) {
           showIndicator(led_addr,
                         IndicatorEffect::Shrink,
-                        color_red,
+                        color_orange,
                         color_off,
                         1000,  // 1 second duration
                         1);    // 1 cycle
@@ -378,6 +378,8 @@ EventHandlerResult LEDIndicators::onHostConnectionStatusChanged(uint8_t device_i
                            10);    // 10 cycles
     break;
   case HostConnectionStatus::Connected:
+    // Clear any existing indicators on this slot (like Advertising) before showing Connected
+    clearIndicator(getLEDForSlot(slot));
     showIndicatorWithDelay(getLEDForSlot(slot),
                            IndicatorEffect::Grow,
                            color_blue,
@@ -412,6 +414,8 @@ EventHandlerResult LEDIndicators::onHostConnectionStatusChanged(uint8_t device_i
                   1);     // 1 cycle
     break;
   case HostConnectionStatus::DeviceSelected:
+    // Clear any previous indicators on this slot before showing DeviceSelected
+    clearIndicator(getLEDForSlot(slot));
     showIndicatorWithDelay(getLEDForSlot(slot),
                            IndicatorEffect::Grow,
                            color_blue,
@@ -424,6 +428,8 @@ EventHandlerResult LEDIndicators::onHostConnectionStatusChanged(uint8_t device_i
     clearIndicator(getLEDForSlot(slot));
     break;
   case HostConnectionStatus::Advertising:
+    // Clear any previous indicators on this slot before showing Advertising
+    clearIndicator(getLEDForSlot(slot));
     showIndicatorWithDelay(getLEDForSlot(slot),
                            IndicatorEffect::Blink,
                            color_blue,

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
@@ -300,11 +300,16 @@ EventHandlerResult LEDIndicators::onHostConnectionStatusChanged(uint8_t device_i
       }
       break;
     case HostConnectionStatus::Disconnected:
-      // USB fully disconnected - clear indicators on all LEDs
+      // USB fully disconnected - show red shrink effect on all LEDs
       for (uint8_t i = 0; i < num_indicator_slots; i++) {
         KeyAddr led_addr = getLEDForSlot(i);
         if (led_addr.isValid()) {
-          clearIndicator(led_addr);
+          showIndicator(led_addr,
+                        IndicatorEffect::Shrink,
+                        color_red,
+                        color_off,
+                        2000,  // 2 second duration
+                        1);    // 1 cycle
         }
       }
       break;

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
@@ -286,16 +286,16 @@ EventHandlerResult LEDIndicators::onHostConnectionStatusChanged(uint8_t device_i
       }
       break;
     case HostConnectionStatus::Connected:
-      // USB data connection established - pulse green 3 times on all LEDs
+      // USB data connection established - fade up green on all LEDs
       for (uint8_t i = 0; i < num_indicator_slots; i++) {
         KeyAddr led_addr = getLEDForSlot(i);
         if (led_addr.isValid()) {
           showIndicator(led_addr,
-                        IndicatorEffect::Pulse,
+                        IndicatorEffect::Grow,
                         color_green,
                         color_off,
-                        1200,  // 3 pulses at 400ms each
-                        3);
+                        1000,  // 1 second fade up
+                        1);
         }
       }
       break;

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
@@ -310,12 +310,19 @@ EventHandlerResult LEDIndicators::onHostConnectionStatusChanged(uint8_t device_i
                   1);    // 1 cycle
     break;
   case HostConnectionStatus::PairingFailed:
-  case HostConnectionStatus::Disconnected:
     showIndicator(getLEDForSlot(slot),
                   IndicatorEffect::Shrink,
                   color_red,
                   color_off,
                   10000,  // 10 second duration
+                  1);     // 1 cycle
+    break;
+  case HostConnectionStatus::Disconnected:
+    showIndicator(getLEDForSlot(slot),
+                  IndicatorEffect::Shrink,
+                  color_blue,
+                  color_off,
+                  5000,  // 5 second duration
                   1);     // 1 cycle
     break;
   case HostConnectionStatus::PairingSuccess:

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
@@ -48,8 +48,6 @@ KeyAddr LEDIndicators::slot_leds[MAX_SLOTS] = {
 // Initialize static indicator array
 kaleidoscope::plugin::LEDIndicators::Indicator LEDIndicators::indicators_[MAX_SLOTS] = {};
 
-// Initialize USB check flag
-bool LEDIndicators::initial_usb_check_done_ = false;
 
 // Setup the plugin
 EventHandlerResult LEDIndicators::onSetup() {
@@ -144,9 +142,6 @@ EventHandlerResult LEDIndicators::beforeSyncingLeds() {
     return EventHandlerResult::OK;
   }
 
-  // Check for USB power-only scenario on startup (once)
-  checkUSBPowerOnlyStatus();
-
   // Update and apply all active indicators
   for (uint8_t i = 0; i < MAX_SLOTS; i++) {
     if (indicators_[i].active) {
@@ -237,31 +232,6 @@ cRGB LEDIndicators::computeCurrentColor(const Indicator &indicator) {
 
   default:
     return indicator.color1;
-  }
-}
-
-// Check if USB has power but no data connection
-bool LEDIndicators::isUSBPowerOnly() {
-  return Runtime.device().mcu().USBPowerDetected() && !Runtime.device().mcu().USBDataConnected();
-}
-
-// Handle USB power-only detection on startup
-void LEDIndicators::checkUSBPowerOnlyStatus() {
-  if (initial_usb_check_done_) {
-    return;  // Already checked
-  }
-  
-  // Delay check slightly to let USB initialization complete
-  if (Runtime.millisAtCycleStart() < 2000) {
-    return;  // Too early to check reliably
-  }
-  
-  initial_usb_check_done_ = true;
-  
-  if (isUSBPowerOnly()) {
-    // USB power only (no data) detected at startup
-    // Manually trigger the Connecting event for device 0 (USB)
-    onHostConnectionStatusChanged(0, HostConnectionStatus::Connecting);
   }
 }
 

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
@@ -158,6 +158,12 @@ class LEDIndicators : public kaleidoscope::Plugin {
    * @return The maximum remaining time in milliseconds, or 0 if no global indicators are active
    */
   uint16_t getGlobalIndicatorRemainingTime();
+  
+  /** @brief Check if a specific LED has an active indicator
+   * @param led_addr The LED to check
+   * @return true if the LED has an active indicator (including global indicators)
+   */
+  bool hasActiveIndicatorForLED(KeyAddr led_addr);
 
   /** @brief Get the LED index for a given slot
    * @param slot The slot number

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
@@ -43,7 +43,8 @@ enum class IndicatorEffect {
   Blink,    ///< Alternates between two colors
   Breathe,  ///< Smoothly transitions between two brightnesses of the same color
   Grow,     ///< Starts dim, breathes to full brightness, stays bright
-  Shrink    ///< Starts bright, breathes to dim, stays dim
+  Shrink,   ///< Starts bright, breathes to dim, stays dim
+  Pulse     ///< Brief bright flash, repeatable (perfect for connection notifications)
 };
 
 /**
@@ -58,6 +59,7 @@ class LEDIndicators : public kaleidoscope::Plugin {
   static cRGB color_red;
   static cRGB color_off;
   static cRGB color_green;
+  static cRGB color_orange;
 
   /** @brief Configure the number of indicator slots and their LED mapping
    * @param num_slots Number of slots to use (must be <= MAX_SLOTS)
@@ -147,6 +149,18 @@ class LEDIndicators : public kaleidoscope::Plugin {
   EventHandlerResult onPowerEvent(PowerEvent event, uint16_t voltage_mv);
 
  private:
+  /**
+   * @brief Check if USB has power but no data connection
+   * @return true if USB power is detected but no data connection
+   */
+  bool isUSBPowerOnly();
+  
+  /**
+   * @brief Handle USB power-only detection on startup
+   */
+  void checkUSBPowerOnlyStatus();
+  
+  static bool initial_usb_check_done_;
   static constexpr uint8_t MAX_SLOTS = 8;  // Maximum number of slots supported
   static uint8_t num_indicator_slots;      // Number of slots configured
   static KeyAddr slot_leds[MAX_SLOTS];     // LED mapping for slots

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
@@ -110,6 +110,23 @@ class LEDIndicators : public kaleidoscope::Plugin {
                      cRGB color2            = {0, 0, 0},
                      uint16_t duration_ms   = 0,
                      uint16_t effect_cycles = 0);
+  
+  /** @brief Show a temporary indicator with delay and duration
+   * @param key_addr The LED index to control
+   * @param effect The type of visual effect to show
+   * @param color1 Primary color for the effect
+   * @param color2 Secondary color for effects that use two colors
+   * @param duration_ms How long to show the indicator (0 for indefinite)
+   * @param delay_ms How long to wait before showing the indicator
+   * @param effect_cycles Number of times to repeat the effect
+   */
+  void showIndicatorWithDelay(KeyAddr key_addr,
+                              IndicatorEffect effect,
+                              cRGB color1,
+                              cRGB color2,
+                              uint16_t duration_ms,
+                              uint16_t delay_ms,
+                              uint16_t effect_cycles = 0);
 
   /** @brief Clear a specific indicator
    * @param key_addr The LED index to clear
@@ -161,6 +178,7 @@ class LEDIndicators : public kaleidoscope::Plugin {
     IndicatorEffect effect;
     uint32_t start_time;
     uint16_t duration_ms;
+    uint16_t delay_ms;      // Delay before showing the indicator
     uint16_t effect_cycles;
     uint32_t last_update;
     uint16_t current_cycle;

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
@@ -111,6 +111,19 @@ class LEDIndicators : public kaleidoscope::Plugin {
                      uint16_t duration_ms   = 0,
                      uint16_t effect_cycles = 0);
   
+  /** @brief Show a global indicator that affects all configured slots
+   * @param effect The type of visual effect to show
+   * @param color1 Primary color for the effect
+   * @param color2 Secondary color for effects that use two colors
+   * @param duration_ms How long to show the indicator (0 for indefinite)
+   * @param effect_cycles Number of times to repeat the effect
+   */
+  void showGlobalIndicator(IndicatorEffect effect,
+                           cRGB color1,
+                           cRGB color2,
+                           uint16_t duration_ms,
+                           uint16_t effect_cycles = 0);
+  
   /** @brief Show a temporary indicator with delay and duration
    * @param key_addr The LED index to control
    * @param effect The type of visual effect to show
@@ -136,12 +149,15 @@ class LEDIndicators : public kaleidoscope::Plugin {
   /** @brief Clear all active indicators */
   void clearAllIndicators();
 
-  /** @brief Check if any indicators are currently active on the given slot range
-   * @param start_slot The first slot to check
-   * @param end_slot The last slot to check (inclusive)
-   * @return true if any indicators are active in the specified range
+  /** @brief Check if any global indicators are currently active
+   * @return true if any global indicators are active and running
    */
-  bool hasActiveIndicators(uint8_t start_slot, uint8_t end_slot);
+  bool hasActiveGlobalIndicator();
+  
+  /** @brief Get the remaining duration of any active global indicator
+   * @return The maximum remaining time in milliseconds, or 0 if no global indicators are active
+   */
+  uint16_t getGlobalIndicatorRemainingTime();
 
   /** @brief Get the LED index for a given slot
    * @param slot The slot number
@@ -189,6 +205,7 @@ class LEDIndicators : public kaleidoscope::Plugin {
     uint16_t effect_cycles;
     uint32_t last_update;
     uint16_t current_cycle;
+    bool is_global = false;  // If true, affects all indicator slots
   };
 
   void updateIndicator(uint8_t index);

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
@@ -136,6 +136,13 @@ class LEDIndicators : public kaleidoscope::Plugin {
   /** @brief Clear all active indicators */
   void clearAllIndicators();
 
+  /** @brief Check if any indicators are currently active on the given slot range
+   * @param start_slot The first slot to check
+   * @param end_slot The last slot to check (inclusive)
+   * @return true if any indicators are active in the specified range
+   */
+  bool hasActiveIndicators(uint8_t start_slot, uint8_t end_slot);
+
   /** @brief Get the LED index for a given slot
    * @param slot The slot number
    * @return The LED index, or KeyAddr::none() if slot is invalid

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
@@ -149,18 +149,6 @@ class LEDIndicators : public kaleidoscope::Plugin {
   EventHandlerResult onPowerEvent(PowerEvent event, uint16_t voltage_mv);
 
  private:
-  /**
-   * @brief Check if USB has power but no data connection
-   * @return true if USB power is detected but no data connection
-   */
-  bool isUSBPowerOnly();
-  
-  /**
-   * @brief Handle USB power-only detection on startup
-   */
-  void checkUSBPowerOnlyStatus();
-  
-  static bool initial_usb_check_done_;
   static constexpr uint8_t MAX_SLOTS = 8;  // Maximum number of slots supported
   static uint8_t num_indicator_slots;      // Number of slots configured
   static KeyAddr slot_leds[MAX_SLOTS];     // LED mapping for slots

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
@@ -110,7 +110,7 @@ class LEDIndicators : public kaleidoscope::Plugin {
                      cRGB color2            = {0, 0, 0},
                      uint16_t duration_ms   = 0,
                      uint16_t effect_cycles = 0);
-  
+
   /** @brief Show a global indicator that affects all configured slots
    * @param effect The type of visual effect to show
    * @param color1 Primary color for the effect
@@ -123,7 +123,7 @@ class LEDIndicators : public kaleidoscope::Plugin {
                            cRGB color2,
                            uint16_t duration_ms,
                            uint16_t effect_cycles = 0);
-  
+
   /** @brief Show a temporary indicator with delay and duration
    * @param key_addr The LED index to control
    * @param effect The type of visual effect to show
@@ -153,12 +153,12 @@ class LEDIndicators : public kaleidoscope::Plugin {
    * @return true if any global indicators are active and running
    */
   bool hasActiveGlobalIndicator();
-  
+
   /** @brief Get the remaining duration of any active global indicator
    * @return The maximum remaining time in milliseconds, or 0 if no global indicators are active
    */
   uint16_t getGlobalIndicatorRemainingTime();
-  
+
   /** @brief Check if a specific LED has an active indicator
    * @param led_addr The LED to check
    * @return true if the LED has an active indicator (including global indicators)
@@ -207,7 +207,7 @@ class LEDIndicators : public kaleidoscope::Plugin {
     IndicatorEffect effect;
     uint32_t start_time;
     uint16_t duration_ms;
-    uint16_t delay_ms;      // Delay before showing the indicator
+    uint16_t delay_ms;  // Delay before showing the indicator
     uint16_t effect_cycles;
     uint32_t last_update;
     uint16_t current_cycle;

--- a/src/kaleidoscope/device/Base.h
+++ b/src/kaleidoscope/device/Base.h
@@ -585,12 +585,12 @@ class Base {
     if (!isHybridHostConnection()) {
       return;
     }
-    if (host_connection_mode_ == MODE_BLE && mcu_.USBConfigured()) {
+    if (host_connection_mode_ == MODE_BLE && mcu_.USBDataConnected()) {
       if (!ble_.connected() || primary_host_connection_mode_ == MODE_USB) {
         setHostConnectionMode(MODE_USB);
       }
     } else if (host_connection_mode_ == MODE_USB && ble_.connected()) {
-      if (!mcu_.USBConfigured() || primary_host_connection_mode_ == MODE_BLE) {
+      if (!mcu_.USBDataConnected() || primary_host_connection_mode_ == MODE_BLE) {
         setHostConnectionMode(MODE_BLE);
       }
     }

--- a/src/kaleidoscope/driver/ble/Bluefruit.cpp
+++ b/src/kaleidoscope/driver/ble/Bluefruit.cpp
@@ -324,8 +324,18 @@ void BLEBluefruit::selectDevice(uint8_t device_id) {
     Bluefruit.setName(name_buffer);
     Hooks::onHostConnectionStatusChanged(device_id, kaleidoscope::HostConnectionStatus::DeviceSelected);
     current_device_id = device_id;
+    startConnectableAdvertising();
+  } else {
+    // Already on the requested device
+    DEBUG_BLE_MSG("Already on device ", device_id);
+    // Only start advertising if not already connected
+    if (!Bluefruit.Periph.connected()) {
+      DEBUG_BLE_MSG("Not connected, starting advertising");
+      startConnectableAdvertising();
+    } else {
+      DEBUG_BLE_MSG("Already connected to device ", device_id);
+    }
   }
-  startConnectableAdvertising();
 
   DEBUG_BLE_MSG(" ====== Device Selection Complete ======\n");
 }

--- a/src/kaleidoscope/driver/led/WS2812.h
+++ b/src/kaleidoscope/driver/led/WS2812.h
@@ -49,13 +49,19 @@ class WS2812 : public Base<_LEDDriverProps> {
   }
 
   void setup() {
+    cRGB rgb;
+    rgb.r = 0;
+    rgb.g = 0;
+    rgb.b = 0;
     pixels.begin();
+
+    for (auto i=0; i<= _LEDDriverProps::led_count; i++) {
+	setCrgbAt(i,	rgb);
+	}	
+    pixels.setBrightness(0);  // Set initial brightness
     pixels.show();             // Initialize all pixels to 'off'
     pixels.setBrightness(50);  // Set initial brightness
 
-    for (int i = 0; i < _LEDDriverProps::led_count; i++) {
-      pixels.setPixelColor(i, pixels.Color(0, 150, 150));
-    }
     modified_ = true;
 
     syncLeds();
@@ -69,6 +75,7 @@ class WS2812 : public Base<_LEDDriverProps> {
       // glowing a dull blue when other LEDs are lit and that one isn't
       // Setting the output mode as output and unconnected when not in use appears to be a better fix.
       pinMode(_LEDDriverProps::pin, OUTPUT);
+      delay(5);
       pixels.show();
 
       modified_ = false;

--- a/src/kaleidoscope/driver/led/WS2812.h
+++ b/src/kaleidoscope/driver/led/WS2812.h
@@ -55,10 +55,10 @@ class WS2812 : public Base<_LEDDriverProps> {
     rgb.b = 0;
     pixels.begin();
 
-    for (auto i=0; i<= _LEDDriverProps::led_count; i++) {
-	setCrgbAt(i,	rgb);
-	}	
-    pixels.setBrightness(0);  // Set initial brightness
+    for (auto i = 0; i <= _LEDDriverProps::led_count; i++) {
+      setCrgbAt(i, rgb);
+    }
+    pixels.setBrightness(0);   // Set initial brightness
     pixels.show();             // Initialize all pixels to 'off'
     pixels.setBrightness(50);  // Set initial brightness
 

--- a/src/kaleidoscope/driver/mcu/nRF52840.cpp
+++ b/src/kaleidoscope/driver/mcu/nRF52840.cpp
@@ -76,8 +76,30 @@ void nRF52840<_Props>::broadcastUSBState(bool connected) {
   }
 }
 
+template<typename _Props>
+void nRF52840<_Props>::checkUSBPowerOnlyStatus() {
+  if (initial_usb_check_done_) {
+    return;  // Already checked
+  }
+  
+  // Delay check slightly to let USB initialization complete
+  if ((millis() - startup_time_) < 2000) {
+    return;  // Too early to check reliably
+  }
+  
+  initial_usb_check_done_ = true;
+  
+  // Check if we have USB power but no data connection
+  if (USBPowerDetected() && !USBDataConnected()) {
+    // USB power only (no data) detected at startup
+    // Trigger the Connecting event for device 0 (USB) which will show orange LEDs
+    kaleidoscope::Hooks::onHostConnectionStatusChanged(USB_DEVICE_ID, kaleidoscope::HostConnectionStatus::Connecting);
+  }
+}
+
 // Explicit template instantiation  
 template void nRF52840<nRF52840Props>::broadcastUSBState(bool);
+template void nRF52840<nRF52840Props>::checkUSBPowerOnlyStatus();
 
 } // namespace mcu
 } // namespace driver

--- a/src/kaleidoscope/driver/mcu/nRF52840.cpp
+++ b/src/kaleidoscope/driver/mcu/nRF52840.cpp
@@ -7,6 +7,30 @@
 #include "kaleidoscope/driver/mcu/nRF52840.h"
 #include "kaleidoscope/hooks.h"
 #include "kaleidoscope/host_connection_status.h"
+#include <Arduino.h>
+
+// Debug speaker pin - PIN_SPEAKER is 18 on Preonic
+#define DEBUG_SPEAKER_PIN 18
+
+/**
+ * @brief Configure speaker pin using Arduino functions
+ */
+static void setupDebugSpeaker() {
+  pinMode(DEBUG_SPEAKER_PIN, OUTPUT);
+}
+
+/**
+ * @brief Play multiple debug tones with gaps using Arduino tone()
+ * @param count Number of tones to play
+ */
+static void playDebugTones(uint8_t count) {
+  setupDebugSpeaker();
+  
+  for (uint8_t i = 0; i < count; i++) {
+    tone(DEBUG_SPEAKER_PIN, 1000, 200);  // 1kHz tone for 200ms
+    delay(250);  // Wait for tone to finish plus gap
+  }
+}
 
 // TinyUSB callbacks must be in global scope with C linkage
 extern "C" {

--- a/src/kaleidoscope/driver/mcu/nRF52840.cpp
+++ b/src/kaleidoscope/driver/mcu/nRF52840.cpp
@@ -7,30 +7,6 @@
 #include "kaleidoscope/driver/mcu/nRF52840.h"
 #include "kaleidoscope/hooks.h"
 #include "kaleidoscope/host_connection_status.h"
-#include <Arduino.h>
-
-// Debug speaker pin - PIN_SPEAKER is 18 on Preonic
-#define DEBUG_SPEAKER_PIN 18
-
-/**
- * @brief Configure speaker pin using Arduino functions
- */
-static void setupDebugSpeaker() {
-  pinMode(DEBUG_SPEAKER_PIN, OUTPUT);
-}
-
-/**
- * @brief Play multiple debug tones with gaps using Arduino tone()
- * @param count Number of tones to play
- */
-static void playDebugTones(uint8_t count) {
-  setupDebugSpeaker();
-  
-  for (uint8_t i = 0; i < count; i++) {
-    tone(DEBUG_SPEAKER_PIN, 1000, 200);  // 1kHz tone for 200ms
-    delay(250);  // Wait for tone to finish plus gap
-  }
-}
 
 // TinyUSB callbacks must be in global scope with C linkage
 extern "C" {

--- a/src/kaleidoscope/driver/mcu/nRF52840.cpp
+++ b/src/kaleidoscope/driver/mcu/nRF52840.cpp
@@ -1,0 +1,86 @@
+// ABOUTME: TinyUSB callback implementation for nRF52840 USB event handling
+// ABOUTME: Provides event-driven USB connection detection for Kaleidoscope
+
+#ifdef ARDUINO_ARCH_NRF52
+
+#include "Adafruit_TinyUSB.h"
+#include "kaleidoscope/driver/mcu/nRF52840.h"
+#include "kaleidoscope/hooks.h"
+#include "kaleidoscope/host_connection_status.h"
+
+// TinyUSB callbacks must be in global scope with C linkage
+extern "C" {
+
+/**
+ * @brief Callback invoked when USB device is mounted (configured by host)
+ * This indicates an active data connection is established
+ */
+void tud_mount_cb(void) {
+  // Notify the nRF52840 driver that USB data connection is established
+  kaleidoscope::driver::mcu::nRF52840<kaleidoscope::driver::mcu::nRF52840Props>::handleUSBMount();
+  
+  // Broadcast host connection status change event for USB device
+  kaleidoscope::driver::mcu::nRF52840<kaleidoscope::driver::mcu::nRF52840Props>::broadcastUSBState(true);
+}
+
+/**
+ * @brief Callback invoked when USB device is unmounted (disconnected from host)
+ * This indicates the data connection has been lost
+ */
+void tud_umount_cb(void) {
+  // Notify the nRF52840 driver that USB data connection is lost
+  kaleidoscope::driver::mcu::nRF52840<kaleidoscope::driver::mcu::nRF52840Props>::handleUSBUnmount();
+  
+  // Broadcast host connection status change event for USB device
+  kaleidoscope::driver::mcu::nRF52840<kaleidoscope::driver::mcu::nRF52840Props>::broadcastUSBState(false);
+}
+
+/**
+ * @brief Callback invoked when USB device is suspended
+ * @param remote_wakeup_en true if remote wakeup feature is enabled
+ */
+void tud_suspend_cb(bool remote_wakeup_en) {
+  // USB is still connected but host has entered suspend state
+  // Device should reduce power consumption
+  (void)remote_wakeup_en; // Unused parameter
+}
+
+/**
+ * @brief Callback invoked when USB device is resumed from suspend
+ */
+void tud_resume_cb(void) {
+  // USB connection resumed from suspend state
+  // Normal operation can continue
+}
+
+} // extern "C"
+
+namespace kaleidoscope {
+namespace driver {
+namespace mcu {
+
+template<typename _Props>
+void nRF52840<_Props>::broadcastUSBState(bool connected) {
+  if (connected) {
+    // Data connection established
+    kaleidoscope::Hooks::onHostConnectionStatusChanged(USB_DEVICE_ID, kaleidoscope::HostConnectionStatus::Connected);
+  } else {
+    // Data connection lost - check if we still have power
+    if (instance_ && instance_->USBPowerDetected()) {
+      // Still have USB power but no data - this is "connecting" state
+      kaleidoscope::Hooks::onHostConnectionStatusChanged(USB_DEVICE_ID, kaleidoscope::HostConnectionStatus::Connecting);
+    } else {
+      // Fully disconnected
+      kaleidoscope::Hooks::onHostConnectionStatusChanged(USB_DEVICE_ID, kaleidoscope::HostConnectionStatus::Disconnected);
+    }
+  }
+}
+
+// Explicit template instantiation  
+template void nRF52840<nRF52840Props>::broadcastUSBState(bool);
+
+} // namespace mcu
+} // namespace driver
+} // namespace kaleidoscope
+
+#endif // ARDUINO_ARCH_NRF52

--- a/src/kaleidoscope/driver/mcu/nRF52840.cpp
+++ b/src/kaleidoscope/driver/mcu/nRF52840.cpp
@@ -18,7 +18,7 @@ extern "C" {
 void tud_mount_cb(void) {
   // Notify the nRF52840 driver that USB data connection is established
   kaleidoscope::driver::mcu::nRF52840<kaleidoscope::driver::mcu::nRF52840Props>::handleUSBMount();
-  
+
   // Broadcast host connection status change event for USB device
   kaleidoscope::driver::mcu::nRF52840<kaleidoscope::driver::mcu::nRF52840Props>::broadcastUSBState(true);
 }
@@ -30,7 +30,7 @@ void tud_mount_cb(void) {
 void tud_umount_cb(void) {
   // Notify the nRF52840 driver that USB data connection is lost
   kaleidoscope::driver::mcu::nRF52840<kaleidoscope::driver::mcu::nRF52840Props>::handleUSBUnmount();
-  
+
   // Broadcast host connection status change event for USB device
   kaleidoscope::driver::mcu::nRF52840<kaleidoscope::driver::mcu::nRF52840Props>::broadcastUSBState(false);
 }
@@ -42,7 +42,7 @@ void tud_umount_cb(void) {
 void tud_suspend_cb(bool remote_wakeup_en) {
   // USB is still connected but host has entered suspend state
   // Device should reduce power consumption
-  (void)remote_wakeup_en; // Unused parameter
+  (void)remote_wakeup_en;  // Unused parameter
 }
 
 /**
@@ -53,7 +53,7 @@ void tud_resume_cb(void) {
   // Normal operation can continue
 }
 
-} // extern "C"
+}  // extern "C"
 
 namespace kaleidoscope {
 namespace driver {
@@ -81,14 +81,14 @@ void nRF52840<_Props>::checkUSBPowerOnlyStatus() {
   if (initial_usb_check_done_) {
     return;  // Already checked
   }
-  
+
   // Delay check slightly to let USB initialization complete
   if ((millis() - startup_time_) < 2000) {
     return;  // Too early to check reliably
   }
-  
+
   initial_usb_check_done_ = true;
-  
+
   // Check if we have USB power but no data connection
   if (USBPowerDetected() && !USBDataConnected()) {
     // USB power only (no data) detected at startup
@@ -97,12 +97,12 @@ void nRF52840<_Props>::checkUSBPowerOnlyStatus() {
   }
 }
 
-// Explicit template instantiation  
+// Explicit template instantiation
 template void nRF52840<nRF52840Props>::broadcastUSBState(bool);
 template void nRF52840<nRF52840Props>::checkUSBPowerOnlyStatus();
 
-} // namespace mcu
-} // namespace driver
-} // namespace kaleidoscope
+}  // namespace mcu
+}  // namespace driver
+}  // namespace kaleidoscope
 
-#endif // ARDUINO_ARCH_NRF52
+#endif  // ARDUINO_ARCH_NRF52

--- a/src/kaleidoscope/driver/mcu/nRF52840.h
+++ b/src/kaleidoscope/driver/mcu/nRF52840.h
@@ -94,7 +94,17 @@ class nRF52840 : public kaleidoscope::driver::mcu::Base<_Props> {
     
     // Set up static pointer for callback access
     instance_ = this;
+    
+    // Mark that we haven't done the initial USB check yet
+    initial_usb_check_done_ = false;
+    startup_time_ = millis();
   }
+  
+  /**
+   * @brief Check for USB power-only state on startup and trigger LED indication
+   * Should be called periodically early in the device lifecycle
+   */
+  void checkUSBPowerOnlyStatus();
 
   /**
    * @brief Broadcast USB connection state change
@@ -463,6 +473,8 @@ class nRF52840 : public kaleidoscope::driver::mcu::Base<_Props> {
   // USB connection state tracking
   static bool usb_data_connected_;
   static nRF52840<_Props>* instance_;  // Static instance pointer for callback access
+  static bool initial_usb_check_done_;  // Track if we've checked USB power-only on startup
+  static uint32_t startup_time_;        // Track when device was initialized
 };
 
 template<typename _Props>
@@ -476,6 +488,12 @@ bool nRF52840<_Props>::usb_data_connected_ = false;
 
 template<typename _Props>
 nRF52840<_Props>* nRF52840<_Props>::instance_ = nullptr;
+
+template<typename _Props>
+bool nRF52840<_Props>::initial_usb_check_done_ = false;
+
+template<typename _Props>
+uint32_t nRF52840<_Props>::startup_time_ = 0;
 
 #else
 template<typename _Props>

--- a/src/kaleidoscope/driver/mcu/nRF52840.h
+++ b/src/kaleidoscope/driver/mcu/nRF52840.h
@@ -91,15 +91,15 @@ class nRF52840 : public kaleidoscope::driver::mcu::Base<_Props> {
   void setup() {
     // Set initial USB connection state based on current hardware status
     usb_data_connected_ = TinyUSBDevice.mounted();
-    
+
     // Set up static pointer for callback access
     instance_ = this;
-    
+
     // Mark that we haven't done the initial USB check yet
     initial_usb_check_done_ = false;
-    startup_time_ = millis();
+    startup_time_           = millis();
   }
-  
+
   /**
    * @brief Check for USB power-only state on startup and trigger LED indication
    * Should be called periodically early in the device lifecycle
@@ -469,10 +469,10 @@ class nRF52840 : public kaleidoscope::driver::mcu::Base<_Props> {
  private:
   static TimerState timer_state_;
   static TWIState twi_state_;
-  
+
   // USB connection state tracking
   static bool usb_data_connected_;
-  static nRF52840<_Props>* instance_;  // Static instance pointer for callback access
+  static nRF52840<_Props> *instance_;   // Static instance pointer for callback access
   static bool initial_usb_check_done_;  // Track if we've checked USB power-only on startup
   static uint32_t startup_time_;        // Track when device was initialized
 };
@@ -487,7 +487,7 @@ template<typename _Props>
 bool nRF52840<_Props>::usb_data_connected_ = false;
 
 template<typename _Props>
-nRF52840<_Props>* nRF52840<_Props>::instance_ = nullptr;
+nRF52840<_Props> *nRF52840<_Props>::instance_ = nullptr;
 
 template<typename _Props>
 bool nRF52840<_Props>::initial_usb_check_done_ = false;

--- a/src/kaleidoscope/hooks.h
+++ b/src/kaleidoscope/hooks.h
@@ -70,6 +70,7 @@ class Hooks {
   friend class plugin::FocusSerial;
   friend class plugin::LEDControl;
   friend class driver::ble::BLEBluefruit;  // Allow BLEBluefruit to trigger hooks
+  template<typename _Props> friend class driver::mcu::nRF52840;  // Allow nRF52840 to trigger USB connection hooks
   friend void sketch_exploration::pluginsExploreSketch();
 
  private:

--- a/src/kaleidoscope/hooks.h
+++ b/src/kaleidoscope/hooks.h
@@ -70,7 +70,8 @@ class Hooks {
   friend class plugin::FocusSerial;
   friend class plugin::LEDControl;
   friend class driver::ble::BLEBluefruit;  // Allow BLEBluefruit to trigger hooks
-  template<typename _Props> friend class driver::mcu::nRF52840;  // Allow nRF52840 to trigger USB connection hooks
+  template<typename _Props>
+  friend class driver::mcu::nRF52840;  // Allow nRF52840 to trigger USB connection hooks
   friend void sketch_exploration::pluginsExploreSketch();
 
  private:

--- a/src/kaleidoscope/hooks.h
+++ b/src/kaleidoscope/hooks.h
@@ -69,9 +69,11 @@ class Hooks {
   friend class Runtime_;
   friend class plugin::FocusSerial;
   friend class plugin::LEDControl;
-  friend class driver::ble::BLEBluefruit;  // Allow BLEBluefruit to trigger hooks
+  friend class driver::ble::BLEBluefruit;  // Allow BLEBluefruit to trigger BLE connection hooks
+#ifdef ARDUINO_NRF52_ADAFRUIT
   template<typename _Props>
-  friend class driver::mcu::Base;  // Allow MCU drivers to trigger USB connection hooks
+  friend class driver::mcu::nRF52840;  // Allow nRF52840 to trigger USB connection hooks
+#endif
   friend void sketch_exploration::pluginsExploreSketch();
 
  private:

--- a/src/kaleidoscope/hooks.h
+++ b/src/kaleidoscope/hooks.h
@@ -71,7 +71,7 @@ class Hooks {
   friend class plugin::LEDControl;
   friend class driver::ble::BLEBluefruit;  // Allow BLEBluefruit to trigger hooks
   template<typename _Props>
-  friend class driver::mcu::nRF52840;  // Allow nRF52840 to trigger USB connection hooks
+  friend class driver::mcu::Base;  // Allow MCU drivers to trigger USB connection hooks
   friend void sketch_exploration::pluginsExploreSketch();
 
  private:


### PR DESCRIPTION
## Summary
This PR adds comprehensive USB/BLE connection detection and automatic switching for the Keyboardio Preonic, along with improved LED indicators that provide clear visual feedback for connection status.

## Major Features

### 1. USB Connection Detection and Auto-Switching
- Added USB connection state detection to nRF52840 MCU driver
- Implemented host connection status tracking with new event system
- Created USBAutoSwitcher plugin that automatically switches between USB and BLE based on connection status
- When USB is disconnected, automatically switches to last-used BLE device

### 2. Enhanced LED Indicators System
- Added comprehensive LED indicators for all connection states
- Implemented global indicators that control all 4 LEDs atomically for USB events
- Different visual effects for different states:
  - **USB Power-only**: Orange pulse (3 times)
  - **USB Connected**: Green grow effect
  - **USB Disconnected**: Orange shrink effect
  - **BLE Connecting/Advertising**: Blue blink
  - **BLE Connected**: Blue grow effect
  - **BLE Device Selected**: Brief blue grow

### 3. Smart Indicator Management
- BLE indicators now use dynamic delays based on active USB indicators
- Prevents indicator conflicts and ensures smooth transitions
- Added `hasActiveIndicatorForLED()` API for better coordination between plugins

### 4. Boot Greeting Improvements
- Fixed interaction between boot greeting and LED indicators
- Simplified rainbow effect for clarity (all LEDs show same color)
- Properly respects active indicators and turns off LEDs when complete
- Fixed KeyAddr usage to correctly detect indicator conflicts

### 5. Bug Fixes
- Fixed BLE device switching issues with proper bond management
- Fixed USB wake-from-sleep using polling after waitForEvent()
- Fixed WS2812 driver brightness calculation to prevent overflow
- Fixed race conditions in indicator timing

## Technical Details

### New APIs
- `onHostConnectionStatusChanged()` hook for plugins to react to connection events
- `hasActiveIndicatorForLED()` to check if an LED has an active indicator
- Global indicator support in LEDIndicators plugin

### Files Changed
- MCU driver: Added USB connection detection
- Device driver: Added connection event broadcasting
- LEDIndicators: Global indicators, smart delays, new colors
- USBAutoSwitcher: New plugin for automatic switching
- PreonicBootGreeting: Fixed indicator interaction
- WS2812: Fixed brightness calculations

## Testing
- Tested USB connect/disconnect with synchronized LED effects
- Verified automatic switching between USB and BLE modes
- Confirmed boot greeting respects indicators
- Tested all connection states and transitions
- Verified no race conditions or LED conflicts

## Backwards Compatibility
All changes are backwards compatible. The USBAutoSwitcher plugin is optional and can be disabled if manual control is preferred.

🤖 Generated with [Claude Code](https://claude.ai/code)