### PR TITLE
Improve LED indicator timing and priority system for Preonic

### DIFF
--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/PreonicBootGreeting.cpp
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/PreonicBootGreeting.cpp
@@ -112,14 +112,14 @@ EventHandlerResult PreonicBootGreetingEffect::afterEachCycle() {
 
   uint16_t elapsed = Runtime.millisAtCycleStart() - start_time;
 
-  // Calculate overall brightness fade
+  // Calculate overall brightness fade (no flapping, just smooth fade in/hold/fade out)
   uint8_t brightness_scale = 255;
 
   if (elapsed < FADE_IN_DURATION) {
     // Fade in phase
     brightness_scale = (elapsed * 255U) / FADE_IN_DURATION;
   } else if (elapsed < FADE_IN_DURATION + FLAPPING_DURATION) {
-    // Full brightness phase
+    // Hold at full brightness phase
     brightness_scale = 255U;
   } else {
     // Fade out phase

--- a/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/PreonicBootGreeting.h
+++ b/plugins/Kaleidoscope-Hardware-Keyboardio-Preonic/src/kaleidoscope/plugin/PreonicBootGreeting.h
@@ -41,9 +41,9 @@ class PreonicBootGreetingEffect : public kaleidoscope::Plugin {
  private:
   static bool done_;
   static uint16_t start_time;
-  static constexpr uint16_t FADE_IN_DURATION  = 1000;  // 1s fade in
-  static constexpr uint16_t FLAPPING_DURATION = 8000;  // 8s flapping
-  static constexpr uint16_t FADE_OUT_DURATION = 1000;  // 1s fade out
+  static constexpr uint16_t FADE_IN_DURATION  = 2000;  // 2s fade in
+  static constexpr uint16_t FLAPPING_DURATION = 1000;  // 1s hold at full brightness
+  static constexpr uint16_t FADE_OUT_DURATION = 2000;  // 2s fade out
   static constexpr uint16_t FLAP_CYCLE_MS     = 2000;  // 2000ms per flap cycle (0.5 flaps/sec)
 
   // LED indices for wings

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
@@ -634,13 +634,17 @@ EventHandlerResult LEDIndicators::onHostConnectionStatusChanged(uint8_t device_i
                   1);     // 1 cycle
     break;
   case HostConnectionStatus::Disconnected:
-    showIndicatorWithDelay(getLEDForSlot(slot),
-                           IndicatorEffect::Shrink,
-                           color_blue,
-                           color_off,
-                           5000,      // 5 second duration
-                           delay_ms,  // Only delay if USB indicators are active
-                           1);        // 1 cycle
+    // Use a dimmer blue that fades to off over a longer duration
+    {
+      cRGB dim_blue = {0, 0, 76};  // ~30% brightness blue (76/255 ≈ 0.3)
+      showIndicatorWithDelay(getLEDForSlot(slot),
+                             IndicatorEffect::Shrink,
+                             dim_blue,
+                             color_off,
+                             8000,      // 8 second duration for longer fade
+                             delay_ms,  // Only delay if USB indicators are active
+                             1);        // 1 cycle
+    }
     break;
   case HostConnectionStatus::PairingSuccess:
     showIndicator(getLEDForSlot(slot),

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.cpp
@@ -199,11 +199,11 @@ void LEDIndicators::showIndicatorWithDelay(KeyAddr led_addr,
 
 // Show a global indicator with delay
 void LEDIndicators::showGlobalIndicatorWithDelay(IndicatorEffect effect,
-                                                  cRGB color1,
-                                                  cRGB color2,
-                                                  uint16_t duration_ms,
-                                                  uint16_t delay_ms,
-                                                  uint16_t effect_cycles) {
+                                                 cRGB color1,
+                                                 cRGB color2,
+                                                 uint16_t duration_ms,
+                                                 uint16_t delay_ms,
+                                                 uint16_t effect_cycles) {
   if (!Runtime.has_leds) {
     return;
   }
@@ -583,17 +583,17 @@ EventHandlerResult LEDIndicators::onHostConnectionStatusChanged(uint8_t device_i
   // Check if we're still in boot greeting period (5 seconds)
   // During boot, delay all Bluetooth indicators
   uint16_t delay_ms = 0;
-  uint32_t uptime = Runtime.millisAtCycleStart();
+  uint32_t uptime   = Runtime.millisAtCycleStart();
   if (uptime < 5000) {
     delay_ms = 5000 - uptime;
   }
-  
+
   // Also wait for any active USB global indicators to complete
   // This ensures Bluetooth indicators don't interfere with USB disconnect/connect sequences
   for (uint8_t i = 0; i < MAX_SLOTS; i++) {
     if (indicators_[i].active && indicators_[i].is_global) {
       // This is a USB global indicator, wait for it to complete
-      uint32_t elapsed = Runtime.millisAtCycleStart() - indicators_[i].start_time;
+      uint32_t elapsed    = Runtime.millisAtCycleStart() - indicators_[i].start_time;
       uint32_t total_time = indicators_[i].delay_ms + indicators_[i].duration_ms;
       if (elapsed < total_time) {
         uint16_t remaining = total_time - elapsed;

--- a/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
+++ b/plugins/Kaleidoscope-LEDIndicators/src/kaleidoscope/plugin/LEDIndicators.h
@@ -124,6 +124,21 @@ class LEDIndicators : public kaleidoscope::Plugin {
                            uint16_t duration_ms,
                            uint16_t effect_cycles = 0);
 
+  /** @brief Show a global indicator with delay and duration
+   * @param effect The type of visual effect to show
+   * @param color1 Primary color for the effect
+   * @param color2 Secondary color for effects that use two colors
+   * @param duration_ms How long to show the indicator (0 for indefinite)
+   * @param delay_ms How long to wait before showing the indicator
+   * @param effect_cycles Number of times to repeat the effect
+   */
+  void showGlobalIndicatorWithDelay(IndicatorEffect effect,
+                                    cRGB color1,
+                                    cRGB color2,
+                                    uint16_t duration_ms,
+                                    uint16_t delay_ms,
+                                    uint16_t effect_cycles = 0);
+
   /** @brief Show a temporary indicator with delay and duration
    * @param key_addr The LED index to control
    * @param effect The type of visual effect to show
@@ -158,6 +173,11 @@ class LEDIndicators : public kaleidoscope::Plugin {
    * @return The maximum remaining time in milliseconds, or 0 if no global indicators are active
    */
   uint16_t getGlobalIndicatorRemainingTime();
+
+  /** @brief Get the remaining duration of any active indicator (global or individual)
+   * @return The maximum remaining time in milliseconds, or 0 if no indicators are active
+   */
+  uint16_t getAnyIndicatorRemainingTime();
 
   /** @brief Check if a specific LED has an active indicator
    * @param led_addr The LED to check


### PR DESCRIPTION
## Summary
- Reduce PreonicBootGreeting duration from 10s to 5s for cleaner boot sequence
- Fix LED indicator priority system to prevent conflicts between USB and Bluetooth events  
- Improve Bluetooth disconnect animation with darker color and longer fade

## Changes Made

### PreonicBootGreeting Timing (1bca5c94)
- Changed timing from (1s fade in + 8s flapping + 1s fade out) to (2s fade in + 1s hold + 2s fade out)
- Total duration reduced from 10 seconds to 5 seconds
- Maintains smooth rainbow fade without flapping animation

### LED Indicator Priority System (0e11f0bf) 
- **Fixed core issue**: USB events now properly take precedence over Bluetooth events
- Added 500ms delay to USB disconnect orange shrink effect
- Bluetooth indicators properly wait for USB sequences to complete before showing
- Added `showGlobalIndicatorWithDelay()` function for delayed global effects
- Individual Bluetooth indicators no longer inappropriately override USB global indicators

### Bluetooth Disconnect Animation (083ad746)
- Use dimmer blue color (30% brightness: `{0, 0, 76}` vs `{0, 0, 255}`)
- Increased duration from 5 seconds to 8 seconds for longer, more subtle fade
- Creates gentler visual feedback for disconnection events

## Issues Resolved
1. **Boot sequence conflicts**: Rainbow boot greeting and Bluetooth indicators no longer interfere
2. **Dark LED slots**: Bluetooth indicators properly show instead of staying dark during transitions  
3. **Priority conflicts**: Bluetooth disconnect no longer overrides USB connect green indicators
4. **Harsh animations**: Bluetooth disconnect now uses softer, longer-lasting visual feedback

## Test Plan
- [x] Boot without USB connection - rainbow greeting shows cleanly for 5s, then Bluetooth indicators can appear
- [x] USB disconnect - orange shrink effect shows on all LEDs with 500ms delay
- [x] USB connect while Bluetooth active - green immediately overrides Bluetooth indicators on all LEDs
- [x] Bluetooth disconnect - dimmer blue fade over 8 seconds on assigned slot only

🤖 Generated with [Claude Code](https://claude.ai/code)