### PR TITLE
Add readBytes stub to NoOpSerial

### DIFF
--- a/src/kaleidoscope/device/Base.h
+++ b/src/kaleidoscope/device/Base.h
@@ -136,6 +136,9 @@ class Base {
     int read() {
       return 0;
     }
+    size_t readBytes(char *buffer, size_t length) {
+      return 0;
+    }
   };
 
   NoOpSerial noop_serial_;


### PR DESCRIPTION
Even if a keyboard doesn't have a Serial port (and thus uses `NoOpSerial`), `FocusSerial.h` is still included from [LEDControl.cpp:26](https://github.com/keyboardio/Kaleidoscope/blob/bfda8e5ce2e2d2b654106eb295cc99bc54a15c56/src/kaleidoscope/plugin/LEDControl.cpp#L26) (even though FocusSerial is not used in that file) and tries to [call readBytes](https://github.com/keyboardio/Kaleidoscope/blob/bfda8e5ce2e2d2b654106eb295cc99bc54a15c56/plugins/Kaleidoscope-FocusSerial/src/kaleidoscope/plugin/FocusSerial.h#L113). Since `NoOpSerial` doesn't have `readBytes`, the build fails.

An alternative solution would be to remove the `FocusSerial.h` include from `LEDControl.cpp`, but this seemed cleaner.

BTW, cool firmware you have here :slightly_smiling_face: 