### PR TITLE
Add support for ignoring Qukeys activation on the same hand

### DIFF
--- a/plugins/Kaleidoscope-Qukeys/README.md
+++ b/plugins/Kaleidoscope-Qukeys/README.md
@@ -141,6 +141,39 @@ likely to generate errors and out-of-order events.
 >
 > Defaults to `75` (milliseconds).
 
+### `.setEnableOppositeHandsRule(enable)`
+
+> When set to `true`, qukeys will only resolve to their alternate (modifier)
+> value when the subsequent key press is on the opposite hand from the qukey.
+> Same-hand rollover will always produce the primary (tap) value, preventing
+> accidental modifier activation during normal typing. This implements the
+> "opposite hands rule" popularized by QMK's Achordion and Chordal Hold
+> features.
+>
+> Hand membership is determined by physical key position (column index), not by
+> the key's logical assignment. This means remapping keys via Chrysalis or
+> EEPROM does not affect the hand detection. On split keyboards like the
+> Keyboardio Model 01/100, keys with column index less than the split column
+> (default 8) are considered left-hand keys.
+>
+> Note that holding a qukey alone past the hold timeout will still activate the
+> alternate (modifier) value regardless of this setting. This is intentional, as
+> it allows using a modifier with a pointing device (e.g. `shift` + `click`).
+>
+> Defaults to `false` (disabled).
+
+### `.setSplitColumn(column)`
+
+> Sets the column index that divides left-hand keys from right-hand keys when
+> the opposite-hands rule is enabled. Keys with a column index less than this
+> value are considered left-hand keys; keys with a column index greater than or
+> equal to this value are considered right-hand keys.
+>
+> For the Keyboardio Model 01 and Model 100, the correct value is `8` (columns
+> 0-7 are the left hand, columns 8-15 are the right hand).
+>
+> Defaults to `8`.
+
 ### `.activate()`
 ### `.deactivate()`
 ### `.toggle()`

--- a/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.h
+++ b/plugins/Kaleidoscope-Qukeys/src/kaleidoscope/plugin/Qukeys.h
@@ -141,6 +141,25 @@ class Qukeys : public kaleidoscope::Plugin {
     minimum_prior_interval_ = min_interval;
   }
 
+  // Enable or disable the opposite-hands rule for home row mods. When enabled,
+  // a qukey will only resolve to its alternate (modifier) value when the
+  // subsequent key is on the opposite hand. Same-hand rollover always produces
+  // the primary (tap) value, preventing accidental modifier activation during
+  // normal typing. The hand boundary is determined by column index: columns
+  // 0 through (split_column - 1) are the left hand, and columns split_column
+  // and above are the right hand.
+  void setEnableOppositeHandsRule(bool enable) {
+    require_opposite_hands_ = enable;
+  }
+
+  // Set the column index that divides left and right hands. Keys with column
+  // index less than this value are considered left-hand keys. Default is 8,
+  // which is correct for Keyboardio Model 01/100 (4x16 matrix, columns 0-7
+  // left, 8-15 right).
+  void setSplitColumn(uint8_t col) {
+    split_column_ = col;
+  }
+
   // Function for defining the array of qukeys data (in PROGMEM). It's a
   // template function that takes as its sole argument an array reference of
   // size `_qukeys_count`, so there's no need to use `sizeof` to calculate the
@@ -210,6 +229,13 @@ class Qukeys : public kaleidoscope::Plugin {
     Key alternate_key{Key_Transparent};
   } queue_head_;
 
+  // When true, qukeys will only resolve to their alternate value when the
+  // subsequent keypress is on the opposite hand.
+  bool require_opposite_hands_{false};
+
+  // The column index that divides left and right hands.
+  uint8_t split_column_{8};
+
   // Internal helper methods.
   bool processQueue();
   void flushEvent(Key event_key);
@@ -217,6 +243,7 @@ class Qukeys : public kaleidoscope::Plugin {
   bool isDualUseKey(Key key);
   bool releaseDelayed(uint16_t overlap_start, uint16_t overlap_end) const;
   bool isKeyAddrInQueueBeforeIndex(KeyAddr k, uint8_t index) const;
+  bool oppositeHands(KeyAddr a, KeyAddr b) const;
 
   // Tap-repeat feature support.
   struct {


### PR DESCRIPTION
This fixes #1407 

Disclaimer: I'm a web developer and this is too low level for me. This is the code Claude Opus generated for me to be able to use Qukeys, but ignore activations from the same hand. I.e. having homerow mods, it will ignore a held key when activating with another key on the same hand (output 2 different keys), but if I hold one key and then press another key on the other cluster, it does trigger the alt mode.